### PR TITLE
fix: remove redundant coverage job from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,14 +43,6 @@ jobs:
       - name: Run unit tests
         run: pnpm -F @accomplish/desktop test:unit
 
-      - name: Upload unit test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: unit-test-results
-          path: apps/desktop/coverage/
-          retention-days: 7
-
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-latest
@@ -73,55 +65,6 @@ jobs:
 
       - name: Run integration tests
         run: pnpm -F @accomplish/desktop test:integration
-
-      - name: Upload integration test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: integration-test-results
-          path: apps/desktop/coverage/
-          retention-days: 7
-
-  # Coverage report runs after both test jobs complete
-  coverage:
-    name: Coverage Report
-    runs-on: ubuntu-latest
-    needs: [unit-tests, integration-tests]
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Run all tests with coverage
-        run: pnpm -F @accomplish/desktop test:coverage
-
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-report
-          path: apps/desktop/coverage/
-          retention-days: 30
-
-      - name: Coverage Summary
-        run: |
-          echo "## Coverage Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Metric | Coverage |" >> $GITHUB_STEP_SUMMARY
-          echo "|--------|----------|" >> $GITHUB_STEP_SUMMARY
-          # Extract coverage from the output
-          cd apps/desktop && pnpm test:coverage 2>&1 | grep -E "All files" | head -1 | awk '{print "| Statements | " $3 " |"}' >> $GITHUB_STEP_SUMMARY || true
 
   # Type checking
   typecheck:


### PR DESCRIPTION
## Summary

Removed the redundant coverage job that was re-running all tests.

### Before (4 jobs, tests run 2x)

```
unit-tests job      → runs unit tests
integration-tests   → runs integration tests  
coverage job        → runs ALL tests AGAIN (duplicate!)
typecheck job       → type checking
```

### After (3 jobs, tests run 1x)

```
unit-tests job      → runs unit tests
integration-tests   → runs integration tests  
typecheck job       → type checking
```

All 3 jobs run in parallel. Tests now execute only once.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)