### PR TITLE
Port functionality to Windows

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,19 +7,23 @@
   "main": "dist-electron/main/index.js",
   "scripts": {
     "postinstall": "electron-rebuild && npm --prefix skills/dev-browser install && npm --prefix skills/file-permission install",
-    "dev": "node scripts/patch-electron-name.cjs && rm -rf dist-electron && vite",
+    "dev": "node scripts/patch-electron-name.cjs && node -e \"require('fs').rmSync('dist-electron', {recursive: true, force: true})\" && vite",
     "dev:clean": "CLEAN_START=1 vite",
     "build": "tsc && vite build && npm --prefix skills/dev-browser install --omit=dev && npm --prefix skills/file-permission install --omit=dev",
     "build:electron": "tsc && vite build && node scripts/package.cjs",
     "build:unpack": "tsc && vite build && node scripts/package.cjs --dir",
-    "package": "pnpm build && node scripts/package.cjs --mac --publish never",
+    "package": "pnpm build && node scripts/package.cjs --publish never",
     "package:mac": "pnpm build && node scripts/package.cjs --mac --publish never",
-    "release": "pnpm build && node scripts/package.cjs --mac --publish always",
+    "package:win": "pnpm build && node scripts/package.cjs --win --publish never",
+    "package:linux": "pnpm build && node scripts/package.cjs --linux --publish never",
+    "release": "pnpm build && node scripts/package.cjs --publish always",
     "release:mac": "pnpm build && node scripts/package.cjs --mac --publish always",
+    "release:win": "pnpm build && node scripts/package.cjs --win --publish always",
+    "release:linux": "pnpm build && node scripts/package.cjs --linux --publish always",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "lint": "tsc --noEmit",
-    "clean": "rm -rf dist dist-electron release",
+    "clean": "node -e \"['dist','dist-electron','release'].forEach(d=>require('fs').rmSync(d,{recursive:true,force:true}))\"",
     "download:nodejs": "node scripts/download-nodejs.cjs",
     "test": "vitest run",
     "test:unit": "vitest run --config vitest.unit.config.ts",
@@ -158,6 +162,39 @@
           "path": "/Applications"
         }
       ]
+    },
+    "win": {
+      "target": [
+        {
+          "target": "nsis",
+          "arch": ["x64"]
+        },
+        {
+          "target": "portable",
+          "arch": ["x64"]
+        }
+      ],
+      "icon": "resources/icon.png"
+    },
+    "nsis": {
+      "oneClick": false,
+      "perMachine": false,
+      "allowToChangeInstallationDirectory": true,
+      "deleteAppDataOnUninstall": false
+    },
+    "linux": {
+      "target": [
+        {
+          "target": "AppImage",
+          "arch": ["x64", "arm64"]
+        },
+        {
+          "target": "deb",
+          "arch": ["x64", "arm64"]
+        }
+      ],
+      "category": "Utility",
+      "icon": "resources/icon.png"
     }
   }
 }

--- a/apps/desktop/scripts/download-nodejs.cjs
+++ b/apps/desktop/scripts/download-nodejs.cjs
@@ -4,6 +4,9 @@
  * Downloads Node.js v20.18.1 for:
  * - macOS x64
  * - macOS arm64
+ * - Windows x64
+ * - Linux x64
+ * - Linux arm64
  *
  * Usage: node scripts/download-nodejs.cjs
  */
@@ -29,6 +32,24 @@ const PLATFORMS = [
     file: `node-v${NODE_VERSION}-darwin-arm64.tar.gz`,
     extract: 'tar',
     sha256: '9e92ce1032455a9cc419fe71e908b27ae477799371b45a0844eedb02279922a4',
+  },
+  {
+    name: 'win32-x64',
+    file: `node-v${NODE_VERSION}-win-x64.zip`,
+    extract: 'zip',
+    sha256: '7161646a592c0d09be29e5e2fc3e623890419e14e46c75d4f8cf84548e0e7e08',
+  },
+  {
+    name: 'linux-x64',
+    file: `node-v${NODE_VERSION}-linux-x64.tar.gz`,
+    extract: 'tar',
+    sha256: 'de2c694e7909c6f42fb85bde69d899f0ae9d51550ffcee7d02d0909c1ce7fd93',
+  },
+  {
+    name: 'linux-arm64',
+    file: `node-v${NODE_VERSION}-linux-arm64.tar.gz`,
+    extract: 'tar',
+    sha256: '16088845dbe734bdc1b7b6a3bae5a49b4376d3c7c78e9db7f25fb02fd0c00f3f',
   },
 ];
 


### PR DESCRIPTION
- Add Windows (x64) and Linux (x64, arm64) to Node.js bundling script
- Add electron-builder configuration for Windows (NSIS, portable) and Linux (AppImage, deb) builds
- Add package:win, package:linux, release:win, release:linux scripts
- Fix PATH delimiter to use path.delimiter instead of hardcoded ':'
- Replace process.env.HOME with os.homedir() for cross-platform support
- Add Windows/Linux Node.js paths (nvm-windows, Scoop, AppData, etc.)
- Add Windows/Linux bundle detection for fresh install cleanup
- Enhance Chrome detection with additional Windows/Linux paths
- Fix dev-browser server startup to use npx on Windows instead of bash
- Make dev and clean scripts cross-platform using Node.js

## Summary
Brief description of changes.

## Changes
- Change 1
- Change 2

## Testing
How was this tested?

## Checklist
- [ ] Code builds without errors (`pnpm build`)
- [ ] Type checks pass (`pnpm typecheck`)
- [ ] Documentation updated (if needed)
