### PR TITLE
feat: add local LLM support and configuration options

### DIFF
--- a/apps/desktop/__tests__/integration/main/appSettings.integration.test.ts
+++ b/apps/desktop/__tests__/integration/main/appSettings.integration.test.ts
@@ -192,6 +192,22 @@ describe('appSettings Integration', () => {
     });
   });
 
+  describe('localLlm', () => {
+    it('should persist local LLM config after setting new value', async () => {
+      // Arrange
+      const { getLocalLlmConfig, setLocalLlmConfig, clearAppSettings } = await import('@main/store/appSettings');
+      clearAppSettings();
+      const localConfig = { baseUrl: 'http://localhost:11434/v1', model: 'llama3', preset: 'ollama' };
+
+      // Act
+      setLocalLlmConfig(localConfig);
+      const result = getLocalLlmConfig();
+
+      // Assert
+      expect(result).toEqual(localConfig);
+    });
+  });
+
   describe('getAppSettings', () => {
     it('should return all default settings on fresh store', async () => {
       // Arrange
@@ -209,19 +225,22 @@ describe('appSettings Integration', () => {
           provider: 'anthropic',
           model: 'anthropic/claude-opus-4-5',
         },
+        localLlm: null,
       });
     });
 
     it('should return all settings after modifications', async () => {
       // Arrange
-      const { getAppSettings, setDebugMode, setOnboardingComplete, setSelectedModel, clearAppSettings } = await import('@main/store/appSettings');
+      const { getAppSettings, setDebugMode, setOnboardingComplete, setSelectedModel, setLocalLlmConfig, clearAppSettings } = await import('@main/store/appSettings');
       clearAppSettings(); // Start fresh
       const customModel = { provider: 'openai', model: 'gpt-4-turbo' };
+      const localConfig = { baseUrl: 'http://localhost:11434/v1', model: 'llama3', preset: 'ollama' };
 
       // Act
       setDebugMode(true);
       setOnboardingComplete(true);
       setSelectedModel(customModel);
+      setLocalLlmConfig(localConfig);
       const result = getAppSettings();
 
       // Assert
@@ -229,6 +248,7 @@ describe('appSettings Integration', () => {
         debugMode: true,
         onboardingComplete: true,
         selectedModel: customModel,
+        localLlm: localConfig,
       });
     });
 
@@ -279,6 +299,7 @@ describe('appSettings Integration', () => {
           provider: 'anthropic',
           model: 'anthropic/claude-opus-4-5',
         },
+        localLlm: null,
       });
     });
 

--- a/apps/desktop/__tests__/integration/main/secureStorage.integration.test.ts
+++ b/apps/desktop/__tests__/integration/main/secureStorage.integration.test.ts
@@ -242,6 +242,7 @@ describe('secureStorage Integration', () => {
         openai: null,
         google: null,
         groq: null,
+        local: null,
         custom: null,
       });
     });
@@ -349,6 +350,7 @@ describe('secureStorage Integration', () => {
         openai: null,
         google: null,
         groq: null,
+        local: null,
         custom: null,
       });
     });

--- a/apps/desktop/__tests__/integration/preload/preload.integration.test.ts
+++ b/apps/desktop/__tests__/integration/preload/preload.integration.test.ts
@@ -203,6 +203,45 @@ describe('Preload Script Integration', () => {
         await (capturedAccomplishAPI.hasAnyApiKey as () => Promise<boolean>)();
         expect(mockInvoke).toHaveBeenCalledWith('api-keys:has-any');
       });
+
+      it('hasAnyLlmConfig should invoke llm:has-any-config', async () => {
+        await (capturedAccomplishAPI.hasAnyLlmConfig as () => Promise<boolean>)();
+        expect(mockInvoke).toHaveBeenCalledWith('llm:has-any-config');
+      });
+    });
+
+    describe('Local LLM Operations', () => {
+      it('getLocalLlmConfig should invoke local-llm:get', async () => {
+        await (capturedAccomplishAPI.getLocalLlmConfig as () => Promise<unknown>)();
+        expect(mockInvoke).toHaveBeenCalledWith('local-llm:get');
+      });
+
+      it('setLocalLlmConfig should invoke local-llm:set', async () => {
+        const config = { baseUrl: 'http://localhost:11434/v1', model: 'llama3' };
+        await (capturedAccomplishAPI.setLocalLlmConfig as (c: unknown) => Promise<unknown>)(config);
+        expect(mockInvoke).toHaveBeenCalledWith('local-llm:set', config);
+      });
+
+      it('clearLocalLlmConfig should invoke local-llm:clear', async () => {
+        await (capturedAccomplishAPI.clearLocalLlmConfig as () => Promise<void>)();
+        expect(mockInvoke).toHaveBeenCalledWith('local-llm:clear');
+      });
+
+      it('setLocalLlmKey should invoke local-llm:set-key', async () => {
+        await (capturedAccomplishAPI.setLocalLlmKey as (k: string) => Promise<void>)('local-key');
+        expect(mockInvoke).toHaveBeenCalledWith('local-llm:set-key', 'local-key');
+      });
+
+      it('clearLocalLlmKey should invoke local-llm:clear-key', async () => {
+        await (capturedAccomplishAPI.clearLocalLlmKey as () => Promise<void>)();
+        expect(mockInvoke).toHaveBeenCalledWith('local-llm:clear-key');
+      });
+
+      it('testLocalLlm should invoke local-llm:test', async () => {
+        const input = { baseUrl: 'http://localhost:11434/v1' };
+        await (capturedAccomplishAPI.testLocalLlm as (i: unknown) => Promise<unknown>)(input);
+        expect(mockInvoke).toHaveBeenCalledWith('local-llm:test', input);
+      });
     });
 
     describe('Onboarding Operations', () => {

--- a/apps/desktop/__tests__/unit/main/opencode/adapter.unit.test.ts
+++ b/apps/desktop/__tests__/unit/main/opencode/adapter.unit.test.ts
@@ -110,12 +110,17 @@ vi.mock('@main/store/secureStorage', () => ({
   getAllApiKeys: vi.fn(() => Promise.resolve({
     anthropic: 'test-anthropic-key',
     openai: 'test-openai-key',
+    google: null,
+    groq: null,
+    local: null,
+    custom: null,
   })),
 }));
 
 // Mock app settings
 vi.mock('@main/store/appSettings', () => ({
-  getSelectedModel: vi.fn(() => ({ model: 'claude-3-opus-20240229' })),
+  getSelectedModel: vi.fn(() => ({ provider: 'anthropic', model: 'claude-3-opus-20240229' })),
+  getLocalLlmConfig: vi.fn(() => null),
 }));
 
 // Mock config generator

--- a/apps/desktop/src/main/store/appSettings.ts
+++ b/apps/desktop/src/main/store/appSettings.ts
@@ -1,5 +1,5 @@
 import Store from 'electron-store';
-import type { SelectedModel, DEFAULT_MODEL } from '@accomplish/shared';
+import type { SelectedModel, LocalLlmConfig, DEFAULT_MODEL } from '@accomplish/shared';
 
 /**
  * App settings schema
@@ -11,6 +11,8 @@ interface AppSettingsSchema {
   onboardingComplete: boolean;
   /** Selected AI model (provider/model format) */
   selectedModel: SelectedModel | null;
+  /** Local OpenAI-compatible endpoint configuration */
+  localLlm: LocalLlmConfig | null;
 }
 
 const appSettingsStore = new Store<AppSettingsSchema>({
@@ -22,6 +24,7 @@ const appSettingsStore = new Store<AppSettingsSchema>({
       provider: 'anthropic',
       model: 'anthropic/claude-opus-4-5',
     },
+    localLlm: null,
   },
 });
 
@@ -68,6 +71,20 @@ export function setSelectedModel(model: SelectedModel): void {
 }
 
 /**
+ * Get local LLM configuration
+ */
+export function getLocalLlmConfig(): LocalLlmConfig | null {
+  return appSettingsStore.get('localLlm');
+}
+
+/**
+ * Set local LLM configuration
+ */
+export function setLocalLlmConfig(config: LocalLlmConfig | null): void {
+  appSettingsStore.set('localLlm', config);
+}
+
+/**
  * Get all app settings
  */
 export function getAppSettings(): AppSettingsSchema {
@@ -75,6 +92,7 @@ export function getAppSettings(): AppSettingsSchema {
     debugMode: appSettingsStore.get('debugMode'),
     onboardingComplete: appSettingsStore.get('onboardingComplete'),
     selectedModel: appSettingsStore.get('selectedModel'),
+    localLlm: appSettingsStore.get('localLlm'),
   };
 }
 

--- a/apps/desktop/src/main/store/secureStorage.ts
+++ b/apps/desktop/src/main/store/secureStorage.ts
@@ -184,21 +184,22 @@ export function deleteApiKey(provider: string): boolean {
 /**
  * Supported API key providers
  */
-export type ApiKeyProvider = 'anthropic' | 'openai' | 'google' | 'groq' | 'custom';
+export type ApiKeyProvider = 'anthropic' | 'openai' | 'google' | 'groq' | 'local' | 'custom';
 
 /**
  * Get all API keys for all providers
  */
 export async function getAllApiKeys(): Promise<Record<ApiKeyProvider, string | null>> {
-  const [anthropic, openai, google, groq, custom] = await Promise.all([
+  const [anthropic, openai, google, groq, local, custom] = await Promise.all([
     getApiKey('anthropic'),
     getApiKey('openai'),
     getApiKey('google'),
     getApiKey('groq'),
+    getApiKey('local'),
     getApiKey('custom'),
   ]);
 
-  return { anthropic, openai, google, groq, custom };
+  return { anthropic, openai, google, groq, local, custom };
 }
 
 /**

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -96,6 +96,22 @@ const accomplishAPI = {
     ipcRenderer.invoke('api-keys:all'),
   hasAnyApiKey: (): Promise<boolean> =>
     ipcRenderer.invoke('api-keys:has-any'),
+  hasAnyLlmConfig: (): Promise<boolean> =>
+    ipcRenderer.invoke('llm:has-any-config'),
+
+  // Local LLM config
+  getLocalLlmConfig: (): Promise<{ baseUrl: string; model: string; preset?: string } | null> =>
+    ipcRenderer.invoke('local-llm:get'),
+  setLocalLlmConfig: (config: { baseUrl: string; model: string; preset?: string }): Promise<unknown> =>
+    ipcRenderer.invoke('local-llm:set', config),
+  clearLocalLlmConfig: (): Promise<void> =>
+    ipcRenderer.invoke('local-llm:clear'),
+  setLocalLlmKey: (key: string): Promise<void> =>
+    ipcRenderer.invoke('local-llm:set-key', key),
+  clearLocalLlmKey: (): Promise<void> =>
+    ipcRenderer.invoke('local-llm:clear-key'),
+  testLocalLlm: (input: { baseUrl?: string; apiKey?: string }): Promise<{ ok: boolean; error?: string }> =>
+    ipcRenderer.invoke('local-llm:test', input),
 
   // Event subscriptions
   onTaskUpdate: (callback: (event: unknown) => void) => {

--- a/apps/desktop/src/renderer/lib/accomplish.ts
+++ b/apps/desktop/src/renderer/lib/accomplish.ts
@@ -15,6 +15,8 @@ import type {
   TaskProgress,
   ApiKeyConfig,
   TaskMessage,
+  LocalLlmConfig,
+  SelectedModel,
 } from '@accomplish/shared';
 
 // Define the API interface
@@ -60,6 +62,15 @@ interface AccomplishAPI {
   // Multi-provider API keys
   getAllApiKeys(): Promise<Record<string, { exists: boolean; prefix?: string }>>;
   hasAnyApiKey(): Promise<boolean>;
+  hasAnyLlmConfig(): Promise<boolean>;
+
+  // Local LLM config
+  getLocalLlmConfig(): Promise<LocalLlmConfig | null>;
+  setLocalLlmConfig(config: LocalLlmConfig): Promise<LocalLlmConfig | null>;
+  clearLocalLlmConfig(): Promise<void>;
+  setLocalLlmKey(key: string): Promise<void>;
+  clearLocalLlmKey(): Promise<void>;
+  testLocalLlm(input: { baseUrl?: string; apiKey?: string }): Promise<{ ok: boolean; error?: string }>;
 
   // Onboarding
   getOnboardingComplete(): Promise<boolean>;
@@ -70,8 +81,8 @@ interface AccomplishAPI {
   getClaudeVersion(): Promise<string | null>;
 
   // Model selection
-  getSelectedModel(): Promise<{ provider: string; model: string } | null>;
-  setSelectedModel(model: { provider: string; model: string }): Promise<void>;
+  getSelectedModel(): Promise<SelectedModel | null>;
+  setSelectedModel(model: SelectedModel): Promise<void>;
 
   // Event subscriptions
   onTaskUpdate(callback: (event: TaskUpdateEvent) => void): () => void;

--- a/apps/desktop/src/renderer/pages/Home.tsx
+++ b/apps/desktop/src/renderer/pages/Home.tsx
@@ -116,9 +116,9 @@ export default function HomePage() {
   const handleSubmit = async () => {
     if (!prompt.trim() || isLoading) return;
 
-    // Check if user has any API key (Anthropic, OpenAI, Google, etc.) before sending
-    const hasKey = await accomplish.hasAnyApiKey();
-    if (!hasKey) {
+    // Check if user has any LLM configuration before sending
+    const hasConfig = await accomplish.hasAnyLlmConfig();
+    if (!hasConfig) {
       setShowSettingsDialog(true);
       return;
     }

--- a/packages/shared/src/types/auth.ts
+++ b/packages/shared/src/types/auth.ts
@@ -28,7 +28,7 @@ export interface AuthTokens {
 
 export interface ApiKeyConfig {
   id: string;
-  provider: 'anthropic' | 'aws_bedrock';
+  provider: 'anthropic' | 'openai' | 'google' | 'groq' | 'local' | 'custom' | 'aws_bedrock';
   label?: string;
   keyPrefix?: string;
   isActive: boolean;

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -2,7 +2,7 @@
  * Provider and model configuration types for multi-provider support
  */
 
-export type ProviderType = 'anthropic' | 'openai' | 'google' | 'local' | 'custom';
+export type ProviderType = 'anthropic' | 'openai' | 'google' | 'groq' | 'local' | 'custom';
 
 export interface ProviderConfig {
   id: ProviderType;
@@ -26,6 +26,12 @@ export interface ModelConfig {
 export interface SelectedModel {
   provider: ProviderType;
   model: string; // Full ID: "anthropic/claude-sonnet-4-5"
+}
+
+export interface LocalLlmConfig {
+  preset?: string;
+  baseUrl: string;
+  model: string;
 }
 
 /**
@@ -101,6 +107,38 @@ export const DEFAULT_PROVIDERS: ProviderConfig[] = [
         fullId: 'google/gemini-3-flash-preview',
         contextWindow: 1000000,
         supportsVision: true,
+      },
+    ],
+  },
+  {
+    id: 'groq',
+    name: 'Groq',
+    requiresApiKey: true,
+    apiKeyEnvVar: 'GROQ_API_KEY',
+    models: [
+      {
+        id: 'llama-3-3-70b',
+        displayName: 'Llama 3.3 70B',
+        provider: 'groq',
+        fullId: 'groq/llama-3.3-70b',
+        contextWindow: 131072,
+        supportsVision: false,
+      },
+      {
+        id: 'llama-3-1-8b-instant',
+        displayName: 'Llama 3.1 8B Instant',
+        provider: 'groq',
+        fullId: 'groq/llama-3.1-8b-instant',
+        contextWindow: 131072,
+        supportsVision: false,
+      },
+      {
+        id: 'mixtral-8x7b',
+        displayName: 'Mixtral 8x7B',
+        provider: 'groq',
+        fullId: 'groq/mixtral-8x7b',
+        contextWindow: 32768,
+        supportsVision: false,
       },
     ],
   },


### PR DESCRIPTION
#15 
## Summary
Adds privacy‑first local LLM support by allowing users to configure an OpenAI‑compatible base URL + model (with optional key), and fully enables Groq in the provider list and settings UI.

## Changes
- Store local LLM config in app settings, store optional local key securely, and expose IPC endpoints for get/set/test + “has any LLM config”
- Route the OpenAI provider to the local base URL when a local model is selected, and update Settings UI/model selection to include local endpoint and Groq


## Testing
pnpm -F @accomplish/desktop lint

## Checklist
- [x] Code builds without errors (`pnpm build`)
- [x] Type checks pass (`pnpm typecheck`)
- [x] Documentation updated (if needed)

## What
- Add Local (OpenAI-compatible) endpoint config (base URL + model + optional key)
- Add Groq provider models + key support in UI and shared provider types
- Route OpenAI provider to local base URL when local model selected
- Update IPC/preload/renderer types for local LLM config and new gate

# Why
- Enables offline/private usage with local models
- Adds Groq support for cloud users

# How
- New local LLM config stored in app settings; optional local key in secure storage
- New IPC endpoints for local config/test and “has any LLM config” gating
- Updated Settings UI and model selection to include local endpoint
- Guard auth callback send to avoid window destroyed crash

