### PR TITLE
fix(opencode): use .mts temp files for browser scripts to enable ESM mode

### DIFF
--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -16,7 +16,8 @@
     "paths": {
       "@/*": ["src/renderer/*"],
       "@main/*": ["src/main/*"],
-      "@shared/*": ["../../packages/shared/src/*"]
+      "@shared/*": ["../../packages/shared/src/*"],
+      "@accomplish/shared": ["../../packages/shared/src/index.ts"]
     }
   },
   "include": [


### PR DESCRIPTION
## Summary
- Switches browser automation scripts from heredocs to `.mts` temp files
- tsx treats `.mts` files as ES modules, enabling top-level await (heredocs with `.ts` default to CJS in /tmp)
- Adds exception to file permission rule for `/tmp/accomplish-*.mts` temp scripts
- Adds `@accomplish/shared` path alias to tsconfig

## Test plan
- [ ] Verify browser automation scripts work with new `.mts` temp file approach
- [ ] Confirm top-level await functions correctly in generated scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)