### PR TITLE
fix(e2e): replace hardcoded timeouts with proper element waits

### DIFF
--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -48,8 +48,11 @@ export const test = base.extend<ElectronFixtures>({
     // Wait for page to be fully loaded
     await window.waitForLoadState('load');
 
-    // Wait for React hydration
-    await window.waitForTimeout(TEST_TIMEOUTS.HYDRATION);
+    // Wait for React hydration by checking for a core UI element
+    await window.waitForSelector('[data-testid="task-input-textarea"]', {
+      state: 'visible',
+      timeout: TEST_TIMEOUTS.NAVIGATION,
+    });
 
     await use(window);
   },

--- a/apps/desktop/e2e/pages/settings.page.ts
+++ b/apps/desktop/e2e/pages/settings.page.ts
@@ -47,7 +47,8 @@ export class SettingsPage {
   async navigateToSettings() {
     // Click the settings button in sidebar to navigate
     await this.sidebarSettingsButton.click();
-    await this.page.waitForTimeout(TEST_TIMEOUTS.STATE_UPDATE);
+    // Wait for settings dialog to be visible
+    await this.modelSelect.waitFor({ state: 'visible', timeout: TEST_TIMEOUTS.NAVIGATION });
   }
 
   async toggleDebugMode() {

--- a/apps/desktop/e2e/specs/home.spec.ts
+++ b/apps/desktop/e2e/specs/home.spec.ts
@@ -103,8 +103,14 @@ test.describe('Home Page', () => {
     const exampleCard0 = homePage.getExampleCard(0);
     await exampleCard0.click();
 
-    // Wait for input to be filled
-    await window.waitForTimeout(TEST_TIMEOUTS.STATE_UPDATE);
+    // Wait for input to be filled with example text
+    await window.waitForFunction(
+      () => {
+        const input = document.querySelector('[data-testid="task-input-textarea"]') as HTMLTextAreaElement;
+        return input && input.value.length > 0;
+      },
+      { timeout: TEST_TIMEOUTS.NAVIGATION }
+    );
 
     // Capture state after clicking example
     await captureForAI(
@@ -147,7 +153,7 @@ test.describe('Home Page', () => {
     await homePage.submitTask();
 
     // Wait for navigation
-    await window.waitForURL(/.*#\/execution.*/, { timeout: TEST_TIMEOUTS.PERMISSION_MODAL });
+    await window.waitForURL(/.*#\/execution.*/, { timeout: TEST_TIMEOUTS.NAVIGATION });
 
     // Capture after navigation
     await captureForAI(

--- a/apps/desktop/e2e/specs/settings.spec.ts
+++ b/apps/desktop/e2e/specs/settings.spec.ts
@@ -7,8 +7,8 @@ test.describe('Settings Dialog', () => {
   test('should open settings dialog when clicking settings button', async ({ window }) => {
     const settingsPage = new SettingsPage(window);
 
+    // Fixture already handles hydration, just ensure DOM is ready
     await window.waitForLoadState('domcontentloaded');
-    await window.waitForTimeout(TEST_TIMEOUTS.HYDRATION);
 
     // Click the settings button in sidebar
     await settingsPage.navigateToSettings();
@@ -32,8 +32,8 @@ test.describe('Settings Dialog', () => {
   test('should display model selection dropdown', async ({ window }) => {
     const settingsPage = new SettingsPage(window);
 
+    // Fixture already handles hydration, just ensure DOM is ready
     await window.waitForLoadState('domcontentloaded');
-    await window.waitForTimeout(TEST_TIMEOUTS.HYDRATION);
 
     // Open settings dialog
     await settingsPage.navigateToSettings();
@@ -57,8 +57,8 @@ test.describe('Settings Dialog', () => {
   test('should display API key input', async ({ window }) => {
     const settingsPage = new SettingsPage(window);
 
+    // Fixture already handles hydration, just ensure DOM is ready
     await window.waitForLoadState('domcontentloaded');
-    await window.waitForTimeout(TEST_TIMEOUTS.HYDRATION);
 
     // Open settings dialog
     await settingsPage.navigateToSettings();
@@ -85,8 +85,8 @@ test.describe('Settings Dialog', () => {
   test('should allow typing in API key input', async ({ window }) => {
     const settingsPage = new SettingsPage(window);
 
+    // Fixture already handles hydration, just ensure DOM is ready
     await window.waitForLoadState('domcontentloaded');
-    await window.waitForTimeout(TEST_TIMEOUTS.HYDRATION);
 
     // Open settings dialog
     await settingsPage.navigateToSettings();
@@ -117,8 +117,8 @@ test.describe('Settings Dialog', () => {
   test('should display debug mode toggle', async ({ window }) => {
     const settingsPage = new SettingsPage(window);
 
+    // Fixture already handles hydration, just ensure DOM is ready
     await window.waitForLoadState('domcontentloaded');
-    await window.waitForTimeout(TEST_TIMEOUTS.HYDRATION);
 
     // Open settings dialog
     await settingsPage.navigateToSettings();
@@ -145,8 +145,8 @@ test.describe('Settings Dialog', () => {
   test('should allow toggling debug mode', async ({ window }) => {
     const settingsPage = new SettingsPage(window);
 
+    // Fixture already handles hydration, just ensure DOM is ready
     await window.waitForLoadState('domcontentloaded');
-    await window.waitForTimeout(TEST_TIMEOUTS.HYDRATION);
 
     // Open settings dialog
     await settingsPage.navigateToSettings();
@@ -165,9 +165,8 @@ test.describe('Settings Dialog', () => {
       ]
     );
 
-    // Click toggle
+    // Click toggle - state change is immediate in React
     await settingsPage.toggleDebugMode();
-    await window.waitForTimeout(TEST_TIMEOUTS.STATE_UPDATE);
 
     // Capture toggled state
     await captureForAI(
@@ -184,8 +183,8 @@ test.describe('Settings Dialog', () => {
   test('should close dialog when pressing Escape', async ({ window }) => {
     const settingsPage = new SettingsPage(window);
 
+    // Fixture already handles hydration, just ensure DOM is ready
     await window.waitForLoadState('domcontentloaded');
-    await window.waitForTimeout(TEST_TIMEOUTS.HYDRATION);
 
     // Open settings dialog
     await settingsPage.navigateToSettings();
@@ -193,9 +192,8 @@ test.describe('Settings Dialog', () => {
     // Verify dialog is open
     await expect(settingsPage.modelSelect).toBeVisible({ timeout: TEST_TIMEOUTS.NAVIGATION });
 
-    // Press Escape to close dialog
+    // Press Escape to close dialog - expect handles the wait
     await window.keyboard.press('Escape');
-    await window.waitForTimeout(TEST_TIMEOUTS.STATE_UPDATE);
 
     // Verify dialog closed (model select should not be visible)
     await expect(settingsPage.modelSelect).not.toBeVisible({ timeout: TEST_TIMEOUTS.NAVIGATION });


### PR DESCRIPTION
## Summary

- Replace hardcoded `waitForTimeout` calls with explicit `waitFor()` element waits
- Remove unsafe `.catch(() => false)` patterns that silently swallowed timeout errors
- Add button visibility waits before clicking permission modal buttons
- Remove redundant hydration waits in settings tests (fixture already handles it)
- Replace fixture hydration timeout with element visibility check
- Use `waitForFunction` for input value changes instead of fixed delays

## Files Changed

- `e2e/fixtures/electron-app.ts` - Wait for task input instead of 1500ms timeout
- `e2e/specs/execution.spec.ts` - Replace all hardcoded sleeps with element waits
- `e2e/specs/settings.spec.ts` - Remove redundant hydration waits
- `e2e/specs/home.spec.ts` - Use `waitForFunction` for input value check
- `e2e/pages/settings.page.ts` - Wait for dialog element instead of timeout

## Test plan

- [x] Ran E2E tests 3 times to verify stability (all 26 tests pass consistently)
- [x] Specifically verified previously flaky tests:
  - Permission modal tests (allow/deny)
  - Cancel task test
  - Follow-up input test
  - Example card click test

🤖 Generated with [Claude Code](https://claude.com/claude-code)