### PR TITLE
fix(ollama): allow task submission when Ollama is configured

### DIFF
--- a/apps/desktop/src/renderer/components/TaskLauncher/TaskLauncher.tsx
+++ b/apps/desktop/src/renderer/components/TaskLauncher/TaskLauncher.tsx
@@ -60,7 +60,10 @@ export default function TaskLauncher() {
       if (searchQuery.trim()) {
         // Start task with search query as prompt
         const hasKey = await accomplish.hasAnyApiKey();
-        if (!hasKey) {
+        const selectedModel = await accomplish.getSelectedModel();
+        const hasOllamaConfigured = selectedModel?.provider === 'ollama';
+
+        if (!hasKey && !hasOllamaConfigured) {
           closeLauncher();
           navigate('/');
           return;

--- a/apps/desktop/src/renderer/pages/Home.tsx
+++ b/apps/desktop/src/renderer/pages/Home.tsx
@@ -116,9 +116,12 @@ export default function HomePage() {
   const handleSubmit = async () => {
     if (!prompt.trim() || isLoading) return;
 
-    // Check if user has any API key (Anthropic, OpenAI, Google, etc.) before sending
+    // Check if user has any API key (Anthropic, OpenAI, Google, etc.) or Ollama configured before sending
     const hasKey = await accomplish.hasAnyApiKey();
-    if (!hasKey) {
+    const selectedModel = await accomplish.getSelectedModel();
+    const hasOllamaConfigured = selectedModel?.provider === 'ollama';
+
+    if (!hasKey && !hasOllamaConfigured) {
       setShowSettingsDialog(true);
       return;
     }


### PR DESCRIPTION
## Summary
Previously, task submission was blocked unless users had a cloud provider API key (Anthropic, OpenAI, Google, xAI). Ollama is a local service that doesn't require an API key, so users with only Ollama configured were incorrectly redirected to the settings dialog.

## Changes
- Updated pre-execution validation in Home.tsx and TaskLauncher.tsx to also check if Ollama is configured as the selected model provider.

## Testing
Built locally + tested with `pnpm dev`

## Checklist
- [x] Code builds without errors (`pnpm build`)
- [x] Type checks pass (`pnpm typecheck`)
- [ ] Documentation updated (if needed) 
