### PR TITLE
fix(tests): add missing mocks for getSelectedModel and getOllamaConfig

### DIFF
--- a/apps/desktop/__tests__/integration/renderer/App.integration.test.tsx
+++ b/apps/desktop/__tests__/integration/renderer/App.integration.test.tsx
@@ -34,6 +34,8 @@ const mockAccomplish = {
   onTaskStatusChange: mockOnTaskStatusChange.mockReturnValue(() => {}),
   onTaskUpdate: mockOnTaskUpdate.mockReturnValue(() => {}),
   getTask: mockGetTask.mockResolvedValue(null),
+  getSelectedModel: vi.fn().mockResolvedValue({ provider: 'anthropic', id: 'claude-3-opus' }),
+  getOllamaConfig: vi.fn().mockResolvedValue(null),
 };
 
 // Mock the accomplish module - always return true for isRunningInElectron for most tests

--- a/apps/desktop/__tests__/integration/renderer/components/SettingsDialog.integration.test.tsx
+++ b/apps/desktop/__tests__/integration/renderer/components/SettingsDialog.integration.test.tsx
@@ -36,6 +36,7 @@ const mockAccomplish = {
   getDebugMode: mockGetDebugMode,
   getVersion: mockGetVersion,
   getSelectedModel: mockGetSelectedModel,
+  getOllamaConfig: vi.fn().mockResolvedValue(null),
   setDebugMode: mockSetDebugMode,
   setSelectedModel: mockSetSelectedModel,
   addApiKey: mockAddApiKey,

--- a/apps/desktop/__tests__/integration/renderer/components/Sidebar.integration.test.tsx
+++ b/apps/desktop/__tests__/integration/renderer/components/Sidebar.integration.test.tsx
@@ -46,6 +46,8 @@ const mockAccomplish = {
   listTasks: mockListTasks.mockResolvedValue([]),
   onTaskStatusChange: mockOnTaskStatusChange.mockReturnValue(() => {}),
   onTaskUpdate: mockOnTaskUpdate.mockReturnValue(() => {}),
+  getSelectedModel: vi.fn().mockResolvedValue({ provider: 'anthropic', id: 'claude-3-opus' }),
+  getOllamaConfig: vi.fn().mockResolvedValue(null),
 };
 
 // Mock the accomplish module

--- a/apps/desktop/__tests__/integration/renderer/components/TaskInputBar.integration.test.tsx
+++ b/apps/desktop/__tests__/integration/renderer/components/TaskInputBar.integration.test.tsx
@@ -19,6 +19,8 @@ vi.mock('@/lib/analytics', () => ({
 // Mock accomplish API
 const mockAccomplish = {
   logEvent: vi.fn().mockResolvedValue(undefined),
+  getSelectedModel: vi.fn().mockResolvedValue({ provider: 'anthropic', id: 'claude-3-opus' }),
+  getOllamaConfig: vi.fn().mockResolvedValue(null),
 };
 
 // Mock the accomplish module

--- a/apps/desktop/__tests__/integration/renderer/components/TaskLauncher.integration.test.tsx
+++ b/apps/desktop/__tests__/integration/renderer/components/TaskLauncher.integration.test.tsx
@@ -41,6 +41,8 @@ function createMockTask(
 // Mock accomplish API
 const mockAccomplish = {
   hasAnyApiKey: mockHasAnyApiKey,
+  getSelectedModel: vi.fn().mockResolvedValue({ provider: 'anthropic', id: 'claude-3-opus' }),
+  getOllamaConfig: vi.fn().mockResolvedValue(null),
 };
 
 // Mock the accomplish module

--- a/apps/desktop/__tests__/integration/renderer/pages/Execution.integration.test.tsx
+++ b/apps/desktop/__tests__/integration/renderer/pages/Execution.integration.test.tsx
@@ -61,6 +61,8 @@ const mockAccomplish = {
   onTaskUpdateBatch: mockOnTaskUpdateBatch.mockReturnValue(() => {}),
   onPermissionRequest: mockOnPermissionRequest.mockReturnValue(() => {}),
   onTaskStatusChange: mockOnTaskStatusChange.mockReturnValue(() => {}),
+  getSelectedModel: vi.fn().mockResolvedValue({ provider: 'anthropic', id: 'claude-3-opus' }),
+  getOllamaConfig: vi.fn().mockResolvedValue(null),
 };
 
 // Mock the accomplish module

--- a/apps/desktop/__tests__/integration/renderer/pages/Home.integration.test.tsx
+++ b/apps/desktop/__tests__/integration/renderer/pages/Home.integration.test.tsx
@@ -44,6 +44,8 @@ function createMockTask(
 // Mock accomplish API
 const mockAccomplish = {
   hasAnyApiKey: mockHasAnyApiKey,
+  getSelectedModel: vi.fn().mockResolvedValue({ provider: 'anthropic', id: 'claude-3-opus' }),
+  getOllamaConfig: vi.fn().mockResolvedValue(null),
   onTaskUpdate: mockOnTaskUpdate.mockReturnValue(() => {}),
   onPermissionRequest: mockOnPermissionRequest.mockReturnValue(() => {}),
   logEvent: mockLogEvent.mockResolvedValue(undefined),

--- a/apps/desktop/__tests__/integration/renderer/taskStore.integration.test.ts
+++ b/apps/desktop/__tests__/integration/renderer/taskStore.integration.test.ts
@@ -44,6 +44,8 @@ const mockAccomplish = {
   deleteTask: vi.fn(),
   clearTaskHistory: vi.fn(),
   logEvent: vi.fn().mockResolvedValue(undefined),
+  getSelectedModel: vi.fn().mockResolvedValue({ provider: 'anthropic', id: 'claude-3-opus' }),
+  getOllamaConfig: vi.fn().mockResolvedValue(null),
 };
 
 // Mock the accomplish module


### PR DESCRIPTION
## Summary
- Add `getSelectedModel` and `getOllamaConfig` mocks to accomplish API mocks in integration test files
- Required after the Ollama integration feature introduced calls to these methods in components

## Test plan
- [x] Ran `pnpm -F @accomplish/desktop test` - all 1094 tests pass
- [x] All 33 test files pass including the 8 modified integration test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)