### PR TITLE
feat: add LiteLLM API key support for authentication

### DIFF
--- a/apps/desktop/src/main/opencode/adapter.ts
+++ b/apps/desktop/src/main/opencode/adapter.ts
@@ -392,6 +392,10 @@ export class OpenCodeAdapter extends EventEmitter<OpenCodeAdapterEvents> {
       env.OPENROUTER_API_KEY = apiKeys.openrouter;
       console.log('[OpenCode CLI] Using OpenRouter API key from settings');
     }
+    if (apiKeys.litellm) {
+      env.LITELLM_API_KEY = apiKeys.litellm;
+      console.log('[OpenCode CLI] Using LiteLLM API key from settings');
+    }
 
     // Set Bedrock credentials if configured
     const bedrockCredentials = getBedrockCredentials();

--- a/apps/desktop/src/main/opencode/config-generator.ts
+++ b/apps/desktop/src/main/opencode/config-generator.ts
@@ -375,6 +375,7 @@ interface LiteLLMProviderConfig {
   name: string;
   options: {
     baseURL: string;
+    apiKey?: string;
   };
   models: Record<string, LiteLLMProviderModelConfig>;
 }
@@ -534,12 +535,23 @@ export async function generateOpenCodeConfig(): Promise<string> {
 
     // Only configure LiteLLM if we have at least one model
     if (Object.keys(litellmModels).length > 0) {
+      // Get LiteLLM API key if configured
+      const litellmApiKey = getApiKey('litellm');
+      
+      const litellmOptions: LiteLLMProviderConfig['options'] = {
+        baseURL: `${litellmConfig.baseUrl}/v1`,
+      };
+      
+      // Add API key to options if available
+      if (litellmApiKey) {
+        litellmOptions.apiKey = litellmApiKey;
+        console.log('[OpenCode Config] LiteLLM API key configured');
+      }
+      
       providerConfig.litellm = {
         npm: '@ai-sdk/openai-compatible',
         name: 'LiteLLM',
-        options: {
-          baseURL: `${litellmConfig.baseUrl}/v1`,
-        },
+        options: litellmOptions,
         models: litellmModels,
       };
       console.log('[OpenCode Config] LiteLLM provider configured with model:', Object.keys(litellmModels));


### PR DESCRIPTION
## Summary

This PR adds support for passing LiteLLM API key to the LiteLLM provider configuration, fixing authentication issues when using LiteLLM proxy services.

## Changes

### `adapter.ts`
- Added `LITELLM_API_KEY` environment variable support in `buildEnvironment()` method

### `config-generator.ts`
- Updated `LiteLLMProviderConfig` interface to include optional `apiKey` in options
- Added logic to retrieve and pass LiteLLM API key to provider options

## Problem

When using LiteLLM proxy services, requests were failing with `10401 - gateway request exception, please auth first` because the API key was not being passed to the provider.

## Solution

Now the LiteLLM API key configured in settings is properly passed to:
1. Environment variables (`LITELLM_API_KEY`)
2. Provider options (`apiKey` field for `@ai-sdk/openai-compatible`)
