### PR TITLE
refactor: move PR approval to private infrastructure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,6 @@ jobs:
       - name: Create release PR and merge
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APPROVER_TOKEN: ${{ secrets.RELEASE_APPROVER_TOKEN }}
         run: |
           VERSION="${{ steps.bump.outputs.new_version }}"
           BRANCH="release/v${VERSION}"
@@ -129,10 +128,7 @@ jobs:
               --head "$BRANCH")
             echo "Created PR: $PR_URL"
 
-            # Approve PR with separate token (can't self-approve)
-            echo "Approving PR..."
-            GH_TOKEN="$APPROVER_TOKEN" gh pr review "$BRANCH" --approve
-
+            # PR will be approved by Cloudflare Worker (private infrastructure)
             # Enable auto-merge (squash)
             gh pr merge "$BRANCH" --squash --auto --delete-branch
 


### PR DESCRIPTION
Removes RELEASE_APPROVER_TOKEN from public repo. The Cloudflare Worker (in private repo) now handles PR approval, keeping the token secure.