### PR TITLE
feat: add new Z.AI GLM models and configure custom provider

### DIFF
--- a/apps/desktop/src/main/opencode/config-generator.ts
+++ b/apps/desktop/src/main/opencode/config-generator.ts
@@ -380,7 +380,21 @@ interface LiteLLMProviderConfig {
   models: Record<string, LiteLLMProviderModelConfig>;
 }
 
-type ProviderConfig = OllamaProviderConfig | BedrockProviderConfig | OpenRouterProviderConfig | LiteLLMProviderConfig;
+interface ZaiProviderModelConfig {
+  name: string;
+  tools?: boolean;
+}
+
+interface ZaiProviderConfig {
+  npm: string;
+  name: string;
+  options: {
+    baseURL: string;
+  };
+  models: Record<string, ZaiProviderModelConfig>;
+}
+
+type ProviderConfig = OllamaProviderConfig | BedrockProviderConfig | OpenRouterProviderConfig | LiteLLMProviderConfig | ZaiProviderConfig;
 
 interface OpenCodeConfig {
   $schema?: string;
@@ -556,6 +570,29 @@ export async function generateOpenCodeConfig(): Promise<string> {
       };
       console.log('[OpenCode Config] LiteLLM provider configured with model:', Object.keys(litellmModels));
     }
+  }
+
+  // Add Z.AI Coding Plan provider configuration with all supported models
+  // This is needed because OpenCode's built-in zai-coding-plan provider may not have all models
+  const zaiKey = getApiKey('zai');
+  if (zaiKey) {
+    const zaiModels: Record<string, ZaiProviderModelConfig> = {
+      'glm-4.7-flashx': { name: 'GLM-4.7 FlashX (Latest)', tools: true },
+      'glm-4.7': { name: 'GLM-4.7', tools: true },
+      'glm-4.7-flash': { name: 'GLM-4.7 Flash', tools: true },
+      'glm-4.6': { name: 'GLM-4.6', tools: true },
+      'glm-4.5-flash': { name: 'GLM-4.5 Flash', tools: true },
+    };
+
+    providerConfig['zai-coding-plan'] = {
+      npm: '@ai-sdk/openai-compatible',
+      name: 'Z.AI Coding Plan',
+      options: {
+        baseURL: 'https://open.bigmodel.cn/api/paas/v4',
+      },
+      models: zaiModels,
+    };
+    console.log('[OpenCode Config] Z.AI Coding Plan provider configured with models:', Object.keys(zaiModels));
   }
 
   const config: OpenCodeConfig = {

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -220,10 +220,26 @@ export const DEFAULT_PROVIDERS: ProviderConfig[] = [
     baseUrl: 'https://open.bigmodel.cn',
     models: [
       {
+        id: 'glm-4.7-flashx',
+        displayName: 'GLM-4.7 FlashX (Latest)',
+        provider: 'zai',
+        fullId: 'zai/glm-4.7-flashx',
+        contextWindow: 200000,
+        supportsVision: false,
+      },
+      {
         id: 'glm-4.7',
-        displayName: 'GLM-4.7 (Latest)',
+        displayName: 'GLM-4.7',
         provider: 'zai',
         fullId: 'zai/glm-4.7',
+        contextWindow: 200000,
+        supportsVision: false,
+      },
+      {
+        id: 'glm-4.7-flash',
+        displayName: 'GLM-4.7 Flash',
+        provider: 'zai',
+        fullId: 'zai/glm-4.7-flash',
         contextWindow: 200000,
         supportsVision: false,
       },


### PR DESCRIPTION
## Summary
- Add GLM-4.7-FlashX and GLM-4.7-Flash models to Z.AI provider
- Configure Z.AI as custom OpenCode provider with explicit model list
- Mark GLM-4.7-FlashX as the latest/default model

## Details
This fixes `ProviderModelNotFoundError` when using newer GLM models that aren't in OpenCode's built-in `zai-coding-plan` provider registry. By configuring Z.AI as a custom provider with an explicit model list, we ensure all supported models are available.

## Test plan
- [ ] Select GLM-4.7-FlashX model in settings
- [ ] Run a task and verify it starts without model not found errors
- [ ] Verify other GLM models (4.7, 4.7-flash, 4.6, 4.5-flash) also work

🤖 Generated with [Claude Code](https://claude.com/claude-code)