### PR TITLE
fix: prohibit shell commands for browser automation

### DIFF
--- a/apps/desktop/skills/dev-browser/SKILL.md
+++ b/apps/desktop/skills/dev-browser/SKILL.md
@@ -7,6 +7,19 @@ description: Browser automation via MCP tools. ALWAYS use these tools for ANY we
 
 Browser automation using MCP tools. Use these tools directly for all web automation tasks.
 
+## CRITICAL: No Shell Commands for Browser
+
+**NEVER use bash/shell commands to open browsers or URLs.** This includes:
+- `open` (macOS)
+- `xdg-open` (Linux)
+- `start` (Windows)
+- Python `subprocess`, `webbrowser`, or similar
+- Any script that launches a browser process
+
+Shell commands open the user's **default browser** (Safari, Arc, Firefox, etc.), not the automation-controlled Chrome instance. This breaks the workflow because you cannot interact with pages opened via shell commands.
+
+**ALL browser automation MUST use the browser_* MCP tools below.**
+
 ## Tools
 
 **browser_navigate(url, page_name?)** - Navigate to a URL

--- a/apps/desktop/src/main/opencode/config-generator.ts
+++ b/apps/desktop/src/main/opencode/config-generator.ts
@@ -147,6 +147,7 @@ See the ask-user-question skill for full documentation and examples.
 <behavior>
 - Use AskUserQuestion tool for clarifying questions before starting ambiguous tasks
 - Use MCP tools directly - browser_navigate, browser_snapshot, browser_click, browser_type, browser_screenshot, browser_sequence
+- **NEVER use shell commands (open, xdg-open, start, subprocess, webbrowser) to open browsers or URLs** - these open the user's default browser, not the automation-controlled Chrome. ALL browser operations MUST use browser_* MCP tools.
 
 **BROWSER ACTION VERBOSITY - Be descriptive about web interactions:**
 - Before each browser action, briefly explain what you're about to do in user terms


### PR DESCRIPTION
## Summary

- Add explicit prohibition against using shell commands (`open`, `xdg-open`, `start`, `subprocess`) for browser automation
- Agents were bypassing MCP tools and using bash `open` command, causing URLs to open in the user's default browser (Safari, Arc) instead of the Playwright-controlled Chrome instance

## Changes

1. **SKILL.md** - Added "CRITICAL: No Shell Commands for Browser" section listing all prohibited commands with explanation
2. **config-generator.ts** - Added inline prohibition in the system prompt's behavior section

## Root Cause

After the Windows support PR (#101), the system prompt changed from detailed script-based instructions to just mentioning MCP tools. This left room for agents to "improvise" with shell commands. The agent knows macOS has an `open` command and nothing explicitly told it NOT to use it for browser tasks.

## Test Plan

- [ ] Run a browser automation task (e.g., "go to gmail")
- [ ] Verify agent uses `browser_navigate` MCP tool instead of `open` command
- [ ] Verify only the Playwright-controlled Chrome opens, not the default browser

🤖 Generated with [Claude Code](https://claude.ai/code)