### PR TITLE
chore: add dev-browser-mcp to postinstall and build scripts

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -6,10 +6,10 @@
   "description": "Accomplish Desktop App",
   "main": "dist-electron/main/index.js",
   "scripts": {
-    "postinstall": "electron-rebuild && npm --prefix skills/dev-browser install && npm --prefix skills/file-permission install && npm --prefix skills/ask-user-question install",
+    "postinstall": "electron-rebuild && npm --prefix skills/dev-browser install && npm --prefix skills/dev-browser-mcp install && npm --prefix skills/file-permission install && npm --prefix skills/ask-user-question install",
     "dev": "node scripts/patch-electron-name.cjs && node -e \"require('fs').rmSync('dist-electron',{recursive:true,force:true})\" && vite",
     "dev:clean": "CLEAN_START=1 vite",
-    "build": "tsc && vite build && npm --prefix skills/dev-browser install --omit=dev && npm --prefix skills/file-permission install --omit=dev && npm --prefix skills/ask-user-question install --omit=dev",
+    "build": "tsc && vite build && npm --prefix skills/dev-browser install --omit=dev && npm --prefix skills/dev-browser-mcp install --omit=dev && npm --prefix skills/file-permission install --omit=dev && npm --prefix skills/ask-user-question install --omit=dev",
     "build:electron": "tsc && vite build && node scripts/package.cjs",
     "build:unpack": "tsc && vite build && node scripts/package.cjs --dir",
     "package": "pnpm build && node scripts/package.cjs --mac --publish never",


### PR DESCRIPTION
Add npm install for skills/dev-browser-mcp to ensure the MCP server dependencies are installed during development and production builds.

## Description

<!-- Brief description of what this PR does -->

## Type of Change

<!-- Mark the relevant option with 'x' -->

- [ ] `feat`: New feature or functionality
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation only changes
- [ ] `chore`: Maintenance, dependencies, or tooling
- [ ] `refactor`: Code refactoring (no feature change)
- [ ] `test`: Adding or updating tests
- [ ] `perf`: Performance improvement
- [ ] `ci`: CI/CD changes

## Checklist

- [ ] PR title follows conventional commit format (e.g., `feat: add dark mode support`)
- [ ] Changes have been tested locally
- [ ] Any new dependencies are justified

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->
