### PR TITLE
fix: correct Ollama model ID format for OpenCode CLI

### DIFF
--- a/apps/desktop/src/main/opencode/adapter.ts
+++ b/apps/desktop/src/main/opencode/adapter.ts
@@ -561,7 +561,8 @@ export class OpenCodeAdapter extends EventEmitter<OpenCodeAdapterEvents> {
         args.push('--model', selectedModel.model);
       } else if (selectedModel.provider === 'ollama') {
         // Ollama models use format: ollama/model-name
-        args.push('--model', selectedModel.model);
+        const modelId = selectedModel.model.replace(/^ollama\//, '');
+        args.push('--model', `ollama/${modelId}`);
       } else if (selectedModel.provider === 'litellm') {
         // LiteLLM models pass through directly
         args.push('--model', selectedModel.model);

--- a/apps/desktop/src/main/opencode/config-generator.ts
+++ b/apps/desktop/src/main/opencode/config-generator.ts
@@ -353,6 +353,9 @@ export async function generateOpenCodeConfig(): Promise<string> {
   if (ollamaProvider?.connectionStatus === 'connected' && ollamaProvider.credentials.type === 'ollama') {
     // New provider settings: Ollama is connected
     if (ollamaProvider.selectedModelId) {
+      // OpenCode CLI splits "ollama/model" into provider="ollama" and modelID="model"
+      // So we need to register the model without the "ollama/" prefix
+      const modelId = ollamaProvider.selectedModelId.replace(/^ollama\//, '');
       providerConfig.ollama = {
         npm: '@ai-sdk/openai-compatible',
         name: 'Ollama (local)',
@@ -360,13 +363,13 @@ export async function generateOpenCodeConfig(): Promise<string> {
           baseURL: `${ollamaProvider.credentials.serverUrl}/v1`,
         },
         models: {
-          [ollamaProvider.selectedModelId]: {
-            name: ollamaProvider.selectedModelId,
+          [modelId]: {
+            name: modelId,
             tools: true,
           },
         },
       };
-      console.log('[OpenCode Config] Ollama configured from new settings:', ollamaProvider.selectedModelId);
+      console.log('[OpenCode Config] Ollama configured from new settings:', modelId);
     }
   } else {
     // Legacy fallback: use old Ollama config


### PR DESCRIPTION
## Summary

Fixes Ollama models not working due to incorrect model ID format when communicating with OpenCode CLI.

- OpenCode CLI parses `--model ollama/qwen3:latest` by splitting on `/` → provider=`ollama`, modelID=`qwen3:latest`
- The config was registering models WITH the prefix (`ollama/qwen3:latest`)
- OpenCode CLI looks them up WITHOUT the prefix (`qwen3:latest`)
- This caused `ProviderModelNotFoundError` for all Ollama models

## Changes

- **adapter.ts**: Ensure model ID always has `ollama/` prefix when passed to CLI
- **config-generator.ts**: Register models WITHOUT `ollama/` prefix in config

## Error Before Fix

```
ProviderModelNotFoundError: ProviderModelNotFoundError
  providerID: "ollama",
  modelID: "qwen3:latest",
  suggestions: [ "ollama/qwen3:latest" ],
```

## Test Plan

- [x] Configured Ollama with `qwen3:latest` model
- [x] Sent test prompt "2 + 2"
- [x] Verified model responds correctly without ProviderModelNotFoundError

## Verification

Tested locally with Ollama running `qwen3:latest`. The model now works correctly.

Fixes #122
Fixes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)