### PR TITLE
feat: add useful development commands at root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,25 @@
   },
   "scripts": {
     "dev": "pnpm -F @accomplish/desktop dev",
+    "dev:clean": "pnpm -F @accomplish/desktop dev:clean",
     "build": "pnpm -r build",
     "build:desktop": "pnpm -F @accomplish/desktop build",
     "lint": "pnpm -r lint",
     "typecheck": "pnpm -r typecheck",
-    "clean": "pnpm -r clean && rm -rf node_modules"
+    "clean": "pnpm -r clean && rm -rf node_modules",
+    "test": "pnpm -F @accomplish/desktop test",
+    "test:unit": "pnpm -F @accomplish/desktop test:unit",
+    "test:integration": "pnpm -F @accomplish/desktop test:integration",
+    "test:coverage": "pnpm -F @accomplish/desktop test:coverage",
+    "test:watch": "pnpm -F @accomplish/desktop test:watch",
+    "test:e2e": "pnpm -F @accomplish/desktop test:e2e:native",
+    "test:e2e:ui": "pnpm -F @accomplish/desktop test:e2e:native:ui",
+    "test:e2e:debug": "pnpm -F @accomplish/desktop test:e2e:native:debug",
+    "test:e2e:fast": "pnpm -F @accomplish/desktop test:e2e:native:fast",
+    "test:e2e:integration": "pnpm -F @accomplish/desktop test:e2e:native:integration",
+    "test:e2e:build": "pnpm -F @accomplish/desktop test:e2e:build",
+    "test:e2e:clean": "pnpm -F @accomplish/desktop test:e2e:clean",
+    "test:e2e:report": "pnpm -F @accomplish/desktop test:e2e:report"
   },
   "engines": {
     "node": ">=20.0.0",


### PR DESCRIPTION
## Description

Adds all development and test commands to the root `package.json` for improved developer experience. Previously, developers had to use `pnpm -F @accomplish/desktop` to run common commands. Now all commands from `CLAUDE.md` are available directly from the monorepo root.

**Added commands:**
- `dev:clean` - Start dev mode with `CLEAN_START=1`
- `test` - Run all tests
- `test:unit` - Run unit tests
- `test:integration` - Run integration tests
- `test:coverage` - Generate coverage report
- `test:watch` - Run tests in watch mode
- `test:e2e` - Run E2E tests (Playwright native)
- `test:e2e:ui` - Run E2E tests with Playwright UI
- `test:e2e:debug` - Run E2E tests in debug mode
- `test:e2e:fast` - Run fast E2E project only
- `test:e2e:integration` - Run integration E2E project only
- `test:e2e:build` - Build Docker containers for E2E
- `test:e2e:clean` - Clean Docker resources
- `test:e2e:report` - Show Playwright HTML report

## Type of Change

- [x] `feat`: New feature or functionality
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation only changes
- [ ] `chore`: Maintenance, dependencies, or tooling
- [ ] `refactor`: Code refactoring (no feature change)
- [ ] `test`: Adding or updating tests
- [ ] `perf`: Performance improvement
- [ ] `ci`: CI/CD changes

## Checklist

- [x] PR title follows conventional commit format (e.g., `feat: add dark mode support`)
- [x] Changes have been tested locally
- [x] Any new dependencies are justified

## Related Issues

Closes #139 
