### PR TITLE
fix(litellm): fix provider integration and model selection

### DIFF
--- a/apps/desktop/src/main/opencode/adapter.ts
+++ b/apps/desktop/src/main/opencode/adapter.ts
@@ -523,10 +523,9 @@ export class OpenCodeAdapter extends EventEmitter<OpenCodeAdapterEvents> {
       console.log('[OpenCode CLI] Using Ollama host from legacy settings:', selectedModel.baseUrl);
     }
 
-    // Set LiteLLM base URL if configured
+    // Set LiteLLM base URL if configured (for debugging/logging purposes)
     if (activeModel?.provider === 'litellm' && activeModel.baseUrl) {
-      env.LITELLM_BASE_URL = activeModel.baseUrl;
-      console.log('[OpenCode CLI] Using LiteLLM base URL:', activeModel.baseUrl);
+      console.log('[OpenCode CLI] LiteLLM active with base URL:', activeModel.baseUrl);
     }
 
     // Log config environment variable
@@ -578,8 +577,9 @@ export class OpenCodeAdapter extends EventEmitter<OpenCodeAdapterEvents> {
         const modelId = selectedModel.model.replace(/^ollama\//, '');
         args.push('--model', `ollama/${modelId}`);
       } else if (selectedModel.provider === 'litellm') {
-        // LiteLLM models pass through directly
-        args.push('--model', selectedModel.model);
+        // LiteLLM models use format: litellm/model-name
+        const modelId = selectedModel.model.replace(/^litellm\//, '');
+        args.push('--model', `litellm/${modelId}`);
       } else {
         args.push('--model', selectedModel.model);
       }

--- a/apps/desktop/src/main/opencode/config-generator.ts
+++ b/apps/desktop/src/main/opencode/config-generator.ts
@@ -532,12 +532,18 @@ export async function generateOpenCodeConfig(): Promise<string> {
   const litellmProvider = providerSettings.connectedProviders.litellm;
   if (litellmProvider?.connectionStatus === 'connected' && litellmProvider.credentials.type === 'litellm') {
     if (litellmProvider.selectedModelId) {
+      // Get API key if available
+      const litellmApiKey = getApiKey('litellm');
+      const litellmOptions: LiteLLMProviderConfig['options'] = {
+        baseURL: `${litellmProvider.credentials.serverUrl}/v1`,
+      };
+      if (litellmApiKey) {
+        litellmOptions.apiKey = litellmApiKey;
+      }
       providerConfig.litellm = {
         npm: '@ai-sdk/openai-compatible',
         name: 'LiteLLM',
-        options: {
-          baseURL: `${litellmProvider.credentials.serverUrl}/v1`,
-        },
+        options: litellmOptions,
         models: {
           [litellmProvider.selectedModelId]: {
             name: litellmProvider.selectedModelId,
@@ -545,7 +551,7 @@ export async function generateOpenCodeConfig(): Promise<string> {
           },
         },
       };
-      console.log('[OpenCode Config] LiteLLM configured:', litellmProvider.selectedModelId);
+      console.log('[OpenCode Config] LiteLLM configured:', litellmProvider.selectedModelId, litellmApiKey ? '(with API key)' : '(no API key)');
     }
   }
 

--- a/apps/desktop/src/renderer/components/settings/providers/LiteLLMProviderForm.tsx
+++ b/apps/desktop/src/renderer/components/settings/providers/LiteLLMProviderForm.tsx
@@ -11,6 +11,7 @@ import {
   FormError,
 } from '../shared';
 import { settingsVariants, settingsTransitions } from '@/lib/animations';
+import { getAccomplish } from '@/lib/accomplish';
 
 // Import LiteLLM logo
 import litellmLogo from '/assets/ai-logos/litellm.svg';
@@ -42,7 +43,28 @@ export function LiteLLMProviderForm({
     setError(null);
 
     try {
-      // For now, just create a placeholder connected state
+      const accomplish = getAccomplish();
+      const trimmedKey = apiKey.trim() || undefined;
+
+      // Test connection and fetch models
+      const result = await accomplish.testLiteLLMConnection(serverUrl, trimmedKey);
+      if (!result.success) {
+        setError(result.error || 'Connection failed');
+        setConnecting(false);
+        return;
+      }
+
+      // Save API key if provided
+      if (trimmedKey) {
+        await accomplish.addApiKey('litellm', trimmedKey);
+      }
+
+      // Map models to the expected format
+      const models = result.models?.map(m => ({
+        id: m.id,
+        name: m.name,
+      })) || [];
+
       const provider: ConnectedProvider = {
         providerId: 'litellm',
         connectionStatus: 'connected',
@@ -50,11 +72,11 @@ export function LiteLLMProviderForm({
         credentials: {
           type: 'litellm',
           serverUrl,
-          hasApiKey: !!apiKey.trim(),
-          keyPrefix: apiKey.trim() ? apiKey.trim().substring(0, 10) + '...' : undefined,
+          hasApiKey: !!trimmedKey,
+          keyPrefix: trimmedKey ? trimmedKey.substring(0, 10) + '...' : undefined,
         } as LiteLLMCredentials,
         lastConnectedAt: new Date().toISOString(),
-        availableModels: [],
+        availableModels: models,
       };
 
       onConnect(provider);


### PR DESCRIPTION
## Summary

- Add provider prefix for ollama and litellm models when passing to CLI args (e.g., `ollama/model-name`, `litellm/model-name`)
- Properly pass LiteLLM API key through the config generator when configured
- Fix LiteLLM provider form to actually test the connection and fetch available models from the server

## Test plan

- [ ] Connect a LiteLLM server in Settings > Providers
- [ ] Verify available models are fetched and displayed
- [ ] Select a LiteLLM model and run a task
- [ ] Verify the model prefix is correctly passed to the CLI

🤖 Generated with [Claude Code](https://claude.ai/claude-code)