### PR TITLE
fix: use authenticated endpoint for OpenRouter API key validation

### DIFF
--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -921,7 +921,7 @@ export function registerIPCHandlers(): void {
 
         case 'openrouter':
           response = await fetchWithTimeout(
-            'https://openrouter.ai/api/v1/models',
+            'https://openrouter.ai/api/v1/auth/key',
             {
               method: 'GET',
               headers: {


### PR DESCRIPTION
## Summary
- Fixed OpenRouter API key validation to properly reject invalid keys
- The `/api/v1/models` endpoint is public and returns 200 OK regardless of key validity
- Switched to `/api/v1/auth/key` which returns 401 for invalid keys and 200 with key metadata for valid keys

## Test plan
- [ ] Enter an invalid OpenRouter API key → should show validation error
- [ ] Enter a valid OpenRouter API key → should connect successfully

🤖 Generated with [Claude Code](https://claude.ai/claude-code)