### PR TITLE
feat: Add Z.AI (International) provider for international subscriptions (#136)

### DIFF
--- a/apps/desktop/src/main/opencode/config-generator.ts
+++ b/apps/desktop/src/main/opencode/config-generator.ts
@@ -473,6 +473,7 @@ export async function generateOpenCodeConfig(azureFoundryToken?: string): Promis
     xai: 'xai',
     deepseek: 'deepseek',
     zai: 'zai-coding-plan',
+    'zai-intl': 'zai-coding-plan-intl',
     bedrock: 'amazon-bedrock',
     'azure-foundry': 'azure-foundry',
     ollama: 'ollama',
@@ -483,7 +484,7 @@ export async function generateOpenCodeConfig(azureFoundryToken?: string): Promis
   };
 
   // Build enabled providers list from new settings or fall back to base providers
-  const baseProviders = ['anthropic', 'openai', 'openrouter', 'google', 'xai', 'deepseek', 'zai-coding-plan', 'amazon-bedrock', 'minimax'];
+  const baseProviders = ['anthropic', 'openai', 'openrouter', 'google', 'xai', 'deepseek', 'zai-coding-plan', 'zai-coding-plan-intl', 'amazon-bedrock', 'minimax'];
   let enabledProviders = baseProviders;
 
   // If we have connected providers in the new settings, use those
@@ -788,13 +789,35 @@ export async function generateOpenCodeConfig(azureFoundryToken?: string): Promis
 
     providerConfig['zai-coding-plan'] = {
       npm: '@ai-sdk/openai-compatible',
-      name: 'Z.AI Coding Plan',
+      name: 'Z.AI Coding Plan (Chinese)',
       options: {
         baseURL: 'https://open.bigmodel.cn/api/paas/v4',
       },
       models: zaiModels,
     };
-    console.log('[OpenCode Config] Z.AI Coding Plan provider configured with models:', Object.keys(zaiModels));
+    console.log('[OpenCode Config] Z.AI Coding Plan (Chinese) provider configured with models:', Object.keys(zaiModels));
+  }
+
+  // Add Z.AI Coding Plan International provider configuration
+  const zaiIntlKey = getApiKey('zai-intl');
+  if (zaiIntlKey) {
+    const zaiIntlModels: Record<string, ZaiProviderModelConfig> = {
+      'glm-4.7-flashx': { name: 'GLM-4.7 FlashX (Latest)', tools: true },
+      'glm-4.7': { name: 'GLM-4.7', tools: true },
+      'glm-4.7-flash': { name: 'GLM-4.7 Flash', tools: true },
+      'glm-4.6': { name: 'GLM-4.6', tools: true },
+      'glm-4.5-flash': { name: 'GLM-4.5 Flash', tools: true },
+    };
+
+    providerConfig['zai-coding-plan-intl'] = {
+      npm: '@ai-sdk/openai-compatible',
+      name: 'Z.AI Coding Plan (International)',
+      options: {
+        baseURL: 'https://api.z.ai/api/coding/paas/v4',
+      },
+      models: zaiIntlModels,
+    };
+    console.log('[OpenCode Config] Z.AI Coding Plan (International) provider configured with models:', Object.keys(zaiIntlModels));
   }
 
   const config: OpenCodeConfig = {
@@ -938,7 +961,16 @@ export async function syncApiKeysToOpenCodeAuth(): Promise<void> {
     if (!auth['zai-coding-plan'] || auth['zai-coding-plan'].key !== apiKeys.zai) {
       auth['zai-coding-plan'] = { type: 'api', key: apiKeys.zai };
       updated = true;
-      console.log('[OpenCode Auth] Synced Z.AI Coding Plan API key');
+      console.log('[OpenCode Auth] Synced Z.AI Coding Plan (Chinese) API key');
+    }
+  }
+
+  // Sync Z.AI Coding Plan International API key
+  if (apiKeys['zai-intl']) {
+    if (!auth['zai-coding-plan-intl'] || auth['zai-coding-plan-intl'].key !== apiKeys['zai-intl']) {
+      auth['zai-coding-plan-intl'] = { type: 'api', key: apiKeys['zai-intl'] };
+      updated = true;
+      console.log('[OpenCode Auth] Synced Z.AI Coding Plan (International) API key');
     }
   }
 

--- a/apps/desktop/src/main/store/secureStorage.ts
+++ b/apps/desktop/src/main/store/secureStorage.ts
@@ -187,13 +187,13 @@ export function deleteApiKey(provider: string): boolean {
 /**
  * Supported API key providers
  */
-export type ApiKeyProvider = 'anthropic' | 'openai' | 'openrouter' | 'google' | 'xai' | 'deepseek' | 'zai' | 'custom' | 'bedrock' | 'litellm' | 'minimax';
+export type ApiKeyProvider = 'anthropic' | 'openai' | 'openrouter' | 'google' | 'xai' | 'deepseek' | 'zai' | 'zai-intl' | 'custom' | 'bedrock' | 'litellm' | 'minimax';
 
 /**
  * Get all API keys for all providers
  */
 export async function getAllApiKeys(): Promise<Record<ApiKeyProvider, string | null>> {
-  const [anthropic, openai, openrouter, google, xai, deepseek, zai, custom, bedrock, litellm, minimax] = await Promise.all([
+  const [anthropic, openai, openrouter, google, xai, deepseek, zai, zaiIntl, custom, bedrock, litellm, minimax] = await Promise.all([
     getApiKey('anthropic'),
     getApiKey('openai'),
     getApiKey('openrouter'),
@@ -201,13 +201,14 @@ export async function getAllApiKeys(): Promise<Record<ApiKeyProvider, string | n
     getApiKey('xai'),
     getApiKey('deepseek'),
     getApiKey('zai'),
+    getApiKey('zai-intl'),
     getApiKey('custom'),
     getApiKey('bedrock'),
     getApiKey('litellm'),
     getApiKey('minimax'),
   ]);
 
-  return { anthropic, openai, openrouter, google, xai, deepseek, zai, custom, bedrock, litellm, minimax };
+  return { anthropic, openai, openrouter, google, xai, deepseek, zai, 'zai-intl': zaiIntl, custom, bedrock, litellm, minimax };
 }
 
 /**

--- a/apps/desktop/src/renderer/components/settings/ProviderCard.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProviderCard.tsx
@@ -31,6 +31,7 @@ const PROVIDER_LOGOS: Record<ProviderId, string> = {
   xai: xaiLogo,
   deepseek: deepseekLogo,
   zai: zaiLogo,
+  'zai-intl': zaiLogo,
   bedrock: bedrockLogo,
   'azure-foundry': azureLogo,
   ollama: ollamaLogo,

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -2,7 +2,7 @@
  * Provider and model configuration types for multi-provider support
  */
 
-export type ProviderType = 'anthropic' | 'openai' | 'openrouter' | 'google' | 'xai' | 'ollama' | 'deepseek' | 'zai' | 'azure-foundry' | 'custom' | 'bedrock' | 'litellm' | 'minimax' | 'lmstudio';
+export type ProviderType = 'anthropic' | 'openai' | 'openrouter' | 'google' | 'xai' | 'ollama' | 'deepseek' | 'zai' | 'zai-intl' | 'azure-foundry' | 'custom' | 'bedrock' | 'litellm' | 'minimax' | 'lmstudio';
 
 export interface ProviderConfig {
   id: ProviderType;
@@ -270,7 +270,7 @@ export const DEFAULT_PROVIDERS: ProviderConfig[] = [
   },
   {
     id: 'zai',
-    name: 'Z.AI Coding Plan',
+    name: 'Z.AI Coding Plan (Chinese)',
     requiresApiKey: true,
     apiKeyEnvVar: 'ZAI_API_KEY',
     baseUrl: 'https://open.bigmodel.cn',
@@ -312,6 +312,55 @@ export const DEFAULT_PROVIDERS: ProviderConfig[] = [
         displayName: 'GLM-4.5 Flash',
         provider: 'zai',
         fullId: 'zai/glm-4.5-flash',
+        contextWindow: 128000,
+        supportsVision: false,
+      },
+    ],
+  },
+  {
+    id: 'zai-intl',
+    name: 'Z.AI Coding Plan (International)',
+    requiresApiKey: true,
+    apiKeyEnvVar: 'ZAI_INTL_API_KEY',
+    baseUrl: 'https://api.z.ai',
+    models: [
+      {
+        id: 'glm-4.7-flashx',
+        displayName: 'GLM-4.7 FlashX (Latest)',
+        provider: 'zai-intl',
+        fullId: 'zai-intl/glm-4.7-flashx',
+        contextWindow: 200000,
+        supportsVision: false,
+      },
+      {
+        id: 'glm-4.7',
+        displayName: 'GLM-4.7',
+        provider: 'zai-intl',
+        fullId: 'zai-intl/glm-4.7',
+        contextWindow: 200000,
+        supportsVision: false,
+      },
+      {
+        id: 'glm-4.7-flash',
+        displayName: 'GLM-4.7 Flash',
+        provider: 'zai-intl',
+        fullId: 'zai-intl/glm-4.7-flash',
+        contextWindow: 200000,
+        supportsVision: false,
+      },
+      {
+        id: 'glm-4.6',
+        displayName: 'GLM-4.6',
+        provider: 'zai-intl',
+        fullId: 'zai-intl/glm-4.6',
+        contextWindow: 200000,
+        supportsVision: false,
+      },
+      {
+        id: 'glm-4.5-flash',
+        displayName: 'GLM-4.5 Flash',
+        provider: 'zai-intl',
+        fullId: 'zai-intl/glm-4.5-flash',
         contextWindow: 128000,
         supportsVision: false,
       },

--- a/packages/shared/src/types/providerSettings.ts
+++ b/packages/shared/src/types/providerSettings.ts
@@ -7,6 +7,7 @@ export type ProviderId =
   | 'xai'
   | 'deepseek'
   | 'zai'
+  | 'zai-intl'
   | 'bedrock'
   | 'azure-foundry'
   | 'ollama'
@@ -32,7 +33,8 @@ export const PROVIDER_META: Record<ProviderId, ProviderMeta> = {
   google: { id: 'google', name: 'Gemini', category: 'classic', label: 'Service', logoKey: 'google-gen-ai', helpUrl: 'https://aistudio.google.com/app/apikey' },
   xai: { id: 'xai', name: 'XAI', category: 'classic', label: 'Service', logoKey: 'Xai', helpUrl: 'https://x.ai/api' },
   deepseek: { id: 'deepseek', name: 'DeepSeek', category: 'classic', label: 'Service', logoKey: 'Deepseek', helpUrl: 'https://platform.deepseek.com/api_keys' },
-  zai: { id: 'zai', name: 'Z-AI', category: 'classic', label: 'Service', logoKey: 'z-ai' },
+  zai: { id: 'zai', name: 'Z-AI (Chinese)', category: 'classic', label: 'Service', logoKey: 'z-ai' },
+  'zai-intl': { id: 'zai-intl', name: 'Z-AI (International)', category: 'classic', label: 'Service', logoKey: 'z-ai' },
   bedrock: { id: 'bedrock', name: 'AWS Bedrock', category: 'aws', label: 'Service', logoKey: 'aws-bedrock' },
   'azure-foundry': { id: 'azure-foundry', name: 'Azure AI Foundry', category: 'azure', label: 'Service', logoKey: 'azure', helpUrl: 'https://ai.azure.com' },
   ollama: { id: 'ollama', name: 'Ollama', category: 'local', label: 'Local Models', logoKey: 'olama' },


### PR DESCRIPTION
## Summary

Adds Z.AI (International) as a separate provider to support users with international Z.AI Coding Plan subscriptions.

## Problem

Z.AI Coding Plan has two different endpoints:
- **Chinese subscription**: `https://open.bigmodel.cn/api/paas/v4`
- **International subscription**: `https://api.z.ai/api/coding/paas/v4`

Previously, Openwork only connected to the Chinese endpoint, causing rate limiting issues for international subscription users (see #136).

## Solution

Following the pattern used by other tools (e.g., cc-switch), this PR creates two separate provider options:
- **Z.AI Coding Plan (Chinese)** - for Chinese subscriptions
- **Z.AI Coding Plan (International)** - for international subscriptions

## Changes

- Added `zai-intl` provider type across type definitions
- Created Z.AI (International) provider configuration with `api.z.ai` endpoint
- Updated OpenCode config generator to handle both Chinese and International Z.AI providers
- Added provider metadata and logo mapping for `zai-intl`
- Updated secure storage to support `zai-intl` API keys
- Both providers now clearly labeled as "Chinese" and "International"

## Implementation Details

**Type definitions** (`packages/shared/src/types/`):
- Added `zai-intl` to `ProviderType` and `ProviderId`
- Created provider metadata for Z.AI (International)
- Added Z.AI International models with same model list as Chinese version

**Config generator** (`apps/desktop/src/main/opencode/config-generator.ts`):
- Maps `zai-intl` to `zai-coding-plan-intl` for OpenCode CLI
- Generates separate provider config with International endpoint
- Syncs international API keys to OpenCode auth.json

**UI** (`apps/desktop/src/renderer/components/settings/ProviderCard.tsx`):
- Added logo mapping for `zai-intl` (reuses same Z.AI logo)

**Storage** (`apps/desktop/src/main/store/secureStorage.ts`):
- Added `zai-intl` to `ApiKeyProvider` type
- Updated `getAllApiKeys` to include `zai-intl`

## Quality Gates

- ✅ TypeScript compilation (`pnpm lint`)
- ✅ Full build (`pnpm build`)
- ✅ No breaking changes

## Testing

Users with international Z.AI subscriptions can now:
1. Go to Settings → Providers
2. Select "Z.AI Coding Plan (International)"
3. Enter their international API key
4. Successfully use Z.AI models without rate limiting

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)