### PR TITLE
feat: add light and dark theme support with toggle (#91)

### DIFF
--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -36,6 +36,8 @@ import {
 import {
   getDebugMode,
   setDebugMode,
+  getTheme,
+  setTheme,
   getAppSettings,
   getOnboardingComplete,
   setOnboardingComplete,
@@ -2233,6 +2235,19 @@ export function registerIPCHandlers(): void {
     for (const win of BrowserWindow.getAllWindows()) {
       win.webContents.send('settings:debug-mode-changed', { enabled });
     }
+  });
+
+  // Settings: Get theme
+  handle('settings:theme', async (_event: IpcMainInvokeEvent) => {
+    return getTheme();
+  });
+
+  // Settings: Set theme
+  handle('settings:set-theme', async (_event: IpcMainInvokeEvent, theme: string) => {
+    if (typeof theme !== 'string' || (theme !== 'light' && theme !== 'dark')) {
+      throw new Error('Invalid theme value');
+    }
+    setTheme(theme);
   });
 
   // Settings: Get all app settings

--- a/apps/desktop/src/main/store/migrations/index.ts
+++ b/apps/desktop/src/main/store/migrations/index.ts
@@ -14,6 +14,7 @@ import { migration as v001 } from './v001-initial';
 import { migration as v002 } from './v002-azure-foundry';
 import { migration as v003 } from './v003-lmstudio';
 import { migration as v004 } from './v004-openai-base-url';
+import { migration as v005 } from './v005-theme';
 
 // Migrations array
 const migrations: Migration[] = [
@@ -21,6 +22,7 @@ const migrations: Migration[] = [
   v002,
   v003,
   v004,
+  v005,
 ];
 
 /**
@@ -36,7 +38,7 @@ export function registerMigration(migration: Migration): void {
  * Current schema version supported by this app.
  * Increment this when adding new migrations.
  */
-export const CURRENT_VERSION = 4;
+export const CURRENT_VERSION = 5;
 
 /**
  * Get the stored schema version from the database.

--- a/apps/desktop/src/main/store/migrations/v005-theme.ts
+++ b/apps/desktop/src/main/store/migrations/v005-theme.ts
@@ -1,0 +1,16 @@
+// apps/desktop/src/main/store/migrations/v005-theme.ts
+
+import type { Database } from 'better-sqlite3';
+import type { Migration } from './index';
+
+export const migration: Migration = {
+  version: 5,
+  up(db: Database): void {
+    // Add theme column to app_settings table
+    db.exec(`
+      ALTER TABLE app_settings ADD COLUMN theme TEXT DEFAULT 'light';
+    `);
+
+    console.log('[Migration v005] Added theme column to app_settings');
+  },
+};

--- a/apps/desktop/src/main/store/repositories/appSettings.ts
+++ b/apps/desktop/src/main/store/repositories/appSettings.ts
@@ -13,6 +13,7 @@ interface AppSettingsRow {
   azure_foundry_config: string | null;
   lmstudio_config: string | null;
   openai_base_url: string | null;
+  theme: string | null;
 }
 
 interface AppSettings {
@@ -150,6 +151,22 @@ export function getOpenAiBaseUrl(): string {
 export function setOpenAiBaseUrl(baseUrl: string): void {
   const db = getDatabase();
   db.prepare('UPDATE app_settings SET openai_base_url = ? WHERE id = 1').run(baseUrl || '');
+}
+
+/**
+ * Get theme ('light' or 'dark', defaults to 'light').
+ */
+export function getTheme(): string {
+  const row = getRow();
+  return row.theme || 'light';
+}
+
+/**
+ * Set theme ('light' or 'dark').
+ */
+export function setTheme(theme: string): void {
+  const db = getDatabase();
+  db.prepare('UPDATE app_settings SET theme = ? WHERE id = 1').run(theme);
 }
 
 function safeParseJson<T>(json: string | null): T | null {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -53,6 +53,10 @@ const accomplishAPI = {
     ipcRenderer.invoke('settings:debug-mode'),
   setDebugMode: (enabled: boolean): Promise<void> =>
     ipcRenderer.invoke('settings:set-debug-mode', enabled),
+  getTheme: (): Promise<string> =>
+    ipcRenderer.invoke('settings:theme'),
+  setTheme: (theme: string): Promise<void> =>
+    ipcRenderer.invoke('settings:set-theme', theme),
   getAppSettings: (): Promise<{ debugMode: boolean; onboardingComplete: boolean }> =>
     ipcRenderer.invoke('settings:app-settings'),
   getOpenAiBaseUrl: (): Promise<string> =>

--- a/apps/desktop/src/renderer/components/layout/SettingsDialog.tsx
+++ b/apps/desktop/src/renderer/components/layout/SettingsDialog.tsx
@@ -16,6 +16,7 @@ import { hasAnyReadyProvider, isProviderReady } from '@accomplish/shared';
 import { useProviderSettings } from '@/components/settings/hooks/useProviderSettings';
 import { ProviderGrid } from '@/components/settings/ProviderGrid';
 import { ProviderSettingsPanel } from '@/components/settings/ProviderSettingsPanel';
+import { useTheme } from '@/contexts/ThemeContext';
 
 // First 4 providers shown in collapsed view (matches PROVIDER_ORDER in ProviderGrid)
 const FIRST_FOUR_PROVIDERS: ProviderId[] = ['openai', 'anthropic', 'google', 'bedrock'];
@@ -47,6 +48,9 @@ export default function SettingsDialog({ open, onOpenChange, onApiKeySaved, init
   const [debugMode, setDebugModeState] = useState(false);
   const [exportStatus, setExportStatus] = useState<'idle' | 'exporting' | 'success' | 'error'>('idle');
   const accomplish = getAccomplish();
+
+  // Theme state from context
+  const { theme, setTheme } = useTheme();
 
   // Refetch settings and debug mode when dialog opens
   useEffect(() => {
@@ -167,6 +171,12 @@ export default function SettingsDialog({ open, onOpenChange, onApiKeySaved, init
     setDebugModeState(newValue);
     analytics.trackToggleDebugMode(newValue);
   }, [debugMode, accomplish]);
+
+  // Handle theme toggle
+  const handleThemeToggle = useCallback(() => {
+    const newTheme = theme === 'light' ? 'dark' : 'light';
+    setTheme(newTheme);
+  }, [theme, setTheme]);
 
   // Handle log export
   const handleExportLogs = useCallback(async () => {
@@ -402,6 +412,56 @@ export default function SettingsDialog({ open, onOpenChange, onApiKeySaved, init
                       </p>
                     </div>
                   )}
+                </div>
+              </motion.section>
+            )}
+          </AnimatePresence>
+
+          {/* Theme Section - only shown when a provider is selected */}
+          <AnimatePresence>
+            {selectedProvider && (
+              <motion.section
+                variants={settingsVariants.slideDown}
+                initial="initial"
+                animate="animate"
+                exit="exit"
+                transition={{ ...settingsTransitions.enter, delay: 0.06 }}
+              >
+                <div className="rounded-lg border border-border bg-card p-5">
+                  <div className="flex items-center justify-between">
+                    <div className="flex-1">
+                      <div className="font-medium text-foreground">Theme</div>
+                      <p className="mt-1.5 text-sm text-muted-foreground leading-relaxed">
+                        Switch between light and dark theme.
+                      </p>
+                    </div>
+                    <div className="ml-4 flex items-center gap-3">
+                      {/* Theme Toggle */}
+                      <button
+                        data-testid="settings-theme-toggle"
+                        onClick={handleThemeToggle}
+                        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors duration-200 ease-accomplish ${theme === 'dark' ? 'bg-primary' : 'bg-muted'
+                          }`}
+                      >
+                        <span
+                          className={`inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition-transform duration-200 ease-accomplish ${theme === 'dark' ? 'translate-x-6' : 'translate-x-1'
+                            }`}
+                        />
+                      </button>
+                      {/* Theme Icon */}
+                      <div className="text-muted-foreground">
+                        {theme === 'dark' ? (
+                          <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                          </svg>
+                        ) : (
+                          <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                          </svg>
+                        )}
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </motion.section>
             )}

--- a/apps/desktop/src/renderer/contexts/ThemeContext.tsx
+++ b/apps/desktop/src/renderer/contexts/ThemeContext.tsx
@@ -1,0 +1,68 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import { getAccomplish } from '../lib/accomplish';
+
+export type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>('light');
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  // Load theme from database on mount
+  useEffect(() => {
+    const loadTheme = async () => {
+      try {
+        const accomplish = getAccomplish();
+        const savedTheme = await accomplish.getTheme();
+        if (savedTheme === 'light' || savedTheme === 'dark') {
+          setThemeState(savedTheme);
+        }
+      } catch (error) {
+        console.error('Failed to load theme:', error);
+      } finally {
+        setIsLoaded(true);
+      }
+    };
+
+    loadTheme();
+  }, []);
+
+  // Apply theme to document root
+  useEffect(() => {
+    if (!isLoaded) return;
+
+    const root = window.document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.classList.add(theme);
+  }, [theme, isLoaded]);
+
+  const setTheme = async (newTheme: Theme) => {
+    setThemeState(newTheme);
+    try {
+      const accomplish = getAccomplish();
+      await accomplish.setTheme(newTheme);
+    } catch (error) {
+      console.error('Failed to save theme:', error);
+    }
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}

--- a/apps/desktop/src/renderer/lib/accomplish.ts
+++ b/apps/desktop/src/renderer/lib/accomplish.ts
@@ -53,6 +53,8 @@ interface AccomplishAPI {
   removeApiKey(id: string): Promise<void>;
   getDebugMode(): Promise<boolean>;
   setDebugMode(enabled: boolean): Promise<void>;
+  getTheme(): Promise<string>;
+  setTheme(theme: string): Promise<void>;
   getAppSettings(): Promise<{ debugMode: boolean; onboardingComplete: boolean }>;
   getOpenAiBaseUrl(): Promise<string>;
   setOpenAiBaseUrl(baseUrl: string): Promise<void>;

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { HashRouter } from 'react-router-dom';
+import { ThemeProvider } from './contexts/ThemeContext';
 import App from './App';
 import './styles/globals.css';
 
@@ -12,8 +13,10 @@ if (!container) {
 const root = createRoot(container);
 root.render(
   <StrictMode>
-    <HashRouter>
-      <App />
-    </HashRouter>
+    <ThemeProvider>
+      <HashRouter>
+        <App />
+      </HashRouter>
+    </ThemeProvider>
   </StrictMode>
 );

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -67,6 +67,28 @@
   --radius: 0.5rem;
 }
 
+.dark {
+  --background: 0 0% 9%; /* #171717 */
+  --foreground: 0 0% 92%; /* #ebebeb */
+  --card: 0 0% 12%; /* #1f1f1f */
+  --card-foreground: 0 0% 92%; /* #ebebeb */
+  --popover: 0 0% 12%; /* #1f1f1f */
+  --popover-foreground: 0 0% 92%; /* #ebebeb */
+  --primary: 123 22% 70%; /* #9bc499 */
+  --primary-foreground: 0 0% 9%; /* #171717 */
+  --secondary: 120 8% 25%; /* #383d37 */
+  --secondary-foreground: 120 14% 85%; /* #d8dfd7 */
+  --muted: 0 0% 15%; /* #262626 */
+  --muted-foreground: 0 0% 60%; /* #999999 */
+  --accent: 0 0% 20%; /* #333333 */
+  --accent-foreground: 0 0% 92%; /* #ebebeb */
+  --destructive: 8 78% 54%; /* #e54d2e */
+  --destructive-foreground: 0 0% 100%; /* #ffffff */
+  --border: 0 0% 20%; /* #333333 */
+  --input: 0 0% 25%; /* #404040 */
+  --ring: 123 22% 70%; /* #9bc499 */
+}
+
 /* Custom scrollbar */
 ::-webkit-scrollbar {
   width: 6px;

--- a/apps/desktop/tailwind.config.ts
+++ b/apps/desktop/tailwind.config.ts
@@ -3,6 +3,7 @@ import tailwindcssAnimate from 'tailwindcss-animate';
 import tailwindcssTypography from '@tailwindcss/typography';
 
 const config: Config = {
+  darkMode: 'class',
   content: [
     './index.html',
     './src/renderer/**/*.{js,ts,jsx,tsx}',


### PR DESCRIPTION
## Summary

Adds comprehensive light and dark theme support to Openwork, allowing users to switch themes via a toggle in the Settings dialog.

## Changes

### UI/UX
- **Theme Toggle**: Added in Settings dialog (appears when a provider is selected)
- **Visual Indicators**: Sun/moon icons show current theme
- **Smooth Transitions**: Leverages Tailwind's dark mode with instant class switching
- **Professional Colors**: Dark theme uses carefully selected colors matching the app's aesthetic

### Implementation

**Frontend:**
- Created `ThemeContext` and `useTheme` hook for React state management
- Added theme toggle section in SettingsDialog with animation support
- Wrapped App with ThemeProvider in main.tsx
- Added dark theme CSS variables to globals.css
- Enabled Tailwind dark mode with `darkMode: 'class'` strategy

**Backend:**
- Database migration v005 adds `theme` column to app_settings
- Added `getTheme`/`setTheme` methods to appSettings repository
- Added IPC handlers: `settings:theme` and `settings:set-theme`
- Extended preload API and AccomplishAPI types

### Theme Colors

**Dark Theme Palette:**
- Background: `#171717` (neutral dark gray)
- Foreground: `#ebebeb` (soft white)
- Primary: `#9bc499` (muted sage green, maintains brand identity)
- Cards: `#1f1f1f` (slightly lighter than background)
- Borders: `#333333` (subtle contrast)
- Muted: `#262626` (for secondary UI elements)

**Light Theme:** (existing)
- Maintains current light theme colors unchanged

## Technical Notes

- Theme defaults to `'light'` for existing users (backward compatible)
- Migration v005 runs automatically on app startup
- Theme state persists across app restarts via SQLite database
- Follows existing design patterns from debug mode toggle
- No breaking changes

## Testing

- ✅ TypeScript compilation (`pnpm lint`)
- ✅ Full build (`pnpm build`)
- Manual testing:
  - Verified theme toggle works in Settings dialog
  - Confirmed theme persists after app restart
  - Checked theme applies globally across all pages
  - Validated migration runs successfully on clean database

## Related

Closes #91

## Screenshots

_Screenshots will be added shortly showing light and dark theme comparison_