### PR TITLE
fix: add default model field to OpenCode config for oh-my-opencode compatibility #218

### DIFF
--- a/apps/desktop/__tests__/integration/main/opencode/config-generator.integration.test.ts
+++ b/apps/desktop/__tests__/integration/main/opencode/config-generator.integration.test.ts
@@ -380,4 +380,59 @@ describe('OpenCode Config Generator Integration', () => {
       expect(content).toContain('\n');
     });
   });
+
+  describe('Default Model Configuration', () => {
+    it('should include model field when active provider model is set', async () => {
+      // Arrange - mock active provider model
+      const { getActiveProviderModel } = await import('@main/store/providerSettings');
+      vi.mocked(getActiveProviderModel).mockReturnValue({
+        provider: 'ollama',
+        model: 'ollama/qwen3:4b',
+        displayName: 'Qwen 3 4B',
+      });
+
+      // Act
+      vi.resetModules();
+      const { generateOpenCodeConfig } = await import('@main/opencode/config-generator');
+      const configPath = await generateOpenCodeConfig();
+
+      // Assert
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(config.model).toBe('ollama/qwen3:4b');
+    });
+
+    it('should not include model field when no active provider model', async () => {
+      // Arrange - no active model
+      const { getActiveProviderModel } = await import('@main/store/providerSettings');
+      vi.mocked(getActiveProviderModel).mockReturnValue(null);
+
+      // Act
+      vi.resetModules();
+      const { generateOpenCodeConfig } = await import('@main/opencode/config-generator');
+      const configPath = await generateOpenCodeConfig();
+
+      // Assert
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(config.model).toBeUndefined();
+    });
+
+    it('should handle anthropic provider model', async () => {
+      // Arrange
+      const { getActiveProviderModel } = await import('@main/store/providerSettings');
+      vi.mocked(getActiveProviderModel).mockReturnValue({
+        provider: 'anthropic',
+        model: 'anthropic/claude-sonnet-4-5',
+        displayName: 'Claude Sonnet 4.5',
+      });
+
+      // Act
+      vi.resetModules();
+      const { generateOpenCodeConfig } = await import('@main/opencode/config-generator');
+      const configPath = await generateOpenCodeConfig();
+
+      // Assert
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(config.model).toBe('anthropic/claude-sonnet-4-5');
+    });
+  });
 });

--- a/apps/desktop/src/main/opencode/config-generator.ts
+++ b/apps/desktop/src/main/opencode/config-generator.ts
@@ -797,8 +797,18 @@ export async function generateOpenCodeConfig(azureFoundryToken?: string): Promis
     console.log('[OpenCode Config] Z.AI Coding Plan provider configured with models:', Object.keys(zaiModels));
   }
 
+  // Determine default model from active provider settings
+  // This is needed for oh-my-opencode plugin compatibility and other OpenCode plugins
+  let defaultModel: string | undefined;
+  if (activeModel) {
+    // Use the full provider/model format (e.g., "ollama/qwen3:4b")
+    defaultModel = activeModel.model;
+    console.log('[OpenCode Config] Setting default model:', defaultModel);
+  }
+
   const config: OpenCodeConfig = {
     $schema: 'https://opencode.ai/config.json',
+    model: defaultModel,
     default_agent: ACCOMPLISH_AGENT_NAME,
     // Enable all supported providers - providers auto-configure when API keys are set via env vars
     enabled_providers: enabledProviders,


### PR DESCRIPTION
## Summary

Fixes #218 - Ollama integration with oh-my-opencode plugins

When users have oh-my-opencode plugins installed, the plugin expects a `model` field in the OpenCode config file. Openwork was only generating `default_agent` but not the `model` field, causing oh-my-opencode to fail with error: "oh-my-opencode requires a default model".

## Changes

- ✅ Added `model` field to OpenCode config when an active provider model is set
- ✅ The model field uses the full provider/model format (e.g., "ollama/qwen3:4b")
- ✅ Added comprehensive tests to verify model field behavior
- ✅ All quality gates passed (build, lint, test, dev)

## Test Plan

- [x] Unit tests for config generator with model field
- [x] Test that model field is included when active model is set
- [x] Test that model field is omitted when no active model
- [x] Test with various providers (Ollama, Anthropic)
- [x] All existing tests still pass (1076 tests passing)
- [x] Build succeeds
- [x] Lint passes
- [x] Dev server starts without errors

## Files Modified

- `apps/desktop/src/main/opencode/config-generator.ts` - Added model field to config
- `apps/desktop/__tests__/integration/main/opencode/config-generator.integration.test.ts` - Added test coverage

## Related

- Issue #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)