### PR TITLE
fix: make permission modal scrollable when content exceeds viewport

### DIFF
--- a/apps/desktop/src/renderer/pages/Execution.tsx
+++ b/apps/desktop/src/renderer/pages/Execution.tsx
@@ -851,8 +851,8 @@ export default function ExecutionPage() {
               exit={{ opacity: 0, scale: 0.95, y: 10 }}
               transition={springs.bouncy}
             >
-              <Card className="w-full max-w-lg p-6 mx-4">
-                <div className="flex items-start gap-4">
+              <Card className="w-full max-w-lg p-6 mx-4 max-h-[80vh] flex flex-col">
+                <div className="flex items-start gap-4 min-h-0 flex-1 overflow-hidden">
                   <div className={cn(
                     "flex h-10 w-10 items-center justify-center rounded-full shrink-0",
                     isDeleteOperation(permissionRequest) ? "bg-red-500/10" :
@@ -869,7 +869,7 @@ export default function ExecutionPage() {
                       <AlertCircle className="h-5 w-5 text-warning" />
                     )}
                   </div>
-                  <div className="flex-1 min-w-0">
+                  <div className="flex-1 min-w-0 overflow-y-auto">
                     <h3 className={cn(
                       "text-lg font-semibold mb-2",
                       isDeleteOperation(permissionRequest) ? "text-red-600" : "text-foreground"


### PR DESCRIPTION
## Summary

Fixes #256 — the authorization pop-up was not scrollable, so when many items were listed (e.g. 10+ files to delete), the Authorize/Delete button was pushed off-screen and unreachable.

## Reproduction

1. Open Openwork
2. Ask it to delete all files from a folder with 10+ files
3. The permission modal appears listing all file paths
4. The modal grows taller than the viewport — no scrollbar, buttons are off-screen and unclickable

I tested this PR against main and confirmed the CSS fix is correct — max-h-[80vh], flex flex-col, and overflow-y-auto will properly constrain and scroll the modal when content exceeds the viewport.

  However, I was unable to reproduce the original bug from #256. When requesting creation/deletion of 30+ files, the permission system now summarizes the file list (e.g., "... and 28 more daniel-test files") instead of listing each path individually. This keeps the modal short enough that it never overflows.

  This summarization behavior appears to have changed independently of this PR, so the specific reproduction case from the original issue may no longer be triggerable. That said, the fix is still valuable as a safety net for any permission modal content that could exceed the viewport height.

## After
![ezgif-126cbabd5fc7fe31](https://github.com/user-attachments/assets/f00409c5-f8d3-46df-95f3-8ff9a99aa785)

## Root Cause

The permission modal in `Execution.tsx` had no height constraint. The `<Card>` wrapper grew unbounded with its content, and the Card component's base class includes `overflow-hidden` which clips content without enabling scroll. When the file path list was long enough, the action buttons (Deny / Delete All) were pushed below the visible area with no way to reach them.

## Fix

Three targeted CSS class changes in `Execution.tsx` (3 lines changed):

| Element | Change | Purpose |
|---------|--------|---------|
| `<Card>` | Added `max-h-[80vh] flex flex-col` | Caps modal height at 80% of viewport, enables flex column layout |
| Outer content `<div>` | Added `min-h-0 flex-1 overflow-hidden` | Allows flex child to shrink below intrinsic content size (required for nested scroll to work) |
| Inner content `<div>` | Added `overflow-y-auto` | Enables vertical scrolling when content exceeds available space |

The icon stays pinned at the top-left. All content (title, file list, buttons) is inside the scrollable area, so the user can always scroll down to reach the action buttons.

## Test plan

- [ ] Open Openwork, trigger a file deletion with 10+ files — verify the modal is scrollable and the Delete All button is reachable
- [ ] Trigger a single-file permission request — verify the modal still looks correct (no unnecessary scrollbar)
- [ ] Trigger a question-type permission with many options — verify scrolling works there too
- [ ] Verify no layout regressions on the standard tool permission modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)