### PR TITLE
perf(browser-mcp): reduce context token consumption ~60%

### DIFF
--- a/apps/desktop/skills/dev-browser-mcp/src/snapshot/types.ts
+++ b/apps/desktop/skills/dev-browser-mcp/src/snapshot/types.ts
@@ -58,11 +58,11 @@ export interface SnapshotOptions {
   fullSnapshot?: boolean;
   /** Only include interactive elements. Default: true */
   interactiveOnly?: boolean;
-  /** Maximum number of elements to include. Default: 300, max: 1000 */
+  /** Maximum number of elements to include. Default: 200, max: 1000 */
   maxElements?: number;
   /** Only include elements visible in viewport. Default: false */
   viewportOnly?: boolean;
-  /** Maximum estimated tokens for output. Default: 8000, max: 50000 */
+  /** Maximum estimated tokens for output. Default: 6000, max: 50000 */
   maxTokens?: number;
   /** Include session navigation history in output. Default: true */
   includeHistory?: boolean;
@@ -72,9 +72,9 @@ export interface SnapshotOptions {
 export const DEFAULT_SNAPSHOT_OPTIONS: Required<SnapshotOptions> = {
   fullSnapshot: false,
   interactiveOnly: true,
-  maxElements: 300,
+  maxElements: 200,
   viewportOnly: false,
-  maxTokens: 8000,
+  maxTokens: 6000,
   includeHistory: true,
 };
 


### PR DESCRIPTION
## Summary

- **Fix in-browser token estimation**: Replace flat 15 tokens/element with name-length-aware formula (`15 + Math.min(ceil(nameLen/2), 50)`), making the token budget actually trigger on content-rich pages
- **Lower default budgets**: `maxElements: 300 → 200`, `maxTokens: 8000 → 6000` across all 6 default locations (inline fallbacks, constants, tool schema descriptions, exported types)
- **Reduce screenshot size**: JPEG quality 80 → 50, cap full-page screenshots at 1800px height to stay under Anthropic's 2000px multi-image dimension limit

## Motivation

Browser-heavy tasks overflow the 200K token context window. A Zillow session accumulated 150K tokens over 24 steps, then a single step pushed to 203K. OpenCode's built-in compaction never fired because context jumped from under threshold to over hard limit in one step.

Root causes:
1. In-browser token estimate (flat 15/element) underestimates by 2-4x — token budget never triggers, only element limit applies
2. Default 300 elements / 8000 tokens produces ~15K actual tokens per snapshot — 9 snapshots = ~135K tokens just from DOM trees
3. Full-page screenshots can exceed Anthropic's 2000px dimension limit

## Token savings estimate

| Source | Before | After | Savings |
|--------|--------|-------|---------|
| DOM snapshot (per call) | ~15K tokens | ~6K tokens | ~60% |
| Full-page screenshot | uncapped (~8K+ tokens) | capped 1800px (~3K tokens) | ~64% |
| **24-step Zillow session** | **~160K tokens** | **~63K tokens** | **~60%** |

## Test plan

- [x] All 59 existing snapshot tests pass (`npx vitest run`)
- [x] Full monorepo build succeeds (`pnpm build`)
- [ ] Manual test: navigate to complex page (Zillow listing), run `browser_snapshot` — verify ≤200 elements and `token budget` truncation reason
- [ ] Manual test: `browser_screenshot(full_page=true)` on a long page — verify image height ≤1800px

🤖 Generated with [Claude Code](https://claude.com/claude-code)