### PR TITLE
chore: add docs/plans to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ coverage/
 prisma/*.db
 prisma/*.db-journal
 
+# Docs
+docs/plans/
+
 # Misc
 *.pem
 .turbo/


### PR DESCRIPTION
## Summary
- Adds `docs/plans/` to `.gitignore` to exclude planning documents from version control

## Test plan
- [x] Verify `docs/plans/` directory contents are ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)