### PR TITLE
feat: integrate opencode-dcp plugin for dynamic context pruning

### DIFF
--- a/apps/desktop/src/main/opencode/config-generator.ts
+++ b/apps/desktop/src/main/opencode/config-generator.ts
@@ -375,6 +375,7 @@ interface OpenCodeConfig {
   agent?: Record<string, AgentConfig>;
   mcp?: Record<string, McpServerConfig>;
   provider?: Record<string, ProviderConfig>;
+  plugin?: string[];
 }
 
 /**
@@ -811,6 +812,9 @@ export async function generateOpenCodeConfig(azureFoundryToken?: string): Promis
       todowrite: 'allow',
     },
     provider: Object.keys(providerConfig).length > 0 ? providerConfig : undefined,
+    // Dynamic Context Pruning plugin - prunes obsolete tool outputs from conversation
+    // history to reduce token usage (deduplication, supersede writes, purge errors)
+    plugin: ['@tarquinen/opencode-dcp@latest'],
     agent: {
       [ACCOMPLISH_AGENT_NAME]: {
         description: 'Browser automation assistant using dev-browser',


### PR DESCRIPTION
## Summary
- Adds the [`@tarquinen/opencode-dcp`](https://github.com/Opencode-DCP/opencode-dynamic-context-pruning) plugin to the generated OpenCode config
- DCP automatically prunes obsolete tool outputs from conversation history (deduplication, supersede writes, purge errors), reducing token usage for long sessions
- Particularly beneficial for browser-heavy tasks where repeated snapshots/screenshots accumulate

## Changes
- Added `plugin?: string[]` to the `OpenCodeConfig` interface
- Added `plugin: ['@tarquinen/opencode-dcp@latest']` to the generated config object

## Observed Impact (Live Zillow Task)

The agent proactively called the `discard` tool **7 times** during a single Zillow browsing session, removing **61 tool outputs** total:

| # | Outputs Pruned | IDs Removed | What Was Pruned |
|---|---------------|-------------|-----------------|
| 1 | 6 | noise, 1-5, 7 | Failed browser_script outputs + redundant search steps |
| 2 | 23 | noise, 9-49 (24 IDs) | Bulk browser snapshots, evaluates, clicks from listing browsing |
| 3 | 13 | completion, 62-79 (14 IDs) | Completed browser tool outputs after data extraction |
| 4 | 1 | completion, 83 | complete_task tool output |
| 5 | 7 | noise, 85-95 (8 IDs) | browser_script outputs from follow-up browsing |
| 6 | 1 | noise, 97 | File read output |
| 7 | 10 | noise, 1-14 (11 IDs) | browser_script/evaluate outputs from new session phase |

**Tool types pruned across session:**
- `browser_script`: 15 outputs pruned
- `browser_evaluate`: 10 outputs pruned
- `browser_snapshot`: 3 outputs pruned
- `complete_task`: 1 output pruned
- `read`: 1 output pruned

**Agent behavior** — the agent proactively manages its own context:
- *"I'm going to prune the failed script and those redundant search steps to keep my workspace organized."*
- *"I'll check the details for 843 Bellaire Dr, but first, I'm going to prune the context to keep things efficient."*
- *"I've already pruned the context and captured all the key findings in the final report."*
- *"I need to read the file before I can overwrite it. While I'm at it, I'll also prune the context to keep things tidy."*

## Test plan
- [x] Start the app and run a task — confirmed `"plugin": ["@tarquinen/opencode-dcp@latest"]` in generated config
- [x] Run a browser-heavy task — confirmed 7 prune operations removing 61 tool outputs
- [ ] Verify no regressions in normal (non-browser) task execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)