### PR TITLE
fix(dev-browser-mcp): remove duplicate browser_keyboard case

### DIFF
--- a/apps/desktop/skills/dev-browser-mcp/src/index.ts
+++ b/apps/desktop/skills/dev-browser-mcp/src/index.ts
@@ -3139,67 +3139,6 @@ The page has loaded. Use browser_snapshot() to see the page elements and find in
         return { content };
       }
 
-      case 'browser_keyboard': {
-        const { action, key, text, typing_delay, page_name } = args as BrowserKeyboardInput;
-        const page = await getPage(page_name);
-
-        switch (action) {
-          case 'press': {
-            if (!key) {
-              return {
-                content: [{ type: 'text', text: 'Error: "key" is required for press action' }],
-                isError: true,
-              };
-            }
-            await page.keyboard.press(key);
-            return {
-              content: [{ type: 'text', text: `Pressed key: ${key}` }],
-            };
-          }
-          case 'type': {
-            if (!text) {
-              return {
-                content: [{ type: 'text', text: 'Error: "text" is required for type action' }],
-                isError: true,
-              };
-            }
-            await page.keyboard.type(text, { delay: typing_delay ?? 20 });
-            return {
-              content: [{ type: 'text', text: `Typed text: "${text}"` }],
-            };
-          }
-          case 'down': {
-            if (!key) {
-              return {
-                content: [{ type: 'text', text: 'Error: "key" is required for down action' }],
-                isError: true,
-              };
-            }
-            await page.keyboard.down(key);
-            return {
-              content: [{ type: 'text', text: `Key down: ${key}` }],
-            };
-          }
-          case 'up': {
-            if (!key) {
-              return {
-                content: [{ type: 'text', text: 'Error: "key" is required for up action' }],
-                isError: true,
-              };
-            }
-            await page.keyboard.up(key);
-            return {
-              content: [{ type: 'text', text: `Key up: ${key}` }],
-            };
-          }
-          default:
-            return {
-              content: [{ type: 'text', text: `Error: Unknown keyboard action "${action}"` }],
-              isError: true,
-            };
-        }
-      }
-
       case 'browser_scroll': {
         const { direction, amount, ref, selector, position, page_name } = args as BrowserScrollInput;
         const page = await getPage(page_name);


### PR DESCRIPTION
## Summary
- Removes unreachable duplicate `case 'browser_keyboard':` block from the switch statement
- The second case (lines 3142-3201) was dead code since JavaScript matches the first case
- Fixes esbuild warning: "This case clause will never be evaluated because it duplicates an earlier case clause"

## Test plan
- [x] Build passes without duplicate-case warning
- [ ] Verify `browser_keyboard` tool still works (existing functionality unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)