### PR TITLE
fix(build): exclude .ignored_* dirs from skills bundle

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -152,6 +152,7 @@
           "!**/tmp/**",
           "!**/.git/**",
           "!**/.browser-data/**",
+          "!**/.ignored_*/**",
           "!**/bun.lock",
           "!**/*.test.ts",
           "!**/vitest.config.ts"


### PR DESCRIPTION
## Summary
- Adds `!**/.ignored_*/**` filter to exclude `.ignored_*` directories from the skills bundle
- Fixes macOS codesign failure caused by symlinks pointing outside the app bundle

## Context
The `skills/dev-browser/node_modules/@accomplish/.ignored_browser-manager/` directory contained pnpm workspace symlinks pointing to absolute paths like `/Users/.../node_modules/.pnpm/...`. macOS codesign rejects bundles with symlinks pointing to invalid destinations.

## Test plan
- [x] `pnpm --filter @accomplish/desktop package:mac` completes without codesign errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)