### PR TITLE
fix(build): inject createRequire banner for dev-browser ESM bundles

### DIFF
--- a/apps/desktop/scripts/bundle-skills.cjs
+++ b/apps/desktop/scripts/bundle-skills.cjs
@@ -33,12 +33,14 @@ const bundles = [
     entry: 'scripts/start-server.ts',
     outfile: 'dist/start-server.mjs',
     external: ['playwright'],
+    banner: true,
   },
   {
     name: 'dev-browser',
     entry: 'scripts/start-relay.ts',
     outfile: 'dist/start-relay.mjs',
     external: ['playwright'],
+    banner: true,
   },
 ];
 
@@ -48,7 +50,7 @@ function ensureDir(dirPath) {
   }
 }
 
-async function bundleSkill({ name, entry, outfile, external = [] }) {
+async function bundleSkill({ name, entry, outfile, external = [], banner: needsBanner }) {
   const skillDir = path.join(skillsDir, name);
   const absEntry = path.join(skillDir, entry);
   const absOutfile = path.join(skillDir, outfile);
@@ -68,6 +70,11 @@ async function bundleSkill({ name, entry, outfile, external = [] }) {
     bundle: true,
     platform: 'node',
     format: 'esm',
+    ...(needsBanner && {
+      banner: {
+        js: "import { createRequire } from 'module'; const require = createRequire(import.meta.url);",
+      },
+    }),
     target: 'node20',
     sourcemap: false,
     logLevel: 'info',


### PR DESCRIPTION
## Summary
- The packaged app's dev-browser server crashed on startup with `Dynamic require of "path" is not supported` because Express's CJS dependency chain (`body-parser` -> `depd`) calls `require()` for Node built-ins, which is not allowed inside ESM modules
- Injects a `createRequire` polyfill banner into the `start-server.mjs` and `start-relay.mjs` bundles so `require()` resolves correctly in ESM output
- Keeps ESM format (preserving top-level `await` and `import.meta.url` support) rather than switching to CJS

## Test plan
- [ ] Build packaged app with `pnpm -F @accomplish/desktop package:mac`
- [ ] Install and launch the packaged `.app`
- [ ] Start a task that uses the dev-browser — verify Chrome opens and browser automation works
- [ ] Verify dev mode (`pnpm dev`) still works (no regression since dev mode uses `tsx` directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)