### PR TITLE
fix(ci): prevent Windows CI hangs with timeouts and optimizations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,10 +144,17 @@ jobs:
   windows-ci:
     name: Windows CI
     runs-on: windows-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Disable Windows Defender scanning
+        run: |
+          Set-MpPreference -DisableRealtimeMonitoring $true
+          Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+        shell: powershell
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -158,8 +165,14 @@ jobs:
           node-version: '20'
           cache: 'pnpm'
 
+      - name: Setup Python (for node-gyp)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        timeout-minutes: 15
 
       - name: Run unit tests
         run: pnpm -F @accomplish/desktop test:unit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -283,11 +283,18 @@ jobs:
     needs: version-bump
     if: needs.version-bump.outputs.platforms == 'all' || needs.version-bump.outputs.platforms == 'windows-only'
     runs-on: windows-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           ref: v${{ needs.version-bump.outputs.new_version }}
+
+      - name: Disable Windows Defender scanning
+        run: |
+          Set-MpPreference -DisableRealtimeMonitoring $true
+          Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+        shell: powershell
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -298,21 +305,30 @@ jobs:
           node-version: '20'
           cache: 'pnpm'
 
+      - name: Setup Python (for node-gyp)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        timeout-minutes: 15
 
       - name: Download Node.js binaries
         run: pnpm -F @accomplish/desktop download:nodejs
 
       - name: Build desktop app
         run: pnpm -F @accomplish/desktop build
+        timeout-minutes: 10
 
       - name: Package (unsigned)
         run: node scripts/package.cjs --win --x64 --publish never
         working-directory: apps/desktop
+        timeout-minutes: 20
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_IDENTITY_AUTO_DISCOVERY: false
+          DEBUG: electron-builder
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Add job-level timeouts (30min CI, 45min release) to fail fast instead of hanging
- Disable Windows Defender real-time scanning on workspace directory
- Add Python 3.11 setup for node-gyp native module compilation (node-pty, better-sqlite3)
- Add step-level timeouts for install (15min), build (10min), package (20min)
- Enable `DEBUG=electron-builder` for better diagnostics on release builds

## Context
Windows CI builds were hanging indefinitely. Common causes include:
- Windows Defender scanning during builds
- node-gyp native module compilation without Python
- electron-builder 25.x ASAR integrity hang ([electron-builder#8709](https://github.com/electron-userland/electron-builder/issues/8709))

## Test plan
- [ ] Trigger Windows CI and verify it completes (or times out with useful error)
- [ ] Run a dry-run release with `windows-only` platform to test packaging

🤖 Generated with [Claude Code](https://claude.ai/code)