### PR TITLE
chore: comment out Windows build from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ on:
         type: choice
         options:
           - all
-          - windows-only
           - macos-only
         default: all
       dry_run:
@@ -278,52 +277,52 @@ jobs:
             apps/desktop/release/*-x64.zip
           retention-days: 30
 
-  build-windows-x64:
-    name: Build Windows (x64)
-    needs: version-bump
-    if: needs.version-bump.outputs.platforms == 'all' || needs.version-bump.outputs.platforms == 'windows-only'
-    runs-on: windows-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: v${{ needs.version-bump.outputs.new_version }}
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Download Node.js binaries
-        run: pnpm -F @accomplish/desktop download:nodejs
-
-      - name: Build desktop app
-        run: pnpm -F @accomplish/desktop build
-
-      - name: Package (unsigned)
-        run: node scripts/package.cjs --win --x64 --publish never
-        working-directory: apps/desktop
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CSC_IDENTITY_AUTO_DISCOVERY: false
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: Openwork-Windows-x64
-          path: apps/desktop/release/*.exe
-          retention-days: 30
+  # build-windows-x64:
+  #   name: Build Windows (x64)
+  #   needs: version-bump
+  #   if: needs.version-bump.outputs.platforms == 'all' || needs.version-bump.outputs.platforms == 'windows-only'
+  #   runs-on: windows-latest
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: v${{ needs.version-bump.outputs.new_version }}
+  #
+  #     - name: Setup pnpm
+  #       uses: pnpm/action-setup@v4
+  #
+  #     - name: Setup Node.js
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: '20'
+  #         cache: 'pnpm'
+  #
+  #     - name: Install dependencies
+  #       run: pnpm install --frozen-lockfile
+  #
+  #     - name: Download Node.js binaries
+  #       run: pnpm -F @accomplish/desktop download:nodejs
+  #
+  #     - name: Build desktop app
+  #       run: pnpm -F @accomplish/desktop build
+  #
+  #     - name: Package (unsigned)
+  #       run: node scripts/package.cjs --win --x64 --publish never
+  #       working-directory: apps/desktop
+  #       env:
+  #         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         CSC_IDENTITY_AUTO_DISCOVERY: false
+  #
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: Openwork-Windows-x64
+  #         path: apps/desktop/release/*.exe
+  #         retention-days: 30
 
   create-release:
     name: Create GitHub Release
-    needs: [version-bump, build-mac-arm64, build-mac-x64, build-windows-x64]
+    needs: [version-bump, build-mac-arm64, build-mac-x64]
     if: always() && needs.version-bump.result == 'success'
     runs-on: ubuntu-latest
     steps:
@@ -332,10 +331,9 @@ jobs:
           PLATFORMS="${{ needs.version-bump.outputs.platforms }}"
           MAC_ARM64="${{ needs.build-mac-arm64.result }}"
           MAC_X64="${{ needs.build-mac-x64.result }}"
-          WIN_X64="${{ needs.build-windows-x64.result }}"
 
           echo "Requested platforms: $PLATFORMS"
-          echo "Build results: macOS-arm64=$MAC_ARM64, macOS-x64=$MAC_X64, Windows-x64=$WIN_X64"
+          echo "Build results: macOS-arm64=$MAC_ARM64, macOS-x64=$MAC_X64"
 
           # Validate all requested platform builds succeeded
           FAILED=0
@@ -347,13 +345,6 @@ jobs:
             fi
             if [ "$MAC_X64" != "success" ]; then
               echo "Error: macOS x64 build failed (result: $MAC_X64)"
-              FAILED=1
-            fi
-          fi
-
-          if [ "$PLATFORMS" == "all" ] || [ "$PLATFORMS" == "windows-only" ]; then
-            if [ "$WIN_X64" != "success" ]; then
-              echo "Error: Windows x64 build failed (result: $WIN_X64)"
               FAILED=1
             fi
           fi
@@ -393,12 +384,12 @@ jobs:
           name: Openwork-macOS-x64
           path: ./release/x64
 
-      - name: Download Windows x64 artifacts
-        if: needs.build-windows-x64.result == 'success'
-        uses: actions/download-artifact@v4
-        with:
-          name: Openwork-Windows-x64
-          path: ./release/win-x64
+      # - name: Download Windows x64 artifacts
+      #   if: needs.build-windows-x64.result == 'success'
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: Openwork-Windows-x64
+      #     path: ./release/win-x64
 
       - name: List release artifacts
         run: |
@@ -416,7 +407,6 @@ jobs:
           files: |
             ./release/arm64/*
             ./release/x64/*
-            ./release/win-x64/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Comments out the `build-windows-x64` job from the release workflow
- Removes `windows-only` from the platforms input options
- Updates `create-release` job to remove Windows build dependency, artifact download, and release file references

## Test plan
- [ ] Trigger a dry-run release and verify it completes with only macOS builds
- [ ] Confirm the workflow dispatch UI no longer shows the `windows-only` platform option

🤖 Generated with [Claude Code](https://claude.com/claude-code)