### PR TITLE
feat(release): auto-approve release PRs on creation

### DIFF
--- a/.github/workflows/auto-approve-release.yml
+++ b/.github/workflows/auto-approve-release.yml
@@ -1,0 +1,23 @@
+name: Auto-approve Release PRs
+
+on:
+  pull_request:
+    types: [opened, reopened]
+    branches: [main]
+
+jobs:
+  approve:
+    name: Approve Release PR
+    if: |
+      startsWith(github.head_ref, 'release/v') &&
+      github.actor == 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approve release PR
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_APPROVER_TOKEN }}
+        run: |
+          gh pr review ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --approve \
+            --body "Automated approval for release PR"


### PR DESCRIPTION
## Summary
- Adds a `pull_request`-triggered workflow that auto-approves release PRs
- Decouples PR approval from the Slack → Cloudflare Worker path so retrying failed releases from the GitHub Actions UI works
- Triggers on `opened` and `reopened` events for PRs targeting `main` with branch `release/v*` from `github-actions[bot]`

## Problem
The Cloudflare worker's `findAndApprovePR` only runs when triggered via Slack. Retrying a failed release from the GitHub Actions UI creates a new PR that never gets approved, causing the workflow to time out.

## Requires
- Add `RELEASE_APPROVER_TOKEN` secret to the openwork repo (same PAT the Cloudflare worker uses as `APPROVER_TOKEN`)

## Follow-up
- Optionally remove `findAndApprovePR` from the Cloudflare worker in `openwork-release-ops` since this workflow makes it redundant

## Test plan
- [ ] Add `RELEASE_APPROVER_TOKEN` secret to openwork repo settings
- [ ] Trigger a release from Slack — verify PR gets approved and merges
- [ ] Retry a failed release from GitHub Actions UI — verify PR gets approved (the previously broken scenario)
- [ ] Open a regular PR — verify the workflow skips it (guard rails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)