### PR TITLE
fix: open settings when Alt pressed without ElevenLabs API key

### DIFF
--- a/apps/desktop/src/renderer/components/landing/TaskInputBar.tsx
+++ b/apps/desktop/src/renderer/components/landing/TaskInputBar.tsx
@@ -64,6 +64,8 @@ export default function TaskInputBar({
       console.error('[Speech] Error:', error.message);
       // Error is stored in speechInput.error state
     },
+    // Open settings when Alt key is pressed but API key is not configured
+    onNotConfigured: onOpenSpeechSettings,
   });
 
   // Auto-focus on mount

--- a/apps/desktop/src/renderer/hooks/useSpeechInput.ts
+++ b/apps/desktop/src/renderer/hooks/useSpeechInput.ts
@@ -44,6 +44,12 @@ export interface UseSpeechInputOptions {
   onError?: (error: SpeechRecognitionError) => void;
 
   /**
+   * Callback when recording is attempted but speech input is not configured.
+   * Use this to open settings dialog so user can add their API key.
+   */
+  onNotConfigured?: () => void;
+
+  /**
    * Maximum recording duration in milliseconds (default 120000 = 2 minutes)
    */
   maxDuration?: number;
@@ -97,6 +103,7 @@ export function useSpeechInput(options: UseSpeechInputOptions = {}): UseSpeechIn
     onTranscriptionComplete,
     onRecordingStateChange,
     onError,
+    onNotConfigured,
     maxDuration = 120000,
     pushToTalkKey = 'Alt',
   } = options;
@@ -178,6 +185,12 @@ export function useSpeechInput(options: UseSpeechInputOptions = {}): UseSpeechIn
     }
 
     if (!state.isConfigured) {
+      // Call the onNotConfigured callback so parent can open settings
+      if (onNotConfigured) {
+        onNotConfigured();
+        return;
+      }
+      // Fallback to error state if no callback provided
       const error = new SpeechRecognitionError(
         'NOT_CONFIGURED',
         'ElevenLabs API is not configured. Please add your API key in settings.'
@@ -262,7 +275,7 @@ export function useSpeechInput(options: UseSpeechInputOptions = {}): UseSpeechIn
       setState((prev) => ({ ...prev, error: speechError, isRecording: false }));
       onError?.(speechError);
     }
-  }, [state.isRecording, state.isTranscribing, state.isConfigured, maxDuration, onRecordingStateChange, onError, cleanup]);
+  }, [state.isRecording, state.isTranscribing, state.isConfigured, maxDuration, onRecordingStateChange, onError, onNotConfigured, cleanup]);
 
   /**
    * Stop recording and transcribe via IPC

--- a/apps/desktop/src/renderer/pages/Execution.tsx
+++ b/apps/desktop/src/renderer/pages/Execution.tsx
@@ -215,6 +215,11 @@ export default function ExecutionPage() {
     todosTaskId,
   } = useTaskStore();
 
+  const handleOpenSpeechSettings = useCallback(() => {
+    setSettingsInitialTab('voice');
+    setShowSettingsDialog(true);
+  }, []);
+
   const speechInput = useSpeechInput({
     onTranscriptionComplete: (text) => {
       setFollowUp((prev) => {
@@ -231,6 +236,8 @@ export default function ExecutionPage() {
     onError: (error) => {
       console.error('[Speech] Error:', error.message);
     },
+    // Open settings when Alt key is pressed but API key is not configured
+    onNotConfigured: handleOpenSpeechSettings,
   });
 
   // Debounced scroll function
@@ -447,11 +454,6 @@ export default function ExecutionPage() {
     // Send a simple "continue" message to resume the task
     await sendFollowUp('continue');
   };
-
-  const handleOpenSpeechSettings = useCallback(() => {
-    setSettingsInitialTab('voice');
-    setShowSettingsDialog(true);
-  }, []);
 
   useEffect(() => {
     if (!pendingSpeechFollowUpRef.current) {


### PR DESCRIPTION
## Summary
- Added `onNotConfigured` callback to `useSpeechInput` hook that is called when recording is attempted without a configured API key
- When pressing Alt to start voice recording without ElevenLabs API key, the settings dialog now opens with the voice tab instead of showing an error
- Applied fix to both `TaskInputBar` (Home page) and `Execution` page

## Test plan
- [ ] Remove ElevenLabs API key from settings
- [ ] Press Alt on the Home page - settings dialog should open to voice tab
- [ ] Press Alt on the Execution page - settings dialog should open to voice tab
- [ ] With API key configured, Alt should start recording as before

Fixes [ENG-71](https://accomplish-ai.atlassian.net/browse/ENG-71)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)