### PR TITLE
fix: add timeout and cancel for OpenAI OAuth flow (ENG-67)

### DIFF
--- a/apps/desktop/__tests__/unit/main/ipc/handlers.unit.test.ts
+++ b/apps/desktop/__tests__/unit/main/ipc/handlers.unit.test.ts
@@ -91,6 +91,7 @@ vi.mock('@main/opencode/adapter', () => ({
 vi.mock('@main/opencode/auth', () => ({
   getOpenAiOauthStatus: vi.fn(() => ({ connected: false })),
   loginOpenAiWithChatGpt: vi.fn(() => Promise.resolve({ openedUrl: undefined })),
+  cancelOpenAiLogin: vi.fn(() => false),
 }));
 
 // Mock task manager

--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -63,7 +63,7 @@ import {
   getProviderDebugMode,
   hasReadyProvider,
 } from '../store/providerSettings';
-import { getOpenAiOauthStatus, loginOpenAiWithChatGpt } from '../opencode/auth';
+import { getOpenAiOauthStatus, loginOpenAiWithChatGpt, cancelOpenAiLogin } from '../opencode/auth';
 import type { ProviderId, ConnectedProvider, BedrockCredentials } from '@accomplish/shared';
 import { getDesktopConfig } from '../config';
 import {
@@ -2311,6 +2311,11 @@ export function registerIPCHandlers(): void {
   handle('opencode:auth:openai:login', async (_event: IpcMainInvokeEvent) => {
     const result = await loginOpenAiWithChatGpt();
     return { ok: true, ...result };
+  });
+
+  // OpenAI OAuth (ChatGPT) cancel login
+  handle('opencode:auth:openai:cancel', async (_event: IpcMainInvokeEvent) => {
+    return cancelOpenAiLogin();
   });
 
   // Onboarding: Get onboarding complete status

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -63,6 +63,8 @@ const accomplishAPI = {
     ipcRenderer.invoke('opencode:auth:openai:status'),
   loginOpenAiWithChatGpt: (): Promise<{ ok: boolean; openedUrl?: string }> =>
     ipcRenderer.invoke('opencode:auth:openai:login'),
+  cancelOpenAiLogin: (): Promise<boolean> =>
+    ipcRenderer.invoke('opencode:auth:openai:cancel'),
 
   // API Key management (new simplified handlers)
   hasApiKey: (): Promise<boolean> =>

--- a/apps/desktop/src/renderer/components/settings/providers/ClassicProviderForm.tsx
+++ b/apps/desktop/src/renderer/components/settings/providers/ClassicProviderForm.tsx
@@ -160,6 +160,15 @@ export function ClassicProviderForm({
     }
   };
 
+  const handleCancelSignIn = async () => {
+    try {
+      const accomplish = getAccomplish();
+      await accomplish.cancelOpenAiLogin();
+    } catch {
+      // Ignore errors - the main flow will handle the cancellation
+    }
+  };
+
   return (
     <div className="rounded-xl border border-border bg-card p-5" data-testid="provider-settings-panel">
       <ProviderFormHeader logoSrc={logoSrc} providerName={meta.name} />
@@ -168,16 +177,35 @@ export function ClassicProviderForm({
       {isOpenAI && !isConnected && (
         <div className="space-y-4">
           {/* OAuth login button */}
-          <button
-            type="button"
-            onClick={handleChatGptSignIn}
-            disabled={signingIn}
-            data-testid="openai-oauth-signin"
-            className="w-full flex items-center justify-center gap-2 rounded-lg border border-border bg-background px-4 py-3 text-sm font-medium text-foreground hover:bg-muted disabled:opacity-50 transition-colors"
-          >
-            <img src={openaiLogo} alt="" className="h-5 w-5" />
-            {signingIn ? 'Signing in...' : 'Login with OpenAI'}
-          </button>
+          {signingIn ? (
+            <div className="space-y-2">
+              <div className="w-full flex items-center justify-center gap-2 rounded-lg border border-border bg-muted px-4 py-3 text-sm font-medium text-muted-foreground">
+                <img src={openaiLogo} alt="" className="h-5 w-5 opacity-50" />
+                <span>Waiting for sign-in...</span>
+              </div>
+              <button
+                type="button"
+                onClick={handleCancelSignIn}
+                data-testid="openai-oauth-cancel"
+                className="w-full flex items-center justify-center gap-2 rounded-lg border border-border bg-background px-4 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+              >
+                Cancel sign-in
+              </button>
+              <p className="text-xs text-center text-muted-foreground">
+                Complete sign-in in your browser, or cancel to try again.
+              </p>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={handleChatGptSignIn}
+              data-testid="openai-oauth-signin"
+              className="w-full flex items-center justify-center gap-2 rounded-lg border border-border bg-background px-4 py-3 text-sm font-medium text-foreground hover:bg-muted transition-colors"
+            >
+              <img src={openaiLogo} alt="" className="h-5 w-5" />
+              Login with OpenAI
+            </button>
+          )}
 
           {/* Divider with "or" */}
           <div className="flex items-center gap-3">

--- a/apps/desktop/src/renderer/lib/accomplish.ts
+++ b/apps/desktop/src/renderer/lib/accomplish.ts
@@ -58,6 +58,7 @@ interface AccomplishAPI {
   setOpenAiBaseUrl(baseUrl: string): Promise<void>;
   getOpenAiOauthStatus(): Promise<{ connected: boolean; expires?: number }>;
   loginOpenAiWithChatGpt(): Promise<{ ok: boolean; openedUrl?: string }>;
+  cancelOpenAiLogin(): Promise<boolean>;
 
   // API Key management
   hasApiKey(): Promise<boolean>;


### PR DESCRIPTION
## Summary
- Fixes [ENG-67](https://accomplish-ai.atlassian.net/browse/ENG-67): OpenAI OAuth gets stuck if user closes browser
- Adds 2-minute timeout to the OAuth flow
- Adds cancel button allowing users to abort and retry

## Problem
When users initiate OpenAI OAuth and then close the browser before completing sign-in:
1. The OpenCode CLI PTY process keeps running, waiting for a callback that will never arrive
2. The Promise in `loginOpenAiWithChatGpt()` never resolves or rejects
3. UI stays stuck with "Signing in..." and disabled button
4. User cannot retry without restarting the app

## Solution
1. **Timeout**: OAuth flow now times out after 2 minutes with a helpful error message
2. **Cancel mechanism**: Track PTY process reference and expose `cancelOpenAiLogin()` function
3. **UI improvements**: Show cancel button with guidance text during sign-in

## Test plan
- [ ] Start OpenAI OAuth login
- [ ] Close browser without completing sign-in
- [ ] Verify timeout error appears after 2 minutes
- [ ] Verify cancel button works immediately
- [ ] Verify retry works after timeout/cancel
- [ ] Verify successful OAuth flow still works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)