### PR TITLE
style: center language selector links in all README files

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -1,4 +1,4 @@
-<p align="right">
+<p align="center">
   <a href="README.md">English</a> | <a href="README.zh-CN.md">中文</a> | <a href="README.ja.md">日本語</a> | <a href="README.ko.md">한국어</a> | <a href="README.es.md">Español</a> | <a href="README.tr.md">Türkçe</a> | <strong>العربية</strong> | <a href="README.id.md">Bahasa Indonesia</a>
 </p>
 

--- a/README.es.md
+++ b/README.es.md
@@ -1,4 +1,4 @@
-<p align="right">
+<p align="center">
   <a href="README.md">English</a> | <a href="README.zh-CN.md">中文</a> | <a href="README.ja.md">日本語</a> | <a href="README.ko.md">한국어</a> | <strong>Español</strong> | <a href="README.tr.md">Türkçe</a> | <a href="README.ar.md">العربية</a> | <a href="README.id.md">Bahasa Indonesia</a>
 </p>
 

--- a/README.id.md
+++ b/README.id.md
@@ -1,4 +1,4 @@
-<p align="right">
+<p align="center">
   <a href="README.md">English</a> | <a href="README.zh-CN.md">中文</a> | <a href="README.ja.md">日本語</a> | <a href="README.ko.md">한국어</a> | <a href="README.es.md">Español</a> | <a href="README.tr.md">Türkçe</a> | <a href="README.ar.md">العربية</a> | <strong>Bahasa Indonesia</strong>
 </p>
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-<p align="right">
+<p align="center">
   <a href="README.md">English</a> | <a href="README.zh-CN.md">中文</a> | <strong>日本語</strong> | <a href="README.ko.md">한국어</a> | <a href="README.es.md">Español</a> | <a href="README.tr.md">Türkçe</a> | <a href="README.ar.md">العربية</a> | <a href="README.id.md">Bahasa Indonesia</a>
 </p>
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,4 +1,4 @@
-<p align="right">
+<p align="center">
   <a href="README.md">English</a> | <a href="README.zh-CN.md">中文</a> | <a href="README.ja.md">日本語</a> | <strong>한국어</strong> | <a href="README.es.md">Español</a> | <a href="README.tr.md">Türkçe</a> | <a href="README.ar.md">العربية</a> | <a href="README.id.md">Bahasa Indonesia</a>
 </p>
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -1,4 +1,4 @@
-<p align="right">
+<p align="center">
   <a href="README.md">English</a> | <a href="README.zh-CN.md">中文</a> | <a href="README.ja.md">日本語</a> | <a href="README.ko.md">한국어</a> | <a href="README.es.md">Español</a> | <strong>Türkçe</strong> | <a href="README.ar.md">العربية</a> | <a href="README.id.md">Bahasa Indonesia</a>
 </p>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,4 +1,4 @@
-<p align="right">
+<p align="center">
   <a href="README.md">English</a> | <strong>中文</strong> | <a href="README.ja.md">日本語</a> | <a href="README.ko.md">한국어</a> | <a href="README.es.md">Español</a> | <a href="README.tr.md">Türkçe</a> | <a href="README.ar.md">العربية</a> | <a href="README.id.md">Bahasa Indonesia</a>
 </p>
 


### PR DESCRIPTION
## Summary
- Update language selector alignment from `align="right"` to `align="center"` for consistency across all localized README files

## Changes
- README.zh-CN.md
- README.ja.md
- README.ko.md
- README.es.md
- README.tr.md
- README.id.md
- README.ar.md (was already centered, no change needed)

## Test plan
- [x] Verified all README files now have centered language selectors