### PR TITLE
feat(ui): remove model selector from home page

### DIFF
--- a/apps/desktop/src/renderer/components/landing/TaskInputBar.tsx
+++ b/apps/desktop/src/renderer/components/landing/TaskInputBar.tsx
@@ -27,6 +27,10 @@ interface TaskInputBarProps {
    */
   onOpenModelSettings?: () => void;
   /**
+   * Hide model indicator when no model is selected (instead of showing warning)
+   */
+  hideModelWhenNoModel?: boolean;
+  /**
    * Automatically submit after a successful transcription.
    */
   autoSubmitOnTranscription?: boolean;
@@ -43,6 +47,7 @@ export default function TaskInputBar({
   autoFocus = false,
   onOpenSpeechSettings,
   onOpenModelSettings,
+  hideModelWhenNoModel = false,
   autoSubmitOnTranscription = true,
 }: TaskInputBarProps) {
   const isDisabled = disabled || isLoading;
@@ -156,6 +161,7 @@ export default function TaskInputBar({
             <ModelIndicator
               isRunning={false}
               onOpenSettings={onOpenModelSettings}
+              hideWhenNoModel={hideModelWhenNoModel}
             />
           )}
 

--- a/apps/desktop/src/renderer/components/ui/ModelIndicator.tsx
+++ b/apps/desktop/src/renderer/components/ui/ModelIndicator.tsx
@@ -27,12 +27,15 @@ interface ModelIndicatorProps {
   onOpenSettings: () => void;
   /** Additional CSS classes */
   className?: string;
+  /** Hide the indicator when no model is selected (instead of showing warning) */
+  hideWhenNoModel?: boolean;
 }
 
 export function ModelIndicator({
   isRunning = false,
   onOpenSettings,
   className,
+  hideWhenNoModel = false,
 }: ModelIndicatorProps) {
   const { settings, loading, refetch } = useProviderSettings();
   const [open, setOpen] = useState(false);
@@ -84,6 +87,11 @@ export function ModelIndicator({
         <div className="w-20 h-4 rounded bg-muted-foreground/10" />
       </div>
     );
+  }
+
+  // Hide completely when no model and hideWhenNoModel is true
+  if (hideWhenNoModel && !hasModel) {
+    return null;
   }
 
   // When running, just show text without dropdown

--- a/apps/desktop/src/renderer/pages/Home.tsx
+++ b/apps/desktop/src/renderer/pages/Home.tsx
@@ -204,6 +204,7 @@ export default function HomePage() {
                 autoFocus={true}
                 onOpenSpeechSettings={handleOpenSpeechSettings}
                 onOpenModelSettings={handleOpenModelSettings}
+                hideModelWhenNoModel={true}
               />
             </CardContent>
 


### PR DESCRIPTION
## Summary
- Remove the ModelIndicator component from the home page task input bar
- If no model is configured, nothing is shown instead of the "Select model" warning
- The model indicator remains visible on the execution page for context during task runs

### No model - Do not show warning or anything 
<img width="946" height="738" alt="Screenshot 2026-02-01 at 10 16 00" src="https://github.com/user-attachments/assets/a85c5b7e-fefe-40c4-894b-7d0d5c078a82" />

### With model - Show
<img width="926" height="828" alt="Screenshot 2026-02-01 at 10 16 48" src="https://github.com/user-attachments/assets/0831e7b8-7121-4049-b24c-1b03d02b1e8f" />


## Test plan
- [ ] Verify home page no longer shows "Select model" warning when no model is configured
- [ ] Verify execution page still shows the model indicator
- [ ] Verify task submission still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)