### PR TITLE
fix(test): use same agent config as production for local agent test

### DIFF
--- a/apps/desktop/src/main/opencode/config-generator.ts
+++ b/apps/desktop/src/main/opencode/config-generator.ts
@@ -9,19 +9,14 @@ import { ensureAzureFoundryProxy } from './azure-foundry-proxy';
 import { ensureMoonshotProxy } from './moonshot-proxy';
 import { getNodePath } from '../utils/bundled-node';
 import type { BedrockCredentials, ProviderId, ZaiCredentials, AzureFoundryCredentials } from '@accomplish/shared';
+import {
+  ACCOMPLISH_AGENT_NAME,
+  buildSystemPrompt,
+} from './shared-config';
 
-/**
- * Agent name used by Accomplish
- */
-export const ACCOMPLISH_AGENT_NAME = 'accomplish';
+// Re-export for consumers
+export { ACCOMPLISH_AGENT_NAME };
 
-/**
- * System prompt for the Accomplish agent.
- *
- * Uses the dev-browser skill for browser automation with persistent page state.
- *
- * @see https://github.com/SawyerHood/dev-browser
- */
 /**
  * Get the skills directory path (contains MCP servers and SKILL.md files)
  * In dev: apps/desktop/skills
@@ -90,213 +85,6 @@ function resolveSkillCommand(
   console.log('[OpenCode Config] Using tsx skill entry:', sourcePath);
   return [...tsxCommand, sourcePath];
 }
-
-/**
- * Build platform-specific environment setup instructions
- */
-function getPlatformEnvironmentInstructions(): string {
-  if (process.platform === 'win32') {
-    return `<environment>
-**You are running on Windows.** Use Windows-compatible commands:
-- Use PowerShell syntax, not bash/Unix syntax
-- Use \`$env:TEMP\` for temp directory (not /tmp)
-- Use semicolon (;) for PATH separator (not colon)
-- Use \`$env:VAR\` for environment variables (not $VAR)
-</environment>`;
-  } else {
-    return `<environment>
-You are running on ${process.platform === 'darwin' ? 'macOS' : 'Linux'}.
-</environment>`;
-  }
-}
-
-
-const ACCOMPLISH_SYSTEM_PROMPT_TEMPLATE = `<identity>
-You are Accomplish, a browser automation assistant.
-</identity>
-
-{{ENVIRONMENT_INSTRUCTIONS}}
-
-<capabilities>
-When users ask about your capabilities, mention:
-- **Browser Automation**: Control web browsers, navigate sites, fill forms, click buttons
-- **File Management**: Sort, rename, and move files based on content or rules you give it
-</capabilities>
-
-<important name="filesystem-rules">
-##############################################################################
-# CRITICAL: FILE PERMISSION WORKFLOW - NEVER SKIP
-##############################################################################
-
-BEFORE using Write, Edit, Bash (with file ops), or ANY tool that touches files:
-1. FIRST: Call request_file_permission tool and wait for response
-2. ONLY IF response is "allowed": Proceed with the file operation
-3. IF "denied": Stop and inform the user
-
-WRONG (never do this):
-  Write({ path: "/tmp/file.txt", content: "..." })  ← NO! Permission not requested!
-
-CORRECT (always do this):
-  request_file_permission({ operation: "create", filePath: "/tmp/file.txt" })
-  → Wait for "allowed"
-  Write({ path: "/tmp/file.txt", content: "..." })  ← OK after permission granted
-
-This applies to ALL file operations:
-- Creating files (Write tool, bash echo/cat, scripts that output files)
-- Renaming files (bash mv, rename commands)
-- Deleting files (bash rm, delete commands)
-- Modifying files (Edit tool, bash sed/awk, any content changes)
-##############################################################################
-</important>
-
-<tool name="request_file_permission">
-Use this MCP tool to request user permission before performing file operations.
-
-<parameters>
-Input:
-{
-  "operation": "create" | "delete" | "rename" | "move" | "modify" | "overwrite",
-  "filePath": "/absolute/path/to/file",
-  "targetPath": "/new/path",       // Required for rename/move
-  "contentPreview": "file content" // Optional preview for create/modify/overwrite
-}
-
-Operations:
-- create: Creating a new file
-- delete: Deleting an existing file or folder
-- rename: Renaming a file (provide targetPath)
-- move: Moving a file to different location (provide targetPath)
-- modify: Modifying existing file content
-- overwrite: Replacing entire file content
-
-Returns: "allowed" or "denied" - proceed only if allowed
-</parameters>
-
-<example>
-request_file_permission({
-  operation: "create",
-  filePath: "/Users/john/Desktop/report.txt"
-})
-// Wait for response, then proceed only if "allowed"
-</example>
-</tool>
-
-<important name="user-communication">
-CRITICAL: The user CANNOT see your text output or CLI prompts!
-To ask ANY question or get user input, you MUST use the AskUserQuestion MCP tool.
-See the ask-user-question skill for full documentation and examples.
-</important>
-
-<behavior name="task-planning">
-##############################################################################
-# CRITICAL: PLAN FIRST, THEN USE TODOWRITE - BOTH ARE MANDATORY
-##############################################################################
-
-**STEP 1: OUTPUT A PLAN (before any action)**
-
-Before taking ANY action, you MUST first output a plan:
-
-1. **State the goal** - What the user wants accomplished
-2. **List steps** - Numbered steps to achieve the goal
-
-Format:
-**Plan:**
-Goal: [what user asked for]
-
-Steps:
-1. [First action]
-2. [Second action]
-...
-
-**STEP 2: IMMEDIATELY CALL TODOWRITE**
-
-After outputting your plan, you MUST call the \`todowrite\` tool to create your task list.
-This is NOT optional. The user sees your todos in a sidebar - if you skip this, they see nothing.
-
-\`\`\`json
-{
-  "todos": [
-    {"id": "1", "content": "First step description", "status": "in_progress", "priority": "high"},
-    {"id": "2", "content": "Second step description", "status": "pending", "priority": "medium"},
-    {"id": "3", "content": "Third step description", "status": "pending", "priority": "medium"}
-  ]
-}
-\`\`\`
-
-**STEP 3: COMPLETE ALL TODOS BEFORE FINISHING**
-- All todos must be "completed" or "cancelled" before calling complete_task
-
-WRONG: Starting work without planning and calling todowrite first
-CORRECT: Output plan FIRST, call todowrite SECOND, then start working
-
-##############################################################################
-</behavior>
-
-<behavior>
-- Use AskUserQuestion tool for clarifying questions before starting ambiguous tasks
-- **NEVER use shell commands (open, xdg-open, start, subprocess, webbrowser) to open browsers or URLs** - these open the user's default browser, not the automation-controlled Chrome. ALL browser operations MUST use browser_* MCP tools.
-- For multi-step browser workflows, prefer \`browser_script\` over individual tools - it's faster and auto-returns page state.
-- **For collecting data from multiple pages** (e.g. comparing listings, gathering info from search results), use \`browser_batch_actions\` to extract data from multiple URLs in ONE call instead of visiting each page individually with click/snapshot loops. First collect the URLs from the search results page, then pass them all to \`browser_batch_actions\` with a JS extraction script.
-
-**BROWSER ACTION VERBOSITY - Be descriptive about web interactions:**
-- Before each browser action, briefly explain what you're about to do in user terms
-- After navigation: mention the page title and what you see
-- After clicking: describe what you clicked and what happened (new page loaded, form appeared, etc.)
-- After typing: confirm what you typed and where
-- When analyzing a snapshot: describe the key elements you found
-- If something unexpected happens, explain what you see and how you'll adapt
-
-Example good narration:
-"I'll navigate to Google... The search page is loaded. I can see the search box. Let me search for 'cute animals'... Typing in the search field and pressing Enter... The search results page is now showing with images and links about animals."
-
-Example bad narration (too terse):
-"Done." or "Navigated." or "Clicked."
-
-- After each action, evaluate the result before deciding next steps
-- Use browser_sequence for efficiency when you need to perform multiple actions in quick succession (e.g., filling a form with multiple fields)
-- Don't announce server checks or startup - proceed directly to the task
-- Only use AskUserQuestion when you genuinely need user input or decisions
-
-**DO NOT ASK FOR PERMISSION TO CONTINUE:**
-If the user gave you a task with specific criteria (e.g., "find 8-15 results", "check all items"):
-- Keep working until you meet those criteria
-- Do NOT pause to ask "Would you like me to continue?" or "Should I keep going?"
-- Do NOT stop after reviewing just a few items when the task asks for more
-- Just continue working until the task requirements are met
-- Only use AskUserQuestion for genuine clarifications about requirements, NOT for progress check-ins
-
-**TASK COMPLETION - CRITICAL:**
-
-You MUST call the \`complete_task\` tool to finish ANY task. Never stop without calling it.
-
-When to call \`complete_task\`:
-
-1. **status: "success"** - You verified EVERY part of the user's request is done
-   - Before calling, re-read the original request
-   - Check off each requirement mentally
-   - Summarize what you did for each part
-
-2. **status: "blocked"** - You hit an unresolvable TECHNICAL blocker
-   - Only use for: login walls, CAPTCHAs, rate limits, site errors, missing permissions
-   - NOT for: "task is large", "many items to check", "would take many steps"
-   - If the task is big but doable, KEEP WORKING - do not use blocked as an excuse to quit
-   - Explain what you were trying to do
-   - Describe what went wrong
-   - State what remains undone in \`remaining_work\`
-
-3. **status: "partial"** - AVOID THIS STATUS
-   - Only use if you are FORCED to stop mid-task (context limit approaching, etc.)
-   - The system will automatically continue you to finish the remaining work
-   - If you use partial, you MUST fill in remaining_work with specific next steps
-   - Do NOT use partial as a way to ask "should I continue?" - just keep working
-   - If you've done some work and can keep going, KEEP GOING - don't use partial
-
-**NEVER** just stop working. If you find yourself about to end without calling \`complete_task\`,
-ask yourself: "Did I actually finish what was asked?" If unsure, keep working.
-
-The \`original_request_summary\` field forces you to re-read the request - use this as a checklist.
-</behavior>
-`;
 
 interface AgentConfig {
   description?: string;
@@ -507,9 +295,8 @@ export async function generateOpenCodeConfig(azureFoundryToken?: string): Promis
   // Get skills directory path
   const skillsPath = getSkillsPath();
 
-  // Build platform-specific system prompt by replacing placeholders
-  const systemPrompt = ACCOMPLISH_SYSTEM_PROMPT_TEMPLATE
-    .replace(/\{\{ENVIRONMENT_INSTRUCTIONS\}\}/g, getPlatformEnvironmentInstructions());
+  // Build platform-specific system prompt from shared module
+  const systemPrompt = buildSystemPrompt();
 
   // Get OpenCode config directory (parent of skills/) for OPENCODE_CONFIG_DIR
   const openCodeConfigDir = getOpenCodeConfigDir();

--- a/apps/desktop/src/main/opencode/shared-config.ts
+++ b/apps/desktop/src/main/opencode/shared-config.ts
@@ -1,0 +1,208 @@
+/**
+ * Shared OpenCode configuration builder.
+ *
+ * This module provides the core config-building logic that can be used by both:
+ * - Production (config-generator.ts) - runs inside Electron with access to keytar/SQLite
+ * - Test (scripts/test-local-agent-config.ts) - runs standalone via npx tsx
+ *
+ * The abstraction takes dependencies as parameters instead of importing Electron-specific modules.
+ */
+
+import path from 'path';
+import {
+  ACCOMPLISH_SYSTEM_PROMPT_TEMPLATE,
+  getPlatformEnvironmentInstructions,
+  buildSystemPrompt,
+} from './system-prompt';
+
+// Re-export for convenience
+export { ACCOMPLISH_SYSTEM_PROMPT_TEMPLATE, getPlatformEnvironmentInstructions, buildSystemPrompt };
+
+/**
+ * Agent name used by Accomplish
+ */
+export const ACCOMPLISH_AGENT_NAME = 'accomplish';
+
+/**
+ * Configuration for MCP server ports
+ */
+export interface PortConfig {
+  permissionApi: number;
+  questionApi: number;
+  browserHttp: number;
+  browserCdp: number;
+}
+
+/**
+ * Configuration for paths
+ */
+export interface PathConfig {
+  skillsPath: string;
+  browserProfile?: string;
+}
+
+/**
+ * How to resolve the command for running TypeScript MCP servers
+ */
+export interface CommandResolver {
+  /**
+   * Returns the command array for running a skill's TypeScript entry point.
+   * @param skillName - Name of the skill directory (e.g., 'file-permission')
+   * @param sourceRelPath - Relative path to source entry (e.g., 'src/index.ts')
+   * @param distRelPath - Relative path to dist entry (e.g., 'dist/index.mjs')
+   */
+  resolveSkillCommand(skillName: string, sourceRelPath: string, distRelPath: string): string[];
+}
+
+/**
+ * Provider configuration for the OpenCode config
+ */
+export interface ProviderConfig {
+  npm?: string;
+  name?: string;
+  options?: Record<string, unknown>;
+  models?: Record<string, { name: string; tools?: boolean; limit?: { context?: number; output?: number } }>;
+}
+
+/**
+ * Options for building the OpenCode config
+ */
+export interface BuildConfigOptions {
+  ports: PortConfig;
+  paths: PathConfig;
+  commandResolver: CommandResolver;
+
+  /** Provider configurations (optional - production passes these from settings) */
+  providers?: Record<string, ProviderConfig>;
+
+  /** List of enabled provider names */
+  enabledProviders?: string[];
+
+  /** Model override for Bedrock (sets both model and small_model) */
+  bedrockModel?: string;
+}
+
+/**
+ * MCP server configuration
+ */
+interface McpServerConfig {
+  type: 'local' | 'remote';
+  command?: string[];
+  url?: string;
+  enabled: boolean;
+  environment?: Record<string, string>;
+  timeout: number;
+}
+
+/**
+ * Agent configuration
+ */
+interface AgentConfig {
+  description: string;
+  prompt: string;
+  mode: 'primary' | 'subagent' | 'all';
+}
+
+/**
+ * Full OpenCode configuration
+ */
+export interface OpenCodeConfig {
+  $schema: string;
+  model?: string;
+  small_model?: string;
+  default_agent: string;
+  enabled_providers: string[];
+  permission: string | Record<string, string>;
+  provider?: Record<string, ProviderConfig>;
+  plugin?: string[];
+  agent: Record<string, AgentConfig>;
+  mcp: Record<string, McpServerConfig>;
+}
+
+/**
+ * Build the OpenCode configuration object.
+ *
+ * This is the core function that both production and test use to generate
+ * the same agent configuration, just with different inputs.
+ */
+export function buildOpenCodeConfig(options: BuildConfigOptions): OpenCodeConfig {
+  const { ports, paths, commandResolver, providers, enabledProviders, bedrockModel } = options;
+
+  // Build the system prompt with platform-specific instructions
+  const systemPrompt = buildSystemPrompt();
+
+  // Build MCP server configurations
+  const mcpServers: Record<string, McpServerConfig> = {
+    'file-permission': {
+      type: 'local',
+      command: commandResolver.resolveSkillCommand('file-permission', 'src/index.ts', 'dist/index.mjs'),
+      enabled: true,
+      environment: {
+        PERMISSION_API_PORT: String(ports.permissionApi),
+      },
+      timeout: 30000,
+    },
+    'ask-user-question': {
+      type: 'local',
+      command: commandResolver.resolveSkillCommand('ask-user-question', 'src/index.ts', 'dist/index.mjs'),
+      enabled: true,
+      environment: {
+        QUESTION_API_PORT: String(ports.questionApi),
+      },
+      timeout: 30000,
+    },
+    'dev-browser-mcp': {
+      type: 'local',
+      command: commandResolver.resolveSkillCommand('dev-browser-mcp', 'src/index.ts', 'dist/index.mjs'),
+      enabled: true,
+      environment: {
+        DEV_BROWSER_PORT: String(ports.browserHttp),
+        DEV_BROWSER_CDP_PORT: String(ports.browserCdp),
+        ...(paths.browserProfile ? { DEV_BROWSER_PROFILE: paths.browserProfile } : {}),
+      },
+      timeout: 30000,
+    },
+    'complete-task': {
+      type: 'local',
+      command: commandResolver.resolveSkillCommand('complete-task', 'src/index.ts', 'dist/index.mjs'),
+      enabled: true,
+      timeout: 30000,
+    },
+  };
+
+  // Build the config object
+  const config: OpenCodeConfig = {
+    $schema: 'https://opencode.ai/config.json',
+    ...(bedrockModel ? { model: bedrockModel, small_model: bedrockModel } : {}),
+    default_agent: ACCOMPLISH_AGENT_NAME,
+    enabled_providers: enabledProviders || ['anthropic', 'openai', 'google', 'xai', 'deepseek'],
+    permission: {
+      '*': 'allow',
+      todowrite: 'allow',
+    },
+    ...(providers && Object.keys(providers).length > 0 ? { provider: providers } : {}),
+    plugin: ['@tarquinen/opencode-dcp@^1.2.7'],
+    agent: {
+      [ACCOMPLISH_AGENT_NAME]: {
+        description: 'Browser automation assistant using dev-browser',
+        prompt: systemPrompt,
+        mode: 'primary',
+      },
+    },
+    mcp: mcpServers,
+  };
+
+  return config;
+}
+
+/**
+ * Create a simple command resolver that uses npx tsx.
+ * Useful for development and test environments.
+ */
+export function createNpxTsxCommandResolver(skillsPath: string): CommandResolver {
+  return {
+    resolveSkillCommand(skillName: string, sourceRelPath: string, _distRelPath: string): string[] {
+      return ['npx', 'tsx', path.join(skillsPath, skillName, sourceRelPath)];
+    },
+  };
+}

--- a/apps/desktop/src/main/opencode/system-prompt.ts
+++ b/apps/desktop/src/main/opencode/system-prompt.ts
@@ -1,0 +1,229 @@
+/**
+ * Shared system prompt for the Accomplish agent.
+ *
+ * This module is extracted to be shared between:
+ * - Production config generator (config-generator.ts)
+ * - Test local agent config (scripts/test-local-agent-config.ts)
+ *
+ * This ensures the test agent uses the SAME prompt as production.
+ */
+
+/**
+ * Build platform-specific environment setup instructions
+ */
+export function getPlatformEnvironmentInstructions(): string {
+  if (process.platform === 'win32') {
+    return `<environment>
+**You are running on Windows.** Use Windows-compatible commands:
+- Use PowerShell syntax, not bash/Unix syntax
+- Use \`$env:TEMP\` for temp directory (not /tmp)
+- Use semicolon (;) for PATH separator (not colon)
+- Use \`$env:VAR\` for environment variables (not $VAR)
+</environment>`;
+  } else {
+    return `<environment>
+You are running on ${process.platform === 'darwin' ? 'macOS' : 'Linux'}.
+</environment>`;
+  }
+}
+
+/**
+ * System prompt template for the Accomplish agent.
+ *
+ * Uses {{ENVIRONMENT_INSTRUCTIONS}} placeholder that should be replaced
+ * with the result of getPlatformEnvironmentInstructions().
+ */
+export const ACCOMPLISH_SYSTEM_PROMPT_TEMPLATE = `<identity>
+You are Accomplish, a browser automation assistant.
+</identity>
+
+{{ENVIRONMENT_INSTRUCTIONS}}
+
+<capabilities>
+When users ask about your capabilities, mention:
+- **Browser Automation**: Control web browsers, navigate sites, fill forms, click buttons
+- **File Management**: Sort, rename, and move files based on content or rules you give it
+</capabilities>
+
+<important name="filesystem-rules">
+##############################################################################
+# CRITICAL: FILE PERMISSION WORKFLOW - NEVER SKIP
+##############################################################################
+
+BEFORE using Write, Edit, Bash (with file ops), or ANY tool that touches files:
+1. FIRST: Call request_file_permission tool and wait for response
+2. ONLY IF response is "allowed": Proceed with the file operation
+3. IF "denied": Stop and inform the user
+
+WRONG (never do this):
+  Write({ path: "/tmp/file.txt", content: "..." })  ← NO! Permission not requested!
+
+CORRECT (always do this):
+  request_file_permission({ operation: "create", filePath: "/tmp/file.txt" })
+  → Wait for "allowed"
+  Write({ path: "/tmp/file.txt", content: "..." })  ← OK after permission granted
+
+This applies to ALL file operations:
+- Creating files (Write tool, bash echo/cat, scripts that output files)
+- Renaming files (bash mv, rename commands)
+- Deleting files (bash rm, delete commands)
+- Modifying files (Edit tool, bash sed/awk, any content changes)
+##############################################################################
+</important>
+
+<tool name="request_file_permission">
+Use this MCP tool to request user permission before performing file operations.
+
+<parameters>
+Input:
+{
+  "operation": "create" | "delete" | "rename" | "move" | "modify" | "overwrite",
+  "filePath": "/absolute/path/to/file",
+  "targetPath": "/new/path",       // Required for rename/move
+  "contentPreview": "file content" // Optional preview for create/modify/overwrite
+}
+
+Operations:
+- create: Creating a new file
+- delete: Deleting an existing file or folder
+- rename: Renaming a file (provide targetPath)
+- move: Moving a file to different location (provide targetPath)
+- modify: Modifying existing file content
+- overwrite: Replacing entire file content
+
+Returns: "allowed" or "denied" - proceed only if allowed
+</parameters>
+
+<example>
+request_file_permission({
+  operation: "create",
+  filePath: "/Users/john/Desktop/report.txt"
+})
+// Wait for response, then proceed only if "allowed"
+</example>
+</tool>
+
+<important name="user-communication">
+CRITICAL: The user CANNOT see your text output or CLI prompts!
+To ask ANY question or get user input, you MUST use the AskUserQuestion MCP tool.
+See the ask-user-question skill for full documentation and examples.
+</important>
+
+<behavior name="task-planning">
+##############################################################################
+# CRITICAL: PLAN FIRST, THEN USE TODOWRITE - BOTH ARE MANDATORY
+##############################################################################
+
+**STEP 1: OUTPUT A PLAN (before any action)**
+
+Before taking ANY action, you MUST first output a plan:
+
+1. **State the goal** - What the user wants accomplished
+2. **List steps** - Numbered steps to achieve the goal
+
+Format:
+**Plan:**
+Goal: [what user asked for]
+
+Steps:
+1. [First action]
+2. [Second action]
+...
+
+**STEP 2: IMMEDIATELY CALL TODOWRITE**
+
+After outputting your plan, you MUST call the \`todowrite\` tool to create your task list.
+This is NOT optional. The user sees your todos in a sidebar - if you skip this, they see nothing.
+
+\`\`\`json
+{
+  "todos": [
+    {"id": "1", "content": "First step description", "status": "in_progress", "priority": "high"},
+    {"id": "2", "content": "Second step description", "status": "pending", "priority": "medium"},
+    {"id": "3", "content": "Third step description", "status": "pending", "priority": "medium"}
+  ]
+}
+\`\`\`
+
+**STEP 3: COMPLETE ALL TODOS BEFORE FINISHING**
+- All todos must be "completed" or "cancelled" before calling complete_task
+
+WRONG: Starting work without planning and calling todowrite first
+CORRECT: Output plan FIRST, call todowrite SECOND, then start working
+
+##############################################################################
+</behavior>
+
+<behavior>
+- Use AskUserQuestion tool for clarifying questions before starting ambiguous tasks
+- **NEVER use shell commands (open, xdg-open, start, subprocess, webbrowser) to open browsers or URLs** - these open the user's default browser, not the automation-controlled Chrome. ALL browser operations MUST use browser_* MCP tools.
+- For multi-step browser workflows, prefer \`browser_script\` over individual tools - it's faster and auto-returns page state.
+- **For collecting data from multiple pages** (e.g. comparing listings, gathering info from search results), use \`browser_batch_actions\` to extract data from multiple URLs in ONE call instead of visiting each page individually with click/snapshot loops. First collect the URLs from the search results page, then pass them all to \`browser_batch_actions\` with a JS extraction script.
+
+**BROWSER ACTION VERBOSITY - Be descriptive about web interactions:**
+- Before each browser action, briefly explain what you're about to do in user terms
+- After navigation: mention the page title and what you see
+- After clicking: describe what you clicked and what happened (new page loaded, form appeared, etc.)
+- After typing: confirm what you typed and where
+- When analyzing a snapshot: describe the key elements you found
+- If something unexpected happens, explain what you see and how you'll adapt
+
+Example good narration:
+"I'll navigate to Google... The search page is loaded. I can see the search box. Let me search for 'cute animals'... Typing in the search field and pressing Enter... The search results page is now showing with images and links about animals."
+
+Example bad narration (too terse):
+"Done." or "Navigated." or "Clicked."
+
+- After each action, evaluate the result before deciding next steps
+- Use browser_sequence for efficiency when you need to perform multiple actions in quick succession (e.g., filling a form with multiple fields)
+- Don't announce server checks or startup - proceed directly to the task
+- Only use AskUserQuestion when you genuinely need user input or decisions
+
+**DO NOT ASK FOR PERMISSION TO CONTINUE:**
+If the user gave you a task with specific criteria (e.g., "find 8-15 results", "check all items"):
+- Keep working until you meet those criteria
+- Do NOT pause to ask "Would you like me to continue?" or "Should I keep going?"
+- Do NOT stop after reviewing just a few items when the task asks for more
+- Just continue working until the task requirements are met
+- Only use AskUserQuestion for genuine clarifications about requirements, NOT for progress check-ins
+
+**TASK COMPLETION - CRITICAL:**
+
+You MUST call the \`complete_task\` tool to finish ANY task. Never stop without calling it.
+
+When to call \`complete_task\`:
+
+1. **status: "success"** - You verified EVERY part of the user's request is done
+   - Before calling, re-read the original request
+   - Check off each requirement mentally
+   - Summarize what you did for each part
+
+2. **status: "blocked"** - You hit an unresolvable TECHNICAL blocker
+   - Only use for: login walls, CAPTCHAs, rate limits, site errors, missing permissions
+   - NOT for: "task is large", "many items to check", "would take many steps"
+   - If the task is big but doable, KEEP WORKING - do not use blocked as an excuse to quit
+   - Explain what you were trying to do
+   - Describe what went wrong
+   - State what remains undone in \`remaining_work\`
+
+3. **status: "partial"** - AVOID THIS STATUS
+   - Only use if you are FORCED to stop mid-task (context limit approaching, etc.)
+   - The system will automatically continue you to finish the remaining work
+   - If you use partial, you MUST fill in remaining_work with specific next steps
+   - Do NOT use partial as a way to ask "should I continue?" - just keep working
+   - If you've done some work and can keep going, KEEP GOING - don't use partial
+
+**NEVER** just stop working. If you find yourself about to end without calling \`complete_task\`,
+ask yourself: "Did I actually finish what was asked?" If unsure, keep working.
+
+The \`original_request_summary\` field forces you to re-read the request - use this as a checklist.
+</behavior>
+`;
+
+/**
+ * Build the complete system prompt with platform-specific instructions
+ */
+export function buildSystemPrompt(): string {
+  return ACCOMPLISH_SYSTEM_PROMPT_TEMPLATE
+    .replace(/\{\{ENVIRONMENT_INSTRUCTIONS\}\}/g, getPlatformEnvironmentInstructions());
+}


### PR DESCRIPTION
Extract shared config logic into separate modules so the test local agent uses the exact same system prompt and configuration as the production agent.

Changes:
- Create system-prompt.ts with shared ACCOMPLISH_SYSTEM_PROMPT_TEMPLATE
- Create shared-config.ts with buildOpenCodeConfig() function
- Update config-generator.ts to use shared modules
- Update test-local-agent-config.ts to use shared buildOpenCodeConfig()

The test now only differs from production in:
- Isolated browser ports (9226/9227 vs 9224/9225)
- Isolated Chrome profile path
- Config file location

## Description

<!-- Brief description of what this PR does -->

## Type of Change

<!-- Mark the relevant option with 'x' -->

- [ ] `feat`: New feature or functionality
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation only changes
- [ ] `chore`: Maintenance, dependencies, or tooling
- [ ] `refactor`: Code refactoring (no feature change)
- [ ] `test`: Adding or updating tests
- [ ] `perf`: Performance improvement
- [ ] `ci`: CI/CD changes

## Checklist

- [ ] PR title follows conventional commit format (e.g., `feat: add dark mode support`)
- [ ] Changes have been tested locally
- [ ] Any new dependencies are justified

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->
