### PR TITLE
fix(ui): hide elapsed time indicator when negative

### DIFF
--- a/apps/desktop/src/renderer/pages/Execution.tsx
+++ b/apps/desktop/src/renderer/pages/Execution.tsx
@@ -900,8 +900,8 @@ export default function ExecutionPage() {
                           ({currentTool})
                         </span>
                       )}
-                      {/* Elapsed time - only show during startup stages */}
-                      {!currentTool && startupStageTaskId === id && startupStage && (
+                      {/* Elapsed time - only show during startup stages when valid */}
+                      {!currentTool && startupStageTaskId === id && startupStage && elapsedTime > 0 && (
                         <span className="text-xs text-muted-foreground/60">
                           ({elapsedTime}s)
                         </span>


### PR DESCRIPTION

<img width="2442" height="1302" alt="Screenshot 2026-02-01 at 6 16 18 PM" src="https://github.com/user-attachments/assets/46ee770e-a201-4cb9-912a-0c5ea3b9e968" />


Fixing possible bug of negative count down 


## Summary
- Hide the elapsed time indicator during startup stages when it shows a negative value
- Caused by clock drift/jumps in VMs (observed on Windows in Parallels)
- Instead of showing confusing values like "(-27008s)", simply don't show the indicator

## Test plan
- [ ] Test on a VM with clock drift to verify negative values no longer appear
- [ ] Verify elapsed time still shows correctly under normal conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)