### PR TITLE
fix(build): add start-task to bundle-skills.cjs

### DIFF
--- a/apps/desktop/scripts/bundle-skills.cjs
+++ b/apps/desktop/scripts/bundle-skills.cjs
@@ -11,7 +11,7 @@ const skillsDir = path.join(__dirname, '..', 'skills');
 const SKILLS_WITH_RUNTIME_DEPS = ['dev-browser', 'dev-browser-mcp'];
 
 // Skills that are fully bundled (no runtime node_modules needed)
-const SKILLS_FULLY_BUNDLED = ['ask-user-question', 'file-permission', 'complete-task'];
+const SKILLS_FULLY_BUNDLED = ['ask-user-question', 'file-permission', 'complete-task', 'start-task'];
 
 const bundles = [
   {
@@ -26,6 +26,11 @@ const bundles = [
   },
   {
     name: 'complete-task',
+    entry: 'src/index.ts',
+    outfile: 'dist/index.mjs',
+  },
+  {
+    name: 'start-task',
     entry: 'src/index.ts',
     outfile: 'dist/index.mjs',
   },


### PR DESCRIPTION
## Summary

The `start-task` skill was added in PR #310 but was missing from the `bundle-skills.cjs` configuration. This was likely lost during conflict resolution when merging main.

Without this fix, the `start-task` skill is **not bundled for production builds**, meaning the packaged app won't have the skill available.

## Changes

1. Add `'start-task'` to `SKILLS_FULLY_BUNDLED` array
2. Add bundle entry for `start-task` skill in the `bundles` array

## Test plan

- [ ] Run `pnpm build:desktop` and verify `start-task` skill is bundled
- [ ] Check `apps/desktop/skills/start-task/dist/index.mjs` exists after build

🤖 Generated with [Claude Code](https://claude.ai/claude-code)