### PR TITLE
fix: correct Bedrock Opus model date to 20251101

### DIFF
--- a/packages/shared/src/types/providerSettings.ts
+++ b/packages/shared/src/types/providerSettings.ts
@@ -163,7 +163,7 @@ export const DEFAULT_MODELS: Partial<Record<ProviderId, string>> = {
   openai: 'openai/gpt-5.2',
   google: 'google/gemini-3-pro-preview',
   xai: 'xai/grok-4',
-  bedrock: 'amazon-bedrock/anthropic.claude-opus-4-5-20251001-v1:0',
+  bedrock: 'amazon-bedrock/anthropic.claude-opus-4-5-20251101-v1:0',
   moonshot: 'moonshot/kimi-latest',
 };
 


### PR DESCRIPTION
## Summary
Fix the Bedrock default model ID to use the correct date for Claude Opus 4.5.

- **Before:** `amazon-bedrock/anthropic.claude-opus-4-5-20251001-v1:0`
- **After:** `amazon-bedrock/anthropic.claude-opus-4-5-20251101-v1:0`

The model wasn't being auto-selected because the ID didn't match what's available in Bedrock.

## Test plan
- [ ] Connect a new Bedrock provider and confirm Opus 4.5 is auto-selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)