### PR TITLE
docs: update download links to v0.3.8 and add Windows 11 support

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/accomplish-ai/accomplish/stargazers"><img src="https://img.shields.io/github/stars/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="نجوم GitHub" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/issues"><img src="https://img.shields.io/github/issues/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="مشكلات GitHub" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/commits"><img src="https://img.shields.io/github/last-commit/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="آخر تحديث" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.3.6/macos/Accomplish-0.3.6-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS-0ea5e9?style=flat-square" alt="تحميل لـ macOS" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/0.3.8/macos/Accomplish-0.3.8-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS-0ea5e9?style=flat-square" alt="تحميل لـ macOS" /></a>
 </p>
 
 # Accomplish™ - وكيل سطح مكتب ذكاء اصطناعي مفتوح المصدر
@@ -23,7 +23,9 @@ Accomplish هو وكيل سطح مكتب ذكاء اصطناعي مفتوح ال
 </p>
 
 <p align="center">
-  <a href="https://downloads.accomplish.ai/downloads/0.3.6/macos/Accomplish-0.3.6-mac-arm64.dmg"><strong>تحميل Accomplish لـ Mac (Apple Silicon)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/0.3.8/macos/Accomplish-0.3.8-mac-arm64.dmg"><strong>تحميل لـ Mac (Apple Silicon)</strong></a>
+  ·
+  <a href="https://downloads.accomplish.ai/downloads/0.3.8/windows/Accomplish-v2-0.3.8-win-x64.exe"><strong>تحميل لـ Windows 11</strong></a>
   ·
   <a href="https://www.accomplish.ai/">موقع Accomplish</a>
   ·
@@ -157,7 +159,7 @@ Accomplish هو وكيل سطح مكتب ذكاء اصطناعي مفتوح ال
 ## متطلبات النظام
 
 - macOS (Apple Silicon)
-- دعم Windows قادم قريباً
+- Windows 11
 
 <br />
 
@@ -183,7 +185,7 @@ Accomplish هو وكيل سطح مكتب ذكاء اصطناعي مفتوح ال
 
 <div align="center">
 
-[**تحميل لـ Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.3.6/macos/Accomplish-0.3.6-mac-arm64.dmg)
+[**تحميل لـ Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.3.8/macos/Accomplish-0.3.8-mac-arm64.dmg) · [**تحميل لـ Windows 11**](https://downloads.accomplish.ai/downloads/0.3.8/windows/Accomplish-v2-0.3.8-win-x64.exe)
 
 </div>
 
@@ -221,7 +223,7 @@ Accomplish هو وكيل سطح مكتب ذكاء اصطناعي مفتوح ال
 نعم. Accomplish مفتوح المصدر ومرخص بـ MIT.
 
 **ما هي المنصات المدعومة؟**
-macOS (Apple Silicon) متاح الآن. دعم Windows قادم قريباً.
+macOS (Apple Silicon) و Windows 11 متاحان الآن.
 
 <br />
 

--- a/README.es.md
+++ b/README.es.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/accomplish-ai/accomplish/stargazers"><img src="https://img.shields.io/github/stars/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Stars" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/issues"><img src="https://img.shields.io/github/issues/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Issues" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/commits"><img src="https://img.shields.io/github/last-commit/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="Último Commit" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.3.6/macos/Accomplish-0.3.6-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS-0ea5e9?style=flat-square" alt="Descargar para macOS" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/0.3.8/macos/Accomplish-0.3.8-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS-0ea5e9?style=flat-square" alt="Descargar para macOS" /></a>
 </p>
 
 # Accomplish™ - Agente de Escritorio de IA de Código Abierto
@@ -23,7 +23,9 @@ Accomplish es un agente de escritorio de IA de código abierto que automatiza la
 </p>
 
 <p align="center">
-  <a href="https://downloads.accomplish.ai/downloads/0.3.6/macos/Accomplish-0.3.6-mac-arm64.dmg"><strong>Descargar Accomplish para Mac (Apple Silicon)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/0.3.8/macos/Accomplish-0.3.8-mac-arm64.dmg"><strong>Descargar para Mac (Apple Silicon)</strong></a>
+  ·
+  <a href="https://downloads.accomplish.ai/downloads/0.3.8/windows/Accomplish-v2-0.3.8-win-x64.exe"><strong>Descargar para Windows 11</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Sitio web de Accomplish</a>
   ·
@@ -157,7 +159,7 @@ Accomplish se ejecuta localmente en tu máquina. Tus archivos permanecen en tu d
 ## Requisitos del sistema
 
 - macOS (Apple Silicon)
-- Soporte para Windows próximamente
+- Windows 11
 
 <br />
 
@@ -183,7 +185,7 @@ Accomplish se ejecuta localmente en tu máquina. Tus archivos permanecen en tu d
 
 <div align="center">
 
-[**Descargar para Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.3.6/macos/Accomplish-0.3.6-mac-arm64.dmg)
+[**Descargar para Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.3.8/macos/Accomplish-0.3.8-mac-arm64.dmg) · [**Descargar para Windows 11**](https://downloads.accomplish.ai/downloads/0.3.8/windows/Accomplish-v2-0.3.8-win-x64.exe)
 
 </div>
 
@@ -221,7 +223,7 @@ Puedes usar tus propias claves API (OpenAI, Anthropic, Google, xAI, etc.) o ejec
 Sí. Accomplish es de código abierto y tiene licencia MIT.
 
 **¿Qué plataformas son compatibles?**
-macOS (Apple Silicon) está disponible ahora. El soporte para Windows llegará pronto.
+macOS (Apple Silicon) y Windows 11 están disponibles ahora.
 
 <br />
 

--- a/README.id.md
+++ b/README.id.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/accomplish-ai/accomplish/stargazers"><img src="https://img.shields.io/github/stars/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Stars" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/issues"><img src="https://img.shields.io/github/issues/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Issues" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/commits"><img src="https://img.shields.io/github/last-commit/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="Commit Terakhir" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.3.6/macos/Accomplish-0.3.6-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS-0ea5e9?style=flat-square" alt="Unduh untuk macOS" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/0.3.8/macos/Accomplish-0.3.8-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS-0ea5e9?style=flat-square" alt="Unduh untuk macOS" /></a>
 </p>
 
 # Accomplish™ - Agen Desktop AI Open Source
@@ -23,7 +23,9 @@ Accomplish adalah agen desktop AI open source yang mengotomatisasi manajemen fil
 </p>
 
 <p align="center">
-  <a href="https://downloads.accomplish.ai/downloads/0.3.6/macos/Accomplish-0.3.6-mac-arm64.dmg"><strong>Unduh Accomplish untuk Mac (Apple Silicon)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/0.3.8/macos/Accomplish-0.3.8-mac-arm64.dmg"><strong>Unduh untuk Mac (Apple Silicon)</strong></a>
+  ·
+  <a href="https://downloads.accomplish.ai/downloads/0.3.8/windows/Accomplish-v2-0.3.8-win-x64.exe"><strong>Unduh untuk Windows 11</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Website Accomplish</a>
   ·
@@ -157,7 +159,7 @@ Accomplish berjalan secara lokal di mesin Anda. File Anda tetap di perangkat And
 ## Persyaratan sistem
 
 - macOS (Apple Silicon)
-- Dukungan Windows segera hadir
+- Windows 11
 
 <br />
 
@@ -183,7 +185,7 @@ Accomplish berjalan secara lokal di mesin Anda. File Anda tetap di perangkat And
 
 <div align="center">
 
-[**Unduh untuk Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.3.6/macos/Accomplish-0.3.6-mac-arm64.dmg)
+[**Unduh untuk Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.3.8/macos/Accomplish-0.3.8-mac-arm64.dmg) · [**Unduh untuk Windows 11**](https://downloads.accomplish.ai/downloads/0.3.8/windows/Accomplish-v2-0.3.8-win-x64.exe)
 
 </div>
 
@@ -221,7 +223,7 @@ Anda bisa menggunakan kunci API Anda sendiri (OpenAI, Anthropic, Google, xAI, dl
 Ya. Accomplish adalah open source dan berlisensi MIT.
 
 **Platform apa yang didukung?**
-macOS (Apple Silicon) tersedia sekarang. Dukungan Windows segera hadir.
+macOS (Apple Silicon) dan Windows 11 tersedia sekarang.
 
 <br />
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/accomplish-ai/accomplish/stargazers"><img src="https://img.shields.io/github/stars/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Stars" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/issues"><img src="https://img.shields.io/github/issues/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Issues" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/commits"><img src="https://img.shields.io/github/last-commit/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="最終コミット" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.3.6/macos/Accomplish-0.3.6-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS-0ea5e9?style=flat-square" alt="macOS用ダウンロード" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/0.3.8/macos/Accomplish-0.3.8-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS-0ea5e9?style=flat-square" alt="macOS用ダウンロード" /></a>
 </p>
 
 # Accomplish™ - オープンソースAIデスクトップエージェント
@@ -23,7 +23,9 @@ Accomplishは、お使いのマシン上でローカルにファイル管理、�
 </p>
 
 <p align="center">
-  <a href="https://downloads.accomplish.ai/downloads/0.3.6/macos/Accomplish-0.3.6-mac-arm64.dmg"><strong>Mac用Accomplishをダウンロード（Apple Silicon）</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/0.3.8/macos/Accomplish-0.3.8-mac-arm64.dmg"><strong>Mac用ダウンロード（Apple Silicon）</strong></a>
+  ·
+  <a href="https://downloads.accomplish.ai/downloads/0.3.8/windows/Accomplish-v2-0.3.8-win-x64.exe"><strong>Windows 11用ダウンロード</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Accomplishウェブサイト</a>
   ·
@@ -157,7 +159,7 @@ Accomplishはお使いのマシン上でローカルに実行されます。フ�
 ## システム要件
 
 - macOS（Apple Silicon）
-- Windows対応は近日公開予定
+- Windows 11
 
 <br />
 
@@ -183,7 +185,7 @@ Accomplishはお使いのマシン上でローカルに実行されます。フ�
 
 <div align="center">
 
-[**Mac用ダウンロード（Apple Silicon）**](https://downloads.accomplish.ai/downloads/0.3.6/macos/Accomplish-0.3.6-mac-arm64.dmg)
+[**Mac用ダウンロード（Apple Silicon）**](https://downloads.accomplish.ai/downloads/0.3.8/macos/Accomplish-0.3.8-mac-arm64.dmg) · [**Windows 11用ダウンロード**](https://downloads.accomplish.ai/downloads/0.3.8/windows/Accomplish-v2-0.3.8-win-x64.exe)
 
 </div>
 
@@ -221,7 +223,7 @@ macOSでのAccomplishの概要と、短いデモ動画。
 はい。AccomplishはオープンソースでMITライセンスです。
 
 **どのプラットフォームに対応していますか？**
-macOS（Apple Silicon）は現在利用可能です。Windows対応は近日公開予定です。
+macOS（Apple Silicon）とWindows 11が利用可能です。
 
 <br />
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/accomplish-ai/accomplish/stargazers"><img src="https://img.shields.io/github/stars/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Stars" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/issues"><img src="https://img.shields.io/github/issues/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Issues" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/commits"><img src="https://img.shields.io/github/last-commit/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="최근 커밋" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.3.6/macos/Accomplish-0.3.6-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS-0ea5e9?style=flat-square" alt="macOS 다운로드" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/0.3.8/macos/Accomplish-0.3.8-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS-0ea5e9?style=flat-square" alt="macOS 다운로드" /></a>
 </p>
 
 # Accomplish™ - 오픈소스 AI 데스크톱 에이전트
@@ -23,7 +23,9 @@ Accomplish는 로컬 머신에서 파일 관리, 문서 작성, 브라우저 작
 </p>
 
 <p align="center">
-  <a href="https://downloads.accomplish.ai/downloads/0.3.6/macos/Accomplish-0.3.6-mac-arm64.dmg"><strong>Mac용 Accomplish 다운로드 (Apple Silicon)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/0.3.8/macos/Accomplish-0.3.8-mac-arm64.dmg"><strong>Mac용 다운로드 (Apple Silicon)</strong></a>
+  ·
+  <a href="https://downloads.accomplish.ai/downloads/0.3.8/windows/Accomplish-v2-0.3.8-win-x64.exe"><strong>Windows 11용 다운로드</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Accomplish 웹사이트</a>
   ·
@@ -157,7 +159,7 @@ Accomplish는 로컬 머신에서 실행됩니다. 파일은 기기에 저장되
 ## 시스템 요구 사항
 
 - macOS (Apple Silicon)
-- Windows 지원 예정
+- Windows 11
 
 <br />
 
@@ -183,7 +185,7 @@ Accomplish는 로컬 머신에서 실행됩니다. 파일은 기기에 저장되
 
 <div align="center">
 
-[**Mac용 다운로드 (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.3.6/macos/Accomplish-0.3.6-mac-arm64.dmg)
+[**Mac용 다운로드 (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.3.8/macos/Accomplish-0.3.8-mac-arm64.dmg) · [**Windows 11용 다운로드**](https://downloads.accomplish.ai/downloads/0.3.8/windows/Accomplish-v2-0.3.8-win-x64.exe)
 
 </div>
 
@@ -221,7 +223,7 @@ macOS에서의 Accomplish 빠른 둘러보기와 짧은 데모 영상.
 네. Accomplish는 오픈소스이며 MIT 라이선스입니다.
 
 **어떤 플랫폼을 지원하나요?**
-macOS (Apple Silicon)는 현재 사용 가능합니다. Windows 지원은 곧 제공될 예정입니다.
+macOS (Apple Silicon)와 Windows 11이 현재 사용 가능합니다.
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/accomplish-ai/accomplish/stargazers"><img src="https://img.shields.io/github/stars/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Stars" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/issues"><img src="https://img.shields.io/github/issues/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Issues" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/commits"><img src="https://img.shields.io/github/last-commit/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="Last Commit" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.3.6/macos/Accomplish-0.3.6-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS-0ea5e9?style=flat-square" alt="Download for macOS" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/0.3.8/macos/Accomplish-0.3.8-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS-0ea5e9?style=flat-square" alt="Download for macOS" /></a>
 </p>
 
 # Accomplish™ (formerly Openwork) - Open Source AI Desktop Agent
@@ -23,7 +23,9 @@ Accomplish is an open source AI desktop agent that automates file management, do
 </p>
 
 <p align="center">
-  <a href="https://downloads.accomplish.ai/downloads/0.3.6/macos/Accomplish-0.3.6-mac-arm64.dmg"><strong>Download Accomplish for Mac (Apple Silicon)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/0.3.8/macos/Accomplish-0.3.8-mac-arm64.dmg"><strong>Download for Mac (Apple Silicon)</strong></a>
+  ·
+  <a href="https://downloads.accomplish.ai/downloads/0.3.8/windows/Accomplish-v2-0.3.8-win-x64.exe"><strong>Download for Windows 11</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Accomplish website</a>
   ·
@@ -157,7 +159,7 @@ Accomplish runs locally on your machine. Your files stay on your device, and you
 ## System requirements
 
 - macOS (Apple Silicon)
-- Windows support coming soon
+- Windows 11
 
 <br />
 
@@ -183,7 +185,7 @@ Accomplish runs locally on your machine. Your files stay on your device, and you
 
 <div align="center">
 
-[**Download for Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.3.6/macos/Accomplish-0.3.6-mac-arm64.dmg)
+[**Download for Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.3.8/macos/Accomplish-0.3.8-mac-arm64.dmg) · [**Download for Windows 11**](https://downloads.accomplish.ai/downloads/0.3.8/windows/Accomplish-v2-0.3.8-win-x64.exe)
 
 </div>
 
@@ -220,8 +222,8 @@ You can use your own API keys (OpenAI, Anthropic, Google, xAI, etc.) or run loca
 **Is Accomplish free?**  
 Yes. Accomplish is open source and MIT licensed.
 
-**Which platforms are supported?**  
-macOS (Apple Silicon) is available now. Windows support is coming soon.
+**Which platforms are supported?**
+macOS (Apple Silicon) and Windows 11 are available now.
 
 <br />
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/accomplish-ai/accomplish/stargazers"><img src="https://img.shields.io/github/stars/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Stars" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/issues"><img src="https://img.shields.io/github/issues/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Issues" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/commits"><img src="https://img.shields.io/github/last-commit/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="Son Commit" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.3.6/macos/Accomplish-0.3.6-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS-0ea5e9?style=flat-square" alt="macOS için İndir" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/0.3.8/macos/Accomplish-0.3.8-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS-0ea5e9?style=flat-square" alt="macOS için İndir" /></a>
 </p>
 
 # Accomplish™ - Açık Kaynaklı AI Masaüstü Ajanı
@@ -23,7 +23,9 @@ Accomplish, bilgisayarınızda yerel olarak dosya yönetimi, belge oluşturma ve
 </p>
 
 <p align="center">
-  <a href="https://downloads.accomplish.ai/downloads/0.3.6/macos/Accomplish-0.3.6-mac-arm64.dmg"><strong>Mac için Accomplish'ü İndirin (Apple Silicon)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/0.3.8/macos/Accomplish-0.3.8-mac-arm64.dmg"><strong>Mac için İndirin (Apple Silicon)</strong></a>
+  ·
+  <a href="https://downloads.accomplish.ai/downloads/0.3.8/windows/Accomplish-v2-0.3.8-win-x64.exe"><strong>Windows 11 için İndirin</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Accomplish web sitesi</a>
   ·
@@ -157,7 +159,7 @@ Accomplish bilgisayarınızda yerel olarak çalışır. Dosyalarınız cihazın�
 ## Sistem gereksinimleri
 
 - macOS (Apple Silicon)
-- Windows desteği yakında
+- Windows 11
 
 <br />
 
@@ -183,7 +185,7 @@ Accomplish bilgisayarınızda yerel olarak çalışır. Dosyalarınız cihazın�
 
 <div align="center">
 
-[**Mac için İndirin (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.3.6/macos/Accomplish-0.3.6-mac-arm64.dmg)
+[**Mac için İndirin (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.3.8/macos/Accomplish-0.3.8-mac-arm64.dmg) · [**Windows 11 için İndirin**](https://downloads.accomplish.ai/downloads/0.3.8/windows/Accomplish-v2-0.3.8-win-x64.exe)
 
 </div>
 
@@ -221,7 +223,7 @@ Kendi API anahtarlarınızı (OpenAI, Anthropic, Google, xAI, vb.) kullanabilir 
 Evet. Accomplish açık kaynaklıdır ve MIT lisanslıdır.
 
 **Hangi platformlar destekleniyor?**
-macOS (Apple Silicon) şu anda mevcut. Windows desteği yakında gelecek.
+macOS (Apple Silicon) ve Windows 11 şu anda mevcut.
 
 <br />
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/accomplish-ai/accomplish/stargazers"><img src="https://img.shields.io/github/stars/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Stars" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/issues"><img src="https://img.shields.io/github/issues/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Issues" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/commits"><img src="https://img.shields.io/github/last-commit/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="最近提交" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.3.6/macos/Accomplish-0.3.6-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS-0ea5e9?style=flat-square" alt="下载 macOS 版" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/0.3.8/macos/Accomplish-0.3.8-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS-0ea5e9?style=flat-square" alt="下载 macOS 版" /></a>
 </p>
 
 # Accomplish™ - 开源 AI 桌面代理
@@ -23,7 +23,9 @@ Accomplish 是一款开源 AI 桌面代理，可在您的本地机器上自动�
 </p>
 
 <p align="center">
-  <a href="https://downloads.accomplish.ai/downloads/0.3.6/macos/Accomplish-0.3.6-mac-arm64.dmg"><strong>下载 Mac 版 Accomplish（Apple Silicon）</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/0.3.8/macos/Accomplish-0.3.8-mac-arm64.dmg"><strong>下载 Mac 版（Apple Silicon）</strong></a>
+  ·
+  <a href="https://downloads.accomplish.ai/downloads/0.3.8/windows/Accomplish-v2-0.3.8-win-x64.exe"><strong>下载 Windows 11 版</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Accomplish 官网</a>
   ·
@@ -157,7 +159,7 @@ Accomplish 在您的机器上本地运行。您的文件保留在您的设备上
 ## 系统要求
 
 - macOS（Apple Silicon）
-- Windows 支持即将推出
+- Windows 11
 
 <br />
 
@@ -183,7 +185,7 @@ Accomplish 在您的机器上本地运行。您的文件保留在您的设备上
 
 <div align="center">
 
-[**下载 Mac 版（Apple Silicon）**](https://downloads.accomplish.ai/downloads/0.3.6/macos/Accomplish-0.3.6-mac-arm64.dmg)
+[**下载 Mac 版（Apple Silicon）**](https://downloads.accomplish.ai/downloads/0.3.8/macos/Accomplish-0.3.8-mac-arm64.dmg) · [**下载 Windows 11 版**](https://downloads.accomplish.ai/downloads/0.3.8/windows/Accomplish-v2-0.3.8-win-x64.exe)
 
 </div>
 
@@ -221,7 +223,7 @@ Accomplish 在您的机器上本地运行。您的文件保留在您的设备上
 是的。Accomplish 是开源的，采用 MIT 许可证。
 
 **支持哪些平台？**
-macOS（Apple Silicon）现已可用。Windows 支持即将推出。
+macOS（Apple Silicon）和 Windows 11 现已可用。
 
 <br />
 


### PR DESCRIPTION
## Summary
- Update Mac download links from v0.3.6 to v0.3.8 across all README translations
- Add Windows 11 download links (https://downloads.accomplish.ai/downloads/0.3.8/windows/Accomplish-v2-0.3.8-win-x64.exe)
- Update system requirements and FAQ to reflect Windows 11 is now supported (replacing "coming soon" text)

## Files Changed
- `README.md` (English)
- `README.ar.md` (Arabic)
- `README.es.md` (Spanish)
- `README.id.md` (Indonesian)
- `README.ja.md` (Japanese)
- `README.ko.md` (Korean)
- `README.tr.md` (Turkish)
- `README.zh-CN.md` (Chinese)

## Test plan
- [ ] Verify Mac download link works: https://downloads.accomplish.ai/downloads/0.3.8/macos/Accomplish-0.3.8-mac-arm64.dmg
- [ ] Verify Windows download link works: https://downloads.accomplish.ai/downloads/0.3.8/windows/Accomplish-v2-0.3.8-win-x64.exe

🤖 Generated with [Claude Code](https://claude.ai/claude-code)