### PR TITLE
fix: Update imports and test mocks for agent-core package merge

### DIFF
--- a/apps/desktop/__tests__/unit/main/ipc/handlers.unit.test.ts
+++ b/apps/desktop/__tests__/unit/main/ipc/handlers.unit.test.ts
@@ -137,6 +137,16 @@ vi.mock('@accomplish/agent-core', async (importOriginal) => {
     // Use actual implementation for task config validation
     validateTaskConfig: actual.validateTaskConfig,
 
+    // Use actual implementation for allowed API key providers constant
+    ALLOWED_API_KEY_PROVIDERS: actual.ALLOWED_API_KEY_PROVIDERS,
+
+    // Use actual implementation for standard validation providers constant
+    STANDARD_VALIDATION_PROVIDERS: actual.STANDARD_VALIDATION_PROVIDERS,
+
+    // Use actual implementation for validation schemas and functions
+    validate: actual.validate,
+    permissionResponseSchema: actual.permissionResponseSchema,
+
   // Utility functions
   fetchWithTimeout: vi.fn(() => Promise.resolve(new Response('{}'))),
   createTaskId: vi.fn(() => `task_${Date.now()}`),

--- a/apps/desktop/src/main/store/secureStorage.ts
+++ b/apps/desktop/src/main/store/secureStorage.ts
@@ -1,5 +1,5 @@
 import { app } from 'electron';
-import { SecureStorage, createSecureStorage } from '@accomplish/agent-core/storage';
+import { SecureStorage, createSecureStorage } from '@accomplish/agent-core';
 import type { ApiKeyProvider } from '@accomplish/agent-core';
 
 export type { ApiKeyProvider };


### PR DESCRIPTION
## Summary
- Fix secureStorage.ts to import from @accomplish/agent-core instead of invalid @accomplish/agent-core/storage path
- Update handlers.unit.test.ts mock to include newly required exports from the shared package merge

## Changes
1. **apps/desktop/src/main/store/secureStorage.ts**: Fix import path for SecureStorage
2. **apps/desktop/__tests__/unit/main/ipc/handlers.unit.test.ts**: Add missing exports to mock:
   - ALLOWED_API_KEY_PROVIDERS
   - STANDARD_VALIDATION_PROVIDERS
   - validate
   - permissionResponseSchema

## Test Plan
- [x] Build passes
- [x] Unit tests pass (487 tests)
- [x] Integration tests pass (523 tests)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)