### PR TITLE
fix(agent-core): include server.cjs in published npm package

### DIFF
--- a/.changeset/fix-dev-browser-cjs.md
+++ b/.changeset/fix-dev-browser-cjs.md
@@ -1,0 +1,5 @@
+---
+"@accomplish_ai/agent-core": patch
+---
+
+Include server.cjs launcher files in published npm package by adding `mcp-tools/*/*.cjs` to the files field

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -46,6 +46,7 @@
     "dist",
     "mcp-tools/*/dist",
     "mcp-tools/*/package.json",
+    "mcp-tools/*/*.cjs",
     "mcp-tools/*/*.md",
     "mcp-tools/package.json"
   ],


### PR DESCRIPTION
## Summary
- Added `mcp-tools/*/*.cjs` to the `files` field in `packages/agent-core/package.json`
- The dev-browser `server.cjs` launcher was missing from the published npm package, causing browser automation to fail when consuming `@accomplish_ai/agent-core` from npm

## Test plan
- [x] Verified with `npm pack --dry-run` that `server.cjs` is now included
- [x] Tested locally via `pnpm link` in accomplish-enterprise — dev-browser server starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)