### PR TITLE
chore: add .claude/ and .mcp.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,10 @@ prisma/*.db-journal
 # Docs
 docs/plans/
 
+# Claude Code
+.claude/
+.mcp.json
+
 # Misc
 *.pem
 .turbo/


### PR DESCRIPTION
## Summary
- Adds `.claude/` and `.mcp.json` to `.gitignore` to prevent local Claude Code configuration files from being tracked

## Test plan
- [x] Verify `.claude/` and `.mcp.json` no longer appear in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)