### PR TITLE
feat: add drag and drop file attachments to task input (#190)

### DIFF
--- a/apps/desktop/src/renderer/components/landing/FileAttachmentChip.tsx
+++ b/apps/desktop/src/renderer/components/landing/FileAttachmentChip.tsx
@@ -1,0 +1,97 @@
+import { X, FileText, Image, Code, File } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+
+export interface FileAttachment {
+  id: string;
+  name: string;
+  path: string;
+  type: 'image' | 'text' | 'code' | 'document' | 'other';
+  size: number;
+}
+
+interface FileAttachmentChipProps {
+  attachment: FileAttachment;
+  onRemove: (id: string) => void;
+  disabled?: boolean;
+}
+
+const FILE_TYPE_ICONS = {
+  image: Image,
+  text: FileText,
+  code: Code,
+  document: FileText,
+  other: File,
+} as const;
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function getFileType(fileName: string): FileAttachment['type'] {
+  const ext = fileName.split('.').pop()?.toLowerCase() ?? '';
+
+  const imageExtensions = ['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'bmp', 'ico'];
+  const textExtensions = ['txt', 'md', 'json', 'yaml', 'yml', 'toml', 'csv', 'xml', 'log'];
+  const codeExtensions = ['js', 'ts', 'tsx', 'jsx', 'py', 'rb', 'go', 'rs', 'java', 'c', 'cpp', 'h', 'css', 'html', 'sh', 'sql'];
+  const documentExtensions = ['pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx'];
+
+  if (imageExtensions.includes(ext)) {
+    return 'image';
+  }
+  if (textExtensions.includes(ext)) {
+    return 'text';
+  }
+  if (codeExtensions.includes(ext)) {
+    return 'code';
+  }
+  if (documentExtensions.includes(ext)) {
+    return 'document';
+  }
+  return 'other';
+}
+
+export const MAX_ATTACHMENTS = 5;
+export const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
+
+export function FileAttachmentChip({ attachment, onRemove, disabled }: FileAttachmentChipProps) {
+  const Icon = FILE_TYPE_ICONS[attachment.type];
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          data-testid={`file-chip-${attachment.id}`}
+          className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-muted text-sm text-foreground border border-border hover:bg-muted/80 transition-colors duration-150 max-w-[200px]"
+        >
+          <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <span className="truncate text-xs font-medium">{attachment.name}</span>
+          <span className="text-[10px] text-muted-foreground shrink-0">
+            {formatFileSize(attachment.size)}
+          </span>
+          <button
+            type="button"
+            data-testid={`file-chip-remove-${attachment.id}`}
+            aria-label={`Remove ${attachment.name}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              onRemove(attachment.id);
+            }}
+            disabled={disabled}
+            className="ml-0.5 p-0.5 rounded hover:bg-destructive/20 hover:text-destructive transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>
+        <span>{attachment.path}</span>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/desktop/src/renderer/pages/Home.tsx
+++ b/apps/desktop/src/renderer/pages/Home.tsx
@@ -11,6 +11,7 @@ import { springs, staggerContainer, staggerItem } from '../lib/animations';
 import { Card, CardContent } from '@/components/ui/card';
 import { ChevronDown } from 'lucide-react';
 import { hasAnyReadyProvider } from '@accomplish_ai/agent-core/common';
+import type { FileAttachment } from '../components/landing/FileAttachmentChip';
 
 // Import use case images for proper bundling in production
 import calendarPrepNotesImg from '/assets/usecases/calendar-prep-notes.png';
@@ -85,6 +86,7 @@ export default function HomePage() {
   const [showExamples, setShowExamples] = useState(true);
   const [showSettingsDialog, setShowSettingsDialog] = useState(false);
   const [settingsInitialTab, setSettingsInitialTab] = useState<'providers' | 'voice' | 'skills' | 'connectors'>('providers');
+  const [attachments, setAttachments] = useState<FileAttachment[]>([]);
   const { startTask, isLoading, addTaskUpdate, setPermissionRequest } = useTaskStore();
   const navigate = useNavigate();
   const accomplish = getAccomplish();
@@ -106,17 +108,26 @@ export default function HomePage() {
   }, [addTaskUpdate, setPermissionRequest, accomplish]);
 
   const executeTask = useCallback(async () => {
-    if (!prompt.trim() || isLoading) return;
+    if ((!prompt.trim() && attachments.length === 0) || isLoading) return;
+
+    // Build the full prompt with file context
+    let fullPrompt = prompt.trim();
+    if (attachments.length > 0) {
+      const fileList = attachments.map(a => a.path).join(', ');
+      const prefix = `[Attached files: ${fileList}]`;
+      fullPrompt = fullPrompt ? `${prefix}\n\n${fullPrompt}` : prefix;
+    }
 
     const taskId = `task_${Date.now()}`;
-    const task = await startTask({ prompt: prompt.trim(), taskId });
+    const task = await startTask({ prompt: fullPrompt, taskId });
     if (task) {
+      setAttachments([]);
       navigate(`/execution/${task.id}`);
     }
-  }, [prompt, isLoading, startTask, navigate]);
+  }, [prompt, attachments, isLoading, startTask, navigate]);
 
   const handleSubmit = async () => {
-    if (!prompt.trim() || isLoading) return;
+    if ((!prompt.trim() && attachments.length === 0) || isLoading) return;
 
     // Check if any provider is ready before sending (skip in E2E mode)
     const isE2EMode = await accomplish.isE2EMode();
@@ -173,118 +184,120 @@ export default function HomePage() {
       <div
         className="h-full flex items-center justify-center p-6 overflow-y-auto bg-accent"
       >
-      <div className="w-full max-w-2xl flex flex-col items-center gap-8">
-        {/* Main Title */}
-        <motion.h1
-          data-testid="home-title"
-          initial={{ opacity: 0, y: -20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={springs.gentle}
-          className="text-4xl font-light tracking-tight text-foreground"
-        >
-          What will you accomplish today?
-        </motion.h1>
+        <div className="w-full max-w-2xl flex flex-col items-center gap-8">
+          {/* Main Title */}
+          <motion.h1
+            data-testid="home-title"
+            initial={{ opacity: 0, y: -20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={springs.gentle}
+            className="text-4xl font-light tracking-tight text-foreground"
+          >
+            What will you accomplish today?
+          </motion.h1>
 
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ ...springs.gentle, delay: 0.1 }}
-          className="w-full"
-        >
-          <Card className="w-full bg-card/95 backdrop-blur-md shadow-xl gap-0 py-0 flex flex-col max-h-[calc(100vh-3rem)]">
-            <CardContent className="p-6 pb-4 flex-shrink-0">
-              {/* Input Section */}
-              <TaskInputBar
-                value={prompt}
-                onChange={setPrompt}
-                onSubmit={handleSubmit}
-                isLoading={isLoading}
-                placeholder="Describe a task and let AI handle the rest"
-                large={true}
-                autoFocus={true}
-                onOpenSpeechSettings={handleOpenSpeechSettings}
-                onOpenSettings={(tab) => {
-                  setSettingsInitialTab(tab);
-                  setShowSettingsDialog(true);
-                }}
-                onOpenModelSettings={handleOpenModelSettings}
-                hideModelWhenNoModel={true}
-              />
-            </CardContent>
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ ...springs.gentle, delay: 0.1 }}
+            className="w-full"
+          >
+            <Card className="w-full bg-card/95 backdrop-blur-md shadow-xl gap-0 py-0 flex flex-col max-h-[calc(100vh-3rem)]">
+              <CardContent className="p-6 pb-4 flex-shrink-0">
+                {/* Input Section */}
+                <TaskInputBar
+                  value={prompt}
+                  onChange={setPrompt}
+                  onSubmit={handleSubmit}
+                  isLoading={isLoading}
+                  placeholder="Describe a task and let AI handle the rest"
+                  large={true}
+                  autoFocus={true}
+                  onOpenSpeechSettings={handleOpenSpeechSettings}
+                  onOpenSettings={(tab) => {
+                    setSettingsInitialTab(tab);
+                    setShowSettingsDialog(true);
+                  }}
+                  onOpenModelSettings={handleOpenModelSettings}
+                  hideModelWhenNoModel={true}
+                  attachments={attachments}
+                  onAttachmentsChange={setAttachments}
+                />
+              </CardContent>
 
-            {/* Examples Toggle */}
-            <div className="border-t border-border">
-              <button
-                onClick={() => setShowExamples(!showExamples)}
-                className="w-full px-6 py-3 flex items-center justify-between text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors duration-200"
-              >
-                <span>Example prompts</span>
-                <motion.div
-                  animate={{ rotate: showExamples ? 180 : 0 }}
-                  transition={{ duration: 0.2 }}
+              {/* Examples Toggle */}
+              <div className="border-t border-border">
+                <button
+                  onClick={() => setShowExamples(!showExamples)}
+                  className="w-full px-6 py-3 flex items-center justify-between text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors duration-200"
                 >
-                  <ChevronDown className="h-4 w-4" />
-                </motion.div>
-              </button>
-
-              <AnimatePresence>
-                {showExamples && (
+                  <span>Example prompts</span>
                   <motion.div
-                    initial={{ height: 0, opacity: 0 }}
-                    animate={{ height: 'auto', opacity: 1 }}
-                    exit={{ height: 0, opacity: 0 }}
+                    animate={{ rotate: showExamples ? 180 : 0 }}
                     transition={{ duration: 0.2 }}
-                    className="overflow-hidden"
                   >
-                    <div
-                      className="px-6 pt-1 pb-4 overflow-y-auto max-h-[360px]"
-                      style={{
-                        background: 'linear-gradient(to bottom, hsl(var(--muted)) 0%, hsl(var(--background)) 100%)',
-                        backgroundAttachment: 'fixed',
-                      }}
-                    >
-                      <motion.div
-                        variants={staggerContainer}
-                        initial="initial"
-                        animate="animate"
-                        className="grid grid-cols-3 gap-3"
-                      >
-                        {USE_CASE_EXAMPLES.map((example, index) => (
-                          <motion.button
-                            key={index}
-                            data-testid={`home-example-${index}`}
-                            variants={staggerItem}
-                            transition={springs.gentle}
-                            whileHover={{ scale: 1.03, transition: { duration: 0.15 } }}
-                            whileTap={{ scale: 0.97 }}
-                            onClick={() => handleExampleClick(example.prompt)}
-                            className="flex flex-col items-center gap-2 p-3 rounded-lg border border-border bg-card hover:border-ring hover:bg-muted/50"
-                          >
-                            <img
-                              src={example.image}
-                              alt={example.title}
-                              className="w-12 h-12 object-cover rounded"
-                            />
-                            <div className="flex flex-col items-center gap-1 w-full">
-                              <div className="font-medium text-xs text-foreground text-center">
-                                {example.title}
-                              </div>
-                              <div className="text-xs text-muted-foreground text-center line-clamp-2">
-                                {example.description}
-                              </div>
-                            </div>
-                          </motion.button>
-                        ))}
-                      </motion.div>
-                    </div>
+                    <ChevronDown className="h-4 w-4" />
                   </motion.div>
-                )}
-              </AnimatePresence>
-            </div>
-          </Card>
-        </motion.div>
+                </button>
+
+                <AnimatePresence>
+                  {showExamples && (
+                    <motion.div
+                      initial={{ height: 0, opacity: 0 }}
+                      animate={{ height: 'auto', opacity: 1 }}
+                      exit={{ height: 0, opacity: 0 }}
+                      transition={{ duration: 0.2 }}
+                      className="overflow-hidden"
+                    >
+                      <div
+                        className="px-6 pt-1 pb-4 overflow-y-auto max-h-[360px]"
+                        style={{
+                          background: 'linear-gradient(to bottom, hsl(var(--muted)) 0%, hsl(var(--background)) 100%)',
+                          backgroundAttachment: 'fixed',
+                        }}
+                      >
+                        <motion.div
+                          variants={staggerContainer}
+                          initial="initial"
+                          animate="animate"
+                          className="grid grid-cols-3 gap-3"
+                        >
+                          {USE_CASE_EXAMPLES.map((example, index) => (
+                            <motion.button
+                              key={index}
+                              data-testid={`home-example-${index}`}
+                              variants={staggerItem}
+                              transition={springs.gentle}
+                              whileHover={{ scale: 1.03, transition: { duration: 0.15 } }}
+                              whileTap={{ scale: 0.97 }}
+                              onClick={() => handleExampleClick(example.prompt)}
+                              className="flex flex-col items-center gap-2 p-3 rounded-lg border border-border bg-card hover:border-ring hover:bg-muted/50"
+                            >
+                              <img
+                                src={example.image}
+                                alt={example.title}
+                                className="w-12 h-12 object-cover rounded"
+                              />
+                              <div className="flex flex-col items-center gap-1 w-full">
+                                <div className="font-medium text-xs text-foreground text-center">
+                                  {example.title}
+                                </div>
+                                <div className="text-xs text-muted-foreground text-center line-clamp-2">
+                                  {example.description}
+                                </div>
+                              </div>
+                            </motion.button>
+                          ))}
+                        </motion.div>
+                      </div>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </div>
+            </Card>
+          </motion.div>
+        </div>
       </div>
-    </div>
     </>
   );
 }


### PR DESCRIPTION
- Add FileAttachmentChip component with type detection and size display

- Add drag-and-drop handlers to TaskInputBar with visual drop zone overlay

- Render file chips between textarea and toolbar with remove button

- Prepend attached file paths to prompt on submit in Home.tsx

- Enforce max 5 files and 10MB per file constraints

- Add 9 integration tests for drag-and-drop functionality

Closes #190

## Description

<!-- Brief description of what this PR does -->

## Type of Change

<!-- Mark the relevant option with 'x' -->

- [ ] `feat`: New feature or functionality
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation only changes
- [ ] `chore`: Maintenance, dependencies, or tooling
- [ ] `refactor`: Code refactoring (no feature change)
- [ ] `test`: Adding or updating tests
- [ ] `perf`: Performance improvement
- [ ] `ci`: CI/CD changes

## Checklist

- [ ] PR title follows conventional commit format (e.g., `feat: add dark mode support`)
- [ ] Changes have been tested locally
- [ ] Any new dependencies are justified

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Drag-and-drop file attachment support with visual drop-zone indicator.
  * File attachments display as removable chips with file type icons and metadata.
  * File validation with error handling (maximum 5 files, 10MB each).
  * Attachment data included in task submission.

* **Tests**
  * Added comprehensive integration test suite for attachment drag-and-drop, covering validation, rendering, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->