### PR TITLE
fix: reduce conversational verbosity and tighten prompt policy

### DIFF
--- a/packages/agent-core/src/opencode/config-generator.ts
+++ b/packages/agent-core/src/opencode/config-generator.ts
@@ -140,6 +140,9 @@ In conversational mode:
 - Keep responses concise by default (1-3 sentences)
 - Do NOT proactively list capabilities
 
+Conversational-bypass interactions are not task workflows. The global complete_task
+requirement in TASK COMPLETION applies only to non-conversational task workflows.
+
 Only enter task workflow when the request needs tools, file operations, browsing, or clear
 multi-step execution.
 
@@ -276,7 +279,9 @@ If the user gave you a task with specific criteria (e.g., "find 8-15 results", "
 
 **TASK COMPLETION - CRITICAL:**
 
-You MUST call the \`complete_task\` tool to finish ANY task. Never stop without calling it.
+You MUST call the \`complete_task\` tool to finish every non-conversational task workflow
+(tool-using or multi-step requests). Never stop these workflows without calling it.
+For conversational-bypass responses, do NOT call \`complete_task\`.
 
 When to call \`complete_task\`:
 

--- a/packages/agent-core/tests/unit/opencode/config-generator.test.ts
+++ b/packages/agent-core/tests/unit/opencode/config-generator.test.ts
@@ -451,6 +451,7 @@ describe('ConfigGenerator', () => {
       expect(result.systemPrompt).toContain('start_task');
       expect(result.systemPrompt).toContain('todowrite');
       expect(result.systemPrompt).toContain('complete_task');
+      expect(result.systemPrompt).toContain('finish every non-conversational task workflow');
     });
 
     it('should include conversational bypass rules for simple chat', () => {
@@ -467,6 +468,10 @@ describe('ConfigGenerator', () => {
       expect(result.systemPrompt).toContain('Do NOT call start_task');
       expect(result.systemPrompt).toContain('Do NOT call complete_task');
       expect(result.systemPrompt).toContain('Keep responses concise by default');
+      expect(result.systemPrompt).toContain('Conversational-bypass interactions are not task workflows');
+      expect(result.systemPrompt).toContain(
+        'applies only to non-conversational task workflows'
+      );
     });
 
     it('should include filesystem rules', () => {


### PR DESCRIPTION
## Summary
This PR makes the assistant significantly less verbose for simple conversational messages (for example: "hi", "thanks", short acknowledgements), while preserving the existing strict task workflow for real execution requests.

## Problem
Issue #416 reports that trivial chat inputs trigger noisy task orchestration output:
- task-plan style behavior for simple greetings
- excessive status chatter
- overly detailed browser narration defaults
- capability-style responses when not explicitly requested

This makes basic conversation feel heavy and robotic.

## Root Cause
The generated system prompt strongly enforced a plan-first task workflow and promoted highly descriptive browser narration, without a dedicated conversational bypass policy.

## What Changed
### 1) Conversational bypass policy (new)
In `packages/agent-core/src/opencode/config-generator.ts`:
- Added a dedicated "CONVERSATIONAL BYPASS" section.
- For simple chat/no-tool turns, the prompt now explicitly instructs:
  - do not call `start_task`
  - do not call `todowrite`
  - do not call `complete_task`
  - keep responses concise by default (1-3 sentences)
  - do not proactively list capabilities

### 2) Task workflow scope clarified
In `packages/agent-core/src/opencode/config-generator.ts`:
- Updated wording so mandatory `start_task` behavior is clearly scoped to non-conversational tasks.

### 3) Capability disclosure tightened
In `packages/agent-core/src/opencode/config-generator.ts`:
- Added explicit rule to mention capabilities only when the user asks.

### 4) Browser narration made concise by default
In `packages/agent-core/src/opencode/config-generator.ts`:
- Replaced per-action verbose narration guidance with concise milestone updates.
- Still allows expanded detail when user requests it or when unexpected behavior needs explanation.

<img width="1919" height="1006" alt="Desktop app chat view showing concise handling of a simple greeting without task-orchestration chatter" src="https://github.com/user-attachments/assets/6dc3e93c-3de3-4641-b9e1-e82a071cc42c" />


### 5) Test updates
In `packages/agent-core/tests/unit/opencode/config-generator.test.ts`:
- Added assertions for conversational bypass policy.
- Added assertions for capability disclosure restraint.
- Added assertions for concise browser communication guidance.
- Fixed one cross-platform path assertion (`dist/index.mjs`) for Windows path separators.

## Why This Approach
- High impact with minimal risk: prompt-policy level changes, no core runtime rewrite.
- Existing conversational no-tool completion path already exists in runtime behavior.
- Preserves strict workflow for real tool/file/multi-step tasks.

## Validation
### Automated tests run
- `corepack pnpm --dir packages/agent-core test -- --run tests/unit/opencode/config-generator.test.ts`  
  Result: passed (41/41)

- `corepack pnpm -F @accomplish/desktop test -- __tests__/integration/main/opencode/config-generator.integration.test.ts`  
  Result: passed (17/17)

## Manual Verification Checklist
1. Send `hi` in the desktop app.
   - Expected: short direct reply.
   - Expected: no task orchestration chatter for this conversational turn.

2. Send a real execution request (example: "scan this folder and summarize markdown files").
   - Expected: normal task workflow behavior remains intact.

3. Send a browser task request.
   - Expected: concise milestone updates, not per-click narration.

4. Ask: "what can you do?"
   - Expected: capability response appears only when explicitly requested.

## Scope
This PR is intentionally scoped to verbosity/prompt behavior improvements for Issue #416.

## Related
- Issue: https://github.com/accomplish-ai/accomplish/issues/416


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversational bypass mode for simple chat that avoids task workflows and keeps replies concise.

* **Enhancements**
  * Clear separation between conversational and non-conversational (task) modes with a structured multi-step task workflow and concise browser communication style.
  * Guidance updated to only list capabilities when requested and to provide short, milestone-focused progress updates.

* **Tests**
  * Added/updated tests covering conversational bypass and concise browser guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->