### PR TITLE
fix(desktop): replace hardcoded colors with theme variables for dark mode consistency

### DIFF
--- a/apps/desktop/src/renderer/components/layout/ConversationListItem.tsx
+++ b/apps/desktop/src/renderer/components/layout/ConversationListItem.tsx
@@ -10,6 +10,10 @@ interface ConversationListItemProps {
   task: Task;
 }
 
+/**
+ * Renders a sidebar conversation list item with status icon, task summary, and delete button.
+ * Highlights the active task and navigates to the execution view on click.
+ */
 export default function ConversationListItem({ task }: ConversationListItemProps) {
   const navigate = useNavigate();
   const location = useLocation();

--- a/apps/desktop/src/renderer/components/layout/Header.tsx
+++ b/apps/desktop/src/renderer/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 import { Link, useLocation } from 'react-router-dom';
 import { cn } from '@/lib/utils';
 
+/** Application header with logo, navigation links, and drag region for the Electron window. */
 export default function Header() {
   const location = useLocation();
   const pathname = location.pathname;
@@ -38,6 +39,7 @@ export default function Header() {
   );
 }
 
+/** Navigation link that highlights when the current route matches. */
 function NavLink({
   to,
   active,

--- a/apps/desktop/src/renderer/pages/Execution.tsx
+++ b/apps/desktop/src/renderer/pages/Execution.tsx
@@ -38,7 +38,7 @@ interface DebugLogEntry {
   data?: unknown;
 }
 
-// Spinning Accomplish icon component
+/** Spinning Accomplish logo used as a loading indicator. */
 const SpinningIcon = ({ className }: { className?: string }) => (
   <img
     src={loadingSymbol}
@@ -107,10 +107,10 @@ const TOOL_PROGRESS_MAP: Record<string, { label: string; icon: typeof FileText }
 };
 
 // Extract base tool name from MCP-prefixed tool names
-// MCP tools are prefixed as "servername_toolname", e.g.:
-//   "dev-browser-mcp_browser_navigate" -> "browser_navigate"
-//   "file-permission_request_file_permission" -> "request_file_permission"
-//   "complete-task_complete_task" -> "complete_task"
+/**
+ * Strips MCP server-name prefix from a tool name to find its base identifier.
+ * E.g. "dev-browser-mcp_browser_navigate" -> "browser_navigate".
+ */
 function getBaseToolName(toolName: string): string {
   // Try progressively stripping prefixes at each underscore position
   // to find a match in our map. This handles server names with hyphens
@@ -127,7 +127,7 @@ function getBaseToolName(toolName: string): string {
   return toolName;
 }
 
-// Get tool display info (label and icon) from tool name
+/** Returns the human-readable label and icon for a given tool name. */
 function getToolDisplayInfo(toolName: string): { label: string; icon: typeof FileText } | undefined {
   // First try direct lookup
   if (TOOL_PROGRESS_MAP[toolName]) {
@@ -139,7 +139,7 @@ function getToolDisplayInfo(toolName: string): { label: string; icon: typeof Fil
 }
 
 
-// Debounce utility
+/** Debounce utility that delays invoking {@link fn} until {@link ms} ms after the last call. */
 function debounce<T extends (...args: unknown[]) => void>(fn: T, ms: number): T {
   let timeoutId: ReturnType<typeof setTimeout>;
   return ((...args: unknown[]) => {
@@ -148,7 +148,7 @@ function debounce<T extends (...args: unknown[]) => void>(fn: T, ms: number): T 
   }) as T;
 }
 
-// Helper for file operation badge colors
+/** Returns Tailwind classes for the file-operation badge based on the operation type. */
 function getOperationBadgeClasses(operation?: string): string {
   switch (operation) {
     case 'delete': return 'bg-red-500/10 text-red-600 dark:text-red-400';
@@ -161,12 +161,12 @@ function getOperationBadgeClasses(operation?: string): string {
   }
 }
 
-// Helper to check if this is a delete operation
+/** Checks whether the given permission request represents a file deletion. */
 function isDeleteOperation(request: { type: string; fileOperation?: string }): boolean {
   return request.type === 'file' && request.fileOperation === 'delete';
 }
 
-// Get file paths to display (handles both single and multiple)
+/** Normalises a permission request into an array of display-ready file paths. */
 function getDisplayFilePaths(request: { filePath?: string; filePaths?: string[] }): string[] {
   if (request.filePaths && request.filePaths.length > 0) {
     return request.filePaths;
@@ -177,6 +177,10 @@ function getDisplayFilePaths(request: { filePath?: string; filePaths?: string[] 
   return [];
 }
 
+/**
+ * Main task execution page that displays messages, tool calls, permission requests,
+ * a debug log panel, and the follow-up input bar for a running or completed task.
+ */
 export default function ExecutionPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();


### PR DESCRIPTION
## Summary

- Replaced the hardcoded zinc and text-white color classes with CSS variable-based theme classes (text-muted-foreground, bg-muted, border-border, text-foreground, etc.) so all UI elements properly adapt to light, dark, and system theme preferences.
- **ConversationListItem**: text-zinc-400 changed to text-muted-foreground for cancelled task icon and delete button
- **Header**: text-white changed to text-primary-foreground on logo SVG icon
- **Execution debug panel**: Convert ~30 hardcoded zinc color classes to theme variables (backgrounds, text, borders, search input, log entries, badges, highlights)

## Why

PR #408 added the core dark mode infrastructure (CSS variables, theme.ts, Appearance settings tab, Electron nativeTheme sync). However, several components still used hardcoded zinc color classes that don't respond to theme changes - most notably the entire debug panel in the Execution page, and minor instances in the sidebar and header.

## How to test

1. Run pnpm dev
2. Open Settings then Appearance and switch between System / Light / Dark
3. Verify the sidebar conversation list items (cancelled icon, delete button hover) adapt to the theme
4. Verify the header logo icon uses the correct foreground color
5. Enable Debug Mode in Settings, run a task, and verify the debug panel (header, search bar, log entries, badges, match highlight) all use theme-aware colors in both light and dark modes

Closes #373


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated color palette across the desktop app for improved visual consistency and readability.
  * Refined theming in conversation list items (status icon, delete button hover), header (logo color and nav active styling), and the execution/debug panels (buttons, badges, inputs, logs, borders, and backgrounds).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->