### PR TITLE
chore(ci): add post-merge downstream notification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,3 +219,17 @@ jobs:
           name: windows-test-results
           path: apps/desktop/coverage/
           retention-days: 7
+
+  # Notify downstream repos of changes
+  notify-downstream:
+    name: Notify Downstream
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [core-tests, unit-tests, typecheck]
+    steps:
+      - name: Post-merge hooks
+        run: |
+          gh api "repos/${{ secrets.DISPATCH_TARGET }}/dispatches" \
+            -f event_type=upstream-agent-core-changed
+        env:
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `notify-downstream` job to CI workflow
- Dispatches `repository_dispatch` event after tests pass on push to `main`
- Enables near-real-time downstream sync instead of weekly polling

## Required secrets
Before merging, add these secrets to the repo (Settings → Secrets → Actions):
- `DISPATCH_TOKEN` — PAT with write access to the target repo
- `DISPATCH_TARGET` — target repo in `owner/repo` format

## Test plan
- [ ] Add both secrets to repo settings
- [ ] Merge this PR
- [ ] Push a change to `packages/agent-core/` on main
- [ ] Verify downstream sync workflow triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated notifications to downstream services triggered on main branch updates, enhancing deployment coordination and system synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->