### PR TITLE
fix(desktop): show copy button on messages with continue button

### DIFF
--- a/apps/desktop/src/renderer/pages/Execution.tsx
+++ b/apps/desktop/src/renderer/pages/Execution.tsx
@@ -1693,7 +1693,7 @@ const MessageBubble = memo(function MessageBubble({ message, shouldStream = fals
     }
   }, [message.content]);
 
-  const showCopyButton = !isTool && !(isAssistant && showContinueButton);
+  const showCopyButton = !isTool && !!message.content?.trim();
 
   const proseClasses = cn(
     'text-sm prose prose-sm max-w-none',


### PR DESCRIPTION
[ENG-173](https://accomplish-ai.atlassian.net/browse/ENG-173)

## Summary

- **Copy button visibility**: Show copy-to-clipboard button on messages that have text content, even when a Continue button is present

## Changes

### Bug Fixes
- Changed `showCopyButton` logic in `MessageBubble` to check for actual text content (`!!message.content?.trim()`) instead of hiding the button when `showContinueButton` is active
- No positioning conflicts — Continue button is in normal document flow (`mt-3`), while copy button is absolutely positioned (`absolute bottom-2 right-2`) and only appears on hover

## Test plan

- [x] TypeScript compiles without errors (`pnpm typecheck`)
- [x] Tests pass (`pnpm -F @accomplish/desktop test` — 1017 passed)
- [x] Manual testing:
  - Trigger a message with a Continue button and confirm the copy icon appears on hover
  - Verify messages with no text content (only Continue button) do not show the copy icon

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message copy button availability by making it consistently visible whenever message content is available, enhancing user accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->