### PR TITLE
ci(sync): trigger split refresh on push, not workflow_run

### DIFF
--- a/.github/workflows/refresh-agent-core-split.yml
+++ b/.github/workflows/refresh-agent-core-split.yml
@@ -1,9 +1,9 @@
 name: refresh-agent-core-split
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
+  push:
+    branches: [main]
+    paths: ['packages/agent-core/**']
   workflow_dispatch:
 
 concurrency:
@@ -25,26 +25,14 @@ jobs:
 
   refresh-and-notify:
     if: |
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'workflow_run' &&
-       github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'push' &&
-       github.event.workflow_run.head_branch == 'main')
+      (github.event_name == 'push') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout tested main commit (workflow_run)
-        if: github.event_name == 'workflow_run'
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_sha }}
-
-      - name: Checkout main (workflow_dispatch)
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: main
 
       - name: Refresh agent-core-split
         id: refresh


### PR DESCRIPTION
## Summary
- Replace `workflow_run` trigger with direct `push` trigger on `main` with `paths: ['packages/agent-core/**']`
- No longer waits for CI completion — runs immediately when agent-core changes land on main
- Eliminates ghost skipped runs from PR/dependabot CI completions (was causing 3+ noisy runs per push)
- Simplified checkout step (no conditional refs needed)
- `workflow_dispatch` retained for manual runs

## Why
The `workflow_run` trigger fires for **every** CI workflow completion (PRs, dependabot, cancelled runs), creating noisy skipped runs. It also adds unnecessary latency by waiting for full CI before refreshing the split branch.

## Test plan
- [ ] Push a change to `packages/agent-core/` on main
- [ ] Verify `refresh-agent-core-split` triggers immediately (not after CI)
- [ ] Verify no ghost runs from PR CI completions
- [ ] Verify downstream sync receives the dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow automation for package refresh processes, streamlining event-based triggering and checkout operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->