### PR TITLE
ci(sync): include split SHA in downstream dispatch payload

### DIFF
--- a/.github/workflows/refresh-agent-core-split.yml
+++ b/.github/workflows/refresh-agent-core-split.yml
@@ -63,6 +63,8 @@ jobs:
           if [ "${MAIN_TREE}" = "${SPLIT_TREE}" ]; then
             echo "agent-core-split already matches main subtree. Nothing to refresh."
             echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "split_sha=" >> "$GITHUB_OUTPUT"
+            echo "main_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -71,6 +73,8 @@ jobs:
           for attempt in 1 2 3; do
             if git push origin agent-core-split --force-with-lease; then
               echo "changed=true" >> "$GITHUB_OUTPUT"
+              echo "split_sha=$(git rev-parse agent-core-split)" >> "$GITHUB_OUTPUT"
+              echo "main_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
               exit 0
             fi
 
@@ -89,4 +93,6 @@ jobs:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
         run: |
           gh api "repos/${{ secrets.DISPATCH_TARGET }}/dispatches" \
-            -f event_type=upstream-agent-core-changed
+            -f event_type=upstream-agent-core-changed \
+            -f client_payload[split_sha]="${{ steps.refresh.outputs.split_sha }}" \
+            -f client_payload[main_sha]="${{ steps.refresh.outputs.main_sha }}"


### PR DESCRIPTION
## Summary
- include `split_sha` and `main_sha` in `upstream-agent-core-changed` repository dispatch payload
- keep existing `changed` gate so downstream is notified only when `agent-core-split` moved
- preserve current refresh behavior; this only improves deterministic downstream sync inputs

## Why
Downstream snapshot sync needs the exact `agent-core-split` commit SHA to avoid ancestry-heavy subtree merge behavior and keep a single clean sync commit per PR.

## Notes
- payload fields are optional for downstream (safe fallback exists)
- no behavior change when there is no split update
