### PR TITLE
feat: add daemon architecture for always-on background task execution

### DIFF
--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@accomplish/daemon",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Accomplish Daemon - Always-on background service for task execution",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "start": "node dist/index.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@accomplish_ai/agent-core": "workspace:*",
+    "opencode-ai": "^1.2.1",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.6",
+    "@types/ws": "^8.5.13",
+    "typescript": "^5.7.2"
+  }
+}

--- a/apps/daemon/src/api.ts
+++ b/apps/daemon/src/api.ts
@@ -1,0 +1,297 @@
+import http from 'http';
+import {
+  createTaskId,
+  createMessageId,
+  validateTaskConfig,
+  sanitizeString,
+  generateTaskSummary,
+  mapResultToStatus,
+} from '@accomplish_ai/agent-core';
+import type {
+  TaskManagerAPI,
+  TaskCallbacks,
+  TaskMessage,
+  TaskResult,
+  TaskStatus,
+  StorageAPI,
+  TodoItem,
+  ProviderId,
+  ConnectedProvider,
+} from '@accomplish_ai/agent-core';
+import { broadcast } from './websocket.js';
+import { registerActiveTask, unregisterActiveTask } from './mcp-bridges.js';
+
+const DAEMON_PORT = 9229;
+
+interface RouteContext {
+  taskManager: TaskManagerAPI;
+  storage: StorageAPI;
+}
+
+type RouteHandler = (req: http.IncomingMessage, res: http.ServerResponse, ctx: RouteContext, params: Record<string, string>) => Promise<void>;
+
+async function parseBody<T>(req: http.IncomingMessage): Promise<T> {
+  let body = '';
+  for await (const chunk of req) body += chunk;
+  return JSON.parse(body) as T;
+}
+
+function json(res: http.ServerResponse, status: number, data: unknown): void {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(data));
+}
+
+/**
+ * Create task callbacks that broadcast events via WebSocket and persist to storage.
+ */
+function createDaemonTaskCallbacks(taskId: string, storage: StorageAPI, taskManager: TaskManagerAPI): TaskCallbacks {
+  return {
+    onBatchedMessages(messages: TaskMessage[]) {
+      broadcast({ type: 'task:update', taskId, data: messages });
+      for (const msg of messages) storage.addTaskMessage(taskId, msg);
+    },
+    onProgress(progress) {
+      broadcast({ type: 'task:progress', taskId, data: progress });
+    },
+    onPermissionRequest(request) {
+      broadcast({ type: 'permission:request', data: request });
+    },
+    onComplete(result: TaskResult) {
+      broadcast({ type: 'task:complete', taskId, data: result });
+      storage.updateTaskStatus(taskId, mapResultToStatus(result), new Date().toISOString());
+      const sessionId = result.sessionId || taskManager.getSessionId(taskId);
+      if (sessionId) storage.updateTaskSessionId(taskId, sessionId);
+      if (result.status === 'success') storage.clearTodosForTask(taskId);
+      unregisterActiveTask(taskId);
+    },
+    onError(error: Error) {
+      broadcast({ type: 'task:error', taskId, error: error.message });
+      storage.updateTaskStatus(taskId, 'failed', new Date().toISOString());
+      unregisterActiveTask(taskId);
+    },
+    onStatusChange(status: TaskStatus) {
+      broadcast({ type: 'task:status-change', taskId, status });
+      storage.updateTaskStatus(taskId, status, new Date().toISOString());
+    },
+    onTodoUpdate(todos: TodoItem[]) {
+      storage.saveTodosForTask(taskId, todos);
+      broadcast({ type: 'task:todo-update', taskId, data: todos });
+    },
+    onAuthError(error) {
+      broadcast({ type: 'auth:error', data: error });
+    },
+  };
+}
+
+// --- Route handlers ---
+
+const startTask: RouteHandler = async (req, res, { taskManager, storage }) => {
+  const config = validateTaskConfig(await parseBody(req));
+
+  if (!storage.hasReadyProvider()) {
+    return json(res, 400, { error: 'No provider ready. Connect a provider first.' });
+  }
+
+  const taskId = createTaskId();
+  const model = storage.getActiveProviderModel() || storage.getSelectedModel();
+  if (model?.model) config.modelId = model.model;
+
+  const callbacks = createDaemonTaskCallbacks(taskId, storage, taskManager);
+  registerActiveTask(taskId);
+
+  const task = await taskManager.startTask(taskId, config, callbacks);
+  task.messages = [{
+    id: createMessageId(),
+    type: 'user',
+    content: config.prompt,
+    timestamp: new Date().toISOString(),
+  }];
+  storage.saveTask(task);
+
+  // Generate summary in background
+  generateTaskSummary(config.prompt, (p: string) => storage.getApiKey(p))
+    .then((summary) => storage.updateTaskSummary(taskId, summary))
+    .catch(() => {});
+
+  json(res, 201, task);
+};
+
+const cancelTask: RouteHandler = async (_req, res, { taskManager, storage }, params) => {
+  const { id } = params;
+  if (taskManager.isTaskQueued(id)) {
+    taskManager.cancelQueuedTask(id);
+    storage.updateTaskStatus(id, 'cancelled', new Date().toISOString());
+  } else if (taskManager.hasActiveTask(id)) {
+    await taskManager.cancelTask(id);
+    storage.updateTaskStatus(id, 'cancelled', new Date().toISOString());
+  }
+  json(res, 200, { ok: true });
+};
+
+const getTask: RouteHandler = async (_req, res, { storage }, params) => {
+  const task = storage.getTask(params.id);
+  json(res, task ? 200 : 404, task || { error: 'Not found' });
+};
+
+const listTasks: RouteHandler = async (_req, res, { storage }) => {
+  json(res, 200, storage.getTasks());
+};
+
+const deleteTask: RouteHandler = async (_req, res, { storage }, params) => {
+  storage.deleteTask(params.id);
+  json(res, 200, { ok: true });
+};
+
+const interruptTask: RouteHandler = async (_req, res, { taskManager }, params) => {
+  if (taskManager.hasActiveTask(params.id)) await taskManager.interruptTask(params.id);
+  json(res, 200, { ok: true });
+};
+
+const respondToTask: RouteHandler = async (req, res, { taskManager }, params) => {
+  const { response } = await parseBody<{ response: string }>(req);
+  await taskManager.sendResponse(params.id, sanitizeString(response, 'response', 1024));
+  json(res, 200, { ok: true });
+};
+
+const getProviderSettings: RouteHandler = async (_req, res, { storage }) => {
+  json(res, 200, storage.getProviderSettings());
+};
+
+const getSelectedModel: RouteHandler = async (_req, res, { storage }) => {
+  json(res, 200, storage.getSelectedModel() || null);
+};
+
+const setSelectedModel: RouteHandler = async (req, res, { storage }) => {
+  const model = await parseBody(req);
+  storage.setSelectedModel(model as Parameters<StorageAPI['setSelectedModel']>[0]);
+  json(res, 200, { ok: true });
+};
+
+const storeApiKey: RouteHandler = async (req, res, { storage }, params) => {
+  const { key } = await parseBody<{ key: string }>(req);
+  storage.storeApiKey(params.provider, sanitizeString(key, 'apiKey', 256));
+  json(res, 200, { ok: true });
+};
+
+const deleteApiKey: RouteHandler = async (_req, res, { storage }, params) => {
+  storage.deleteApiKey(params.provider);
+  json(res, 200, { ok: true });
+};
+
+const connectProvider: RouteHandler = async (req, res, { storage }, params) => {
+  const { key, modelId } = await parseBody<{ key: string; modelId: string }>(req);
+  const providerId = params.id as ProviderId;
+
+  storage.storeApiKey(providerId, sanitizeString(key, 'apiKey', 256));
+
+  const provider: ConnectedProvider = {
+    providerId,
+    connectionStatus: 'connected',
+    selectedModelId: modelId,
+    credentials: { type: 'api_key', keyPrefix: key.slice(0, 8) + '...' },
+    lastConnectedAt: new Date().toISOString(),
+  };
+  storage.setConnectedProvider(providerId, provider);
+  storage.setActiveProvider(providerId);
+
+  json(res, 200, { ok: true, providerId, modelId });
+};
+
+const updateProviderModel: RouteHandler = async (req, res, { storage }, params) => {
+  const { modelId } = await parseBody<{ modelId: string }>(req);
+  storage.updateProviderModel(params.id as ProviderId, modelId);
+  json(res, 200, { ok: true });
+};
+
+const activateProvider: RouteHandler = async (_req, res, { storage }, params) => {
+  storage.setActiveProvider(params.id as ProviderId);
+  json(res, 200, { ok: true });
+};
+
+const removeProvider: RouteHandler = async (_req, res, { storage }, params) => {
+  storage.removeConnectedProvider(params.id as ProviderId);
+  storage.deleteApiKey(params.id);
+  json(res, 200, { ok: true });
+};
+
+const healthCheck: RouteHandler = async (_req, res, { taskManager }) => {
+  json(res, 200, {
+    status: 'ok',
+    pid: process.pid,
+    uptime: process.uptime(),
+    activeTasks: taskManager.getActiveTaskCount(),
+    queuedTasks: taskManager.getQueueLength(),
+  });
+};
+
+const shutdown: RouteHandler = async (_req, res) => {
+  json(res, 200, { status: 'shutting down' });
+  // Give time for response to be sent
+  setTimeout(() => process.exit(0), 100);
+};
+
+// --- Router ---
+
+interface Route { method: string; pattern: RegExp; handler: RouteHandler; paramNames: string[] }
+
+function route(method: string, path: string, handler: RouteHandler): Route {
+  const paramNames: string[] = [];
+  const pattern = new RegExp('^' + path.replace(/:(\w+)/g, (_m, name) => {
+    paramNames.push(name);
+    return '([^/]+)';
+  }) + '$');
+  return { method, pattern, handler, paramNames };
+}
+
+const routes: Route[] = [
+  route('GET',    '/health',                healthCheck),
+  route('POST',   '/shutdown',              shutdown),
+  route('POST',   '/tasks',                 startTask),
+  route('GET',    '/tasks',                 listTasks),
+  route('GET',    '/tasks/:id',             getTask),
+  route('DELETE', '/tasks/:id',             deleteTask),
+  route('POST',   '/tasks/:id/cancel',      cancelTask),
+  route('POST',   '/tasks/:id/interrupt',   interruptTask),
+  route('POST',   '/tasks/:id/respond',     respondToTask),
+  route('GET',    '/settings/providers',    getProviderSettings),
+  route('GET',    '/settings/model',        getSelectedModel),
+  route('PUT',    '/settings/model',        setSelectedModel),
+  route('POST',   '/api-keys/:provider',    storeApiKey),
+  route('DELETE', '/api-keys/:provider',    deleteApiKey),
+  route('POST',   '/providers/:id/connect',  connectProvider),
+  route('PUT',    '/providers/:id/model',    updateProviderModel),
+  route('POST',   '/providers/:id/activate', activateProvider),
+  route('DELETE', '/providers/:id',          removeProvider),
+];
+
+export function createApiServer(taskManager: TaskManagerAPI, storage: StorageAPI): http.Server {
+  const ctx: RouteContext = { taskManager, storage };
+
+  const server = http.createServer(async (req, res) => {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+    if (req.method === 'OPTIONS') { res.writeHead(200); res.end(); return; }
+
+    const url = req.url?.split('?')[0] || '/';
+
+    for (const r of routes) {
+      if (req.method !== r.method) continue;
+      const match = url.match(r.pattern);
+      if (!match) continue;
+
+      const params: Record<string, string> = {};
+      r.paramNames.forEach((name, i) => { params[name] = match[i + 1]; });
+
+      await r.handler(req, res, ctx, params);
+      return;
+    }
+
+    json(res, 404, { error: 'Not found' });
+  });
+
+  return server;
+}
+
+export { DAEMON_PORT };

--- a/apps/daemon/src/daemon-options.ts
+++ b/apps/daemon/src/daemon-options.ts
@@ -1,0 +1,121 @@
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import { fileURLToPath } from 'url';
+import type { TaskManagerOptions, TaskConfig, StorageAPI } from '@accomplish_ai/agent-core';
+import {
+  resolveCliPath,
+  buildCliArgs as coreBuildCliArgs,
+  buildOpenCodeEnvironment,
+  getModelDisplayName,
+  generateConfig,
+  buildProviderConfigs,
+  syncApiKeysToOpenCodeAuth,
+  getOpenCodeAuthPath,
+  PERMISSION_API_PORT,
+  QUESTION_API_PORT,
+} from '@accomplish_ai/agent-core';
+import type { EnvironmentConfig } from '@accomplish_ai/agent-core';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DAEMON_ROOT = path.resolve(__dirname, '..');
+
+let storage: StorageAPI;
+let dataDir: string;
+
+export function initDaemonOptions(s: StorageAPI, dir: string): void {
+  storage = s;
+  dataDir = dir;
+}
+
+function getCliCommand(): { command: string; args: string[] } {
+  const resolved = resolveCliPath({ isPackaged: false, appPath: DAEMON_ROOT });
+  if (resolved) return { command: resolved.cliPath, args: [] };
+
+  const local = path.join(DAEMON_ROOT, 'node_modules', 'opencode-ai', 'bin', 'opencode');
+  if (fs.existsSync(local)) return { command: local, args: [] };
+
+  return { command: 'opencode', args: [] };
+}
+
+function getMcpToolsPath(): string {
+  const mono = path.resolve(DAEMON_ROOT, '../../packages/agent-core/mcp-tools');
+  return fs.existsSync(mono) ? mono : path.join(DAEMON_ROOT, 'node_modules', '@accomplish_ai', 'agent-core', 'mcp-tools');
+}
+
+async function buildEnvironment(taskId: string): Promise<NodeJS.ProcessEnv> {
+  const apiKeys = await storage.getAllApiKeys();
+  const activeModel = storage.getActiveProviderModel();
+  const selectedModel = storage.getSelectedModel();
+
+  const envConfig: EnvironmentConfig = {
+    apiKeys,
+    bedrockCredentials: (storage.getBedrockCredentials() as unknown as EnvironmentConfig['bedrockCredentials']) ?? undefined,
+    taskId,
+    openAiBaseUrl: apiKeys.openai ? storage.getOpenAiBaseUrl().trim() || undefined : undefined,
+    ollamaHost:
+      (activeModel?.provider === 'ollama' ? activeModel.baseUrl : null) ||
+      (selectedModel?.provider === 'ollama' ? selectedModel.baseUrl : null) ||
+      undefined,
+  };
+
+  return buildOpenCodeEnvironment({ ...process.env }, envConfig);
+}
+
+async function buildCliArgs(config: TaskConfig): Promise<string[]> {
+  const model = storage.getActiveProviderModel() || storage.getSelectedModel();
+  return coreBuildCliArgs({
+    prompt: config.prompt,
+    sessionId: config.sessionId,
+    selectedModel: model ? { provider: model.provider, model: model.model } : null,
+  });
+}
+
+async function onBeforeStart(): Promise<void> {
+  const apiKeys = await storage.getAllApiKeys();
+  await syncApiKeysToOpenCodeAuth(getOpenCodeAuthPath(), apiKeys);
+
+  const { providerConfigs, enabledProviders, modelOverride } = await buildProviderConfigs({
+    getApiKey: (p: string) => storage.getApiKey(p),
+  });
+
+  const result = generateConfig({
+    platform: process.platform,
+    mcpToolsPath: getMcpToolsPath(),
+    userDataPath: dataDir,
+    isPackaged: false,
+    skills: [],
+    providerConfigs,
+    permissionApiPort: PERMISSION_API_PORT,
+    questionApiPort: QUESTION_API_PORT,
+    enabledProviders,
+    model: modelOverride?.model,
+    smallModel: modelOverride?.smallModel,
+  });
+
+  process.env.OPENCODE_CONFIG = result.configPath;
+  process.env.OPENCODE_CONFIG_DIR = path.dirname(result.configPath);
+  console.log('[Daemon] OpenCode config at:', result.configPath);
+}
+
+export function createDaemonTaskManagerOptions(): TaskManagerOptions {
+  return {
+    adapterOptions: {
+      platform: process.platform,
+      isPackaged: false,
+      tempPath: os.tmpdir(),
+      getCliCommand,
+      buildEnvironment,
+      onBeforeStart,
+      getModelDisplayName,
+      buildCliArgs,
+    },
+    defaultWorkingDirectory: os.tmpdir(),
+    maxConcurrentTasks: 10,
+    isCliAvailable: async () => {
+      const { command } = getCliCommand();
+      return fs.existsSync(command);
+    },
+    async onBeforeTaskStart() {},
+  };
+}

--- a/apps/daemon/src/index.ts
+++ b/apps/daemon/src/index.ts
@@ -1,0 +1,88 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { createStorage, createTaskManager } from '@accomplish_ai/agent-core';
+import { checkExistingDaemon, writePidFile, removePidFile } from './pid.js';
+import { initDaemonOptions, createDaemonTaskManagerOptions } from './daemon-options.js';
+import { setupWebSocket } from './websocket.js';
+import { initMcpBridges, startPermissionServer, startQuestionServer, startThoughtStreamServer } from './mcp-bridges.js';
+import { createApiServer, DAEMON_PORT } from './api.js';
+
+// --- CLI args ---
+
+const args = process.argv.slice(2);
+const portFlag = args.indexOf('--port');
+const port = portFlag !== -1 ? parseInt(args[portFlag + 1], 10) : DAEMON_PORT;
+
+const dataDirFlag = args.indexOf('--data-dir');
+const dataDir = dataDirFlag !== -1
+  ? args[dataDirFlag + 1]
+  : path.join(os.homedir(), '.accomplish', 'data');
+
+// --- Startup ---
+
+const existingPid = checkExistingDaemon();
+if (existingPid) {
+  console.error(`[Daemon] Another instance is already running (pid ${existingPid}). Exiting.`);
+  process.exit(1);
+}
+
+console.log('[Daemon] Starting Accomplish daemon...');
+console.log('[Daemon] Data directory:', dataDir);
+console.log('[Daemon] API port:', port);
+
+// Ensure data directory exists
+fs.mkdirSync(dataDir, { recursive: true });
+
+// Initialize storage
+const storage = createStorage({
+  databasePath: path.join(dataDir, 'accomplish.db'),
+  userDataPath: dataDir,
+  runMigrations: true,
+});
+storage.initialize();
+
+// Initialize daemon options (used by TaskManager)
+initDaemonOptions(storage, dataDir);
+
+// Create TaskManager
+const taskManager = createTaskManager(createDaemonTaskManagerOptions());
+
+// Create HTTP + WebSocket server
+const server = createApiServer(taskManager, storage);
+setupWebSocket(server);
+
+// Initialize MCP bridges (permission, question, thought stream)
+initMcpBridges(() => taskManager.getActiveTaskId());
+startPermissionServer();
+startQuestionServer();
+startThoughtStreamServer();
+
+// Start listening
+server.listen(port, '127.0.0.1', () => {
+  console.log(`[Daemon] API server listening on http://127.0.0.1:${port}`);
+  console.log('[Daemon] WebSocket available at ws://127.0.0.1:' + port + '/ws');
+  writePidFile();
+});
+
+// --- Graceful shutdown ---
+
+function shutdown(): void {
+  console.log('[Daemon] Shutting down...');
+  taskManager.dispose();
+  storage.close();
+  removePidFile();
+  server.close();
+  process.exit(0);
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
+
+process.on('uncaughtException', (err) => {
+  console.error('[Daemon] Uncaught exception:', err);
+});
+
+process.on('unhandledRejection', (reason) => {
+  console.error('[Daemon] Unhandled rejection:', reason);
+});

--- a/apps/daemon/src/mcp-bridges.ts
+++ b/apps/daemon/src/mcp-bridges.ts
@@ -1,0 +1,154 @@
+import http from 'http';
+import {
+  PERMISSION_API_PORT,
+  QUESTION_API_PORT,
+  THOUGHT_STREAM_PORT,
+  createPermissionHandler,
+  createThoughtStreamHandler,
+} from '@accomplish_ai/agent-core';
+import type {
+  PermissionHandlerAPI,
+  ThoughtStreamAPI,
+} from '@accomplish_ai/agent-core';
+import { broadcast, onClientMessage } from './websocket.js';
+import type { ClientMessage } from './websocket.js';
+
+const permissionHandler: PermissionHandlerAPI = createPermissionHandler();
+const thoughtStreamHandler: ThoughtStreamAPI = createThoughtStreamHandler();
+
+let getActiveTaskId: (() => string | null) | null = null;
+
+export function initMcpBridges(taskIdGetter: () => string | null): void {
+  getActiveTaskId = taskIdGetter;
+
+  // Listen for permission/question responses from WebSocket clients
+  onClientMessage((msg: ClientMessage) => {
+    if (msg.type === 'permission:response') {
+      permissionHandler.resolvePermissionRequest(msg.requestId, msg.allowed);
+    } else if (msg.type === 'question:response') {
+      permissionHandler.resolveQuestionRequest(msg.requestId, msg.data as Record<string, unknown>);
+    }
+  });
+}
+
+export function registerActiveTask(taskId: string): void {
+  thoughtStreamHandler.registerTask(taskId);
+}
+
+export function unregisterActiveTask(taskId: string): void {
+  thoughtStreamHandler.unregisterTask(taskId);
+}
+
+/**
+ * Parse JSON body from an HTTP request.
+ */
+async function parseBody<T>(req: http.IncomingMessage): Promise<T> {
+  let body = '';
+  for await (const chunk of req) body += chunk;
+  return JSON.parse(body) as T;
+}
+
+/**
+ * Set common CORS headers on a response.
+ */
+function setCors(res: http.ServerResponse): void {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}
+
+function json(res: http.ServerResponse, status: number, data: unknown): void {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(data));
+}
+
+function createMcpServer(
+  port: number,
+  label: string,
+  handler: (req: http.IncomingMessage, res: http.ServerResponse) => void
+): http.Server {
+  const server = http.createServer((req, res) => {
+    setCors(res);
+    if (req.method === 'OPTIONS') { res.writeHead(200); res.end(); return; }
+    handler(req, res);
+  });
+
+  server.listen(port, '127.0.0.1', () => {
+    console.log(`[${label}] Listening on port ${port}`);
+  });
+
+  server.on('error', (err: NodeJS.ErrnoException) => {
+    if (err.code === 'EADDRINUSE') {
+      console.warn(`[${label}] Port ${port} in use, skipping`);
+    } else {
+      console.error(`[${label}] Error:`, err);
+    }
+  });
+
+  return server;
+}
+
+export function startPermissionServer(): http.Server {
+  return createMcpServer(PERMISSION_API_PORT, 'Permission API', async (req, res) => {
+    if (req.method !== 'POST' || req.url !== '/permission') return json(res, 404, { error: 'Not found' });
+
+    const data = await parseBody(req);
+    const validation = permissionHandler.validateFilePermissionRequest(data as Record<string, unknown>);
+    if (!validation.valid) return json(res, 400, { error: validation.error });
+
+    const taskId = getActiveTaskId?.();
+    if (!taskId) return json(res, 400, { error: 'No active task' });
+
+    const { requestId, promise } = permissionHandler.createPermissionRequest();
+    const permReq = permissionHandler.buildFilePermissionRequest(requestId, taskId, data as Record<string, unknown>);
+
+    // Forward to UI clients via WebSocket
+    broadcast({ type: 'permission:request', data: permReq });
+
+    const allowed = await promise;
+    json(res, 200, { allowed });
+  });
+}
+
+export function startQuestionServer(): http.Server {
+  return createMcpServer(QUESTION_API_PORT, 'Question API', async (req, res) => {
+    if (req.method !== 'POST' || req.url !== '/question') return json(res, 404, { error: 'Not found' });
+
+    const data = await parseBody(req);
+    const validation = permissionHandler.validateQuestionRequest(data as Record<string, unknown>);
+    if (!validation.valid) return json(res, 400, { error: validation.error });
+
+    const taskId = getActiveTaskId?.();
+    if (!taskId) return json(res, 400, { error: 'No active task' });
+
+    const { requestId, promise } = permissionHandler.createQuestionRequest();
+    const questionReq = permissionHandler.buildQuestionRequest(requestId, taskId, data as Record<string, unknown>);
+
+    broadcast({ type: 'permission:request', data: questionReq });
+
+    const response = await promise;
+    json(res, 200, response);
+  });
+}
+
+export function startThoughtStreamServer(): http.Server {
+  return createMcpServer(THOUGHT_STREAM_PORT, 'Thought Stream', async (req, res) => {
+    if (req.method !== 'POST') return json(res, 404, { error: 'Not found' });
+
+    const data = await parseBody<Record<string, unknown>>(req);
+    const taskId = data.taskId as string;
+
+    if (!taskId || !thoughtStreamHandler.isTaskActive(taskId)) {
+      res.writeHead(200); res.end(); return;
+    }
+
+    if (req.url === '/thought') {
+      broadcast({ type: 'task:thought', data });
+    } else if (req.url === '/checkpoint') {
+      broadcast({ type: 'task:checkpoint', data });
+    }
+
+    res.writeHead(200);
+    res.end();
+  });
+}

--- a/apps/daemon/src/pid.ts
+++ b/apps/daemon/src/pid.ts
@@ -1,0 +1,64 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+const PID_DIR = path.join(os.homedir(), '.accomplish');
+const PID_FILE = path.join(PID_DIR, 'daemon.pid');
+
+/**
+ * Check if a process with the given PID is still running.
+ * process.kill(pid, 0) throws ESRCH if the process doesn't exist,
+ * or EPERM if it exists but we lack permission (still means it's running).
+ */
+function isProcessRunning(pid: number): boolean {
+  try { process.kill(pid, 0); return true; }
+  catch (e) { return (e as NodeJS.ErrnoException).code === 'EPERM'; }
+}
+
+/**
+ * Check if another daemon instance is already running.
+ * Returns the PID if running, null otherwise.
+ * Cleans up stale PID files automatically.
+ */
+export function checkExistingDaemon(): number | null {
+  if (!fs.existsSync(PID_FILE)) return null;
+
+  const raw = fs.readFileSync(PID_FILE, 'utf-8').trim();
+  const pid = parseInt(raw, 10);
+
+  if (isNaN(pid)) {
+    removePidFile();
+    return null;
+  }
+
+  if (!isProcessRunning(pid)) {
+    console.log(`[Daemon] Removing stale PID file (pid ${pid} not running)`);
+    removePidFile();
+    return null;
+  }
+
+  return pid;
+}
+
+/**
+ * Write the current process PID to the PID file.
+ */
+export function writePidFile(): void {
+  fs.mkdirSync(PID_DIR, { recursive: true });
+  fs.writeFileSync(PID_FILE, String(process.pid), 'utf-8');
+  console.log(`[Daemon] PID file written: ${PID_FILE} (pid ${process.pid})`);
+}
+
+/**
+ * Remove the PID file if it exists.
+ */
+export function removePidFile(): void {
+  if (fs.existsSync(PID_FILE)) {
+    fs.unlinkSync(PID_FILE);
+    console.log('[Daemon] PID file removed');
+  }
+}
+
+export function getPidFilePath(): string {
+  return PID_FILE;
+}

--- a/apps/daemon/src/websocket.ts
+++ b/apps/daemon/src/websocket.ts
@@ -1,0 +1,68 @@
+import { WebSocketServer, WebSocket } from 'ws';
+import type { Server } from 'http';
+
+export type DaemonEvent =
+  | { type: 'task:update'; taskId: string; data: unknown }
+  | { type: 'task:progress'; taskId: string; data: unknown }
+  | { type: 'task:status-change'; taskId: string; status: string }
+  | { type: 'task:complete'; taskId: string; data: unknown }
+  | { type: 'task:error'; taskId: string; error: string }
+  | { type: 'task:thought'; data: unknown }
+  | { type: 'task:checkpoint'; data: unknown }
+  | { type: 'task:todo-update'; taskId: string; data: unknown }
+  | { type: 'permission:request'; data: unknown }
+  | { type: 'auth:error'; data: unknown };
+
+export type ClientMessage =
+  | { type: 'permission:response'; requestId: string; allowed: boolean }
+  | { type: 'question:response'; requestId: string; data: unknown };
+
+type MessageHandler = (clientMessage: ClientMessage) => void;
+
+let wss: WebSocketServer | null = null;
+const messageHandlers = new Set<MessageHandler>();
+
+export function setupWebSocket(server: Server): WebSocketServer {
+  wss = new WebSocketServer({ server, path: '/ws' });
+
+  wss.on('connection', (ws) => {
+    console.log('[WebSocket] Client connected. Total:', wss!.clients.size);
+
+    ws.on('message', (raw) => {
+      const msg = JSON.parse(raw.toString()) as ClientMessage;
+      messageHandlers.forEach((handler) => handler(msg));
+    });
+
+    ws.on('close', () => {
+      console.log('[WebSocket] Client disconnected. Total:', wss!.clients.size);
+    });
+  });
+
+  console.log('[WebSocket] Server ready on /ws');
+  return wss;
+}
+
+/**
+ * Broadcast an event to all connected WebSocket clients.
+ */
+export function broadcast(event: DaemonEvent): void {
+  if (!wss) return;
+  const data = JSON.stringify(event);
+  wss.clients.forEach((client) => {
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(data);
+    }
+  });
+}
+
+/**
+ * Register a handler for incoming client messages (permission/question responses).
+ */
+export function onClientMessage(handler: MessageHandler): () => void {
+  messageHandlers.add(handler);
+  return () => messageHandlers.delete(handler);
+}
+
+export function getConnectedClientCount(): number {
+  return wss?.clients.size ?? 0;
+}

--- a/apps/daemon/tsconfig.json
+++ b/apps/daemon/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -69,10 +69,12 @@
     "react-markdown": "^9.0.1",
     "react-router-dom": "^7.1.1",
     "tailwind-merge": "^3.3.1",
+    "ws": "^8.18.0",
     "zod": "^3.24.1",
     "zustand": "^5.0.2"
   },
   "devDependencies": {
+    "@types/ws": "^8.5.13",
     "@electron/rebuild": "^4.0.2",
     "@playwright/test": "^1.57.0",
     "@tailwindcss/typography": "^0.5.15",

--- a/apps/desktop/src/main/daemon-client.ts
+++ b/apps/desktop/src/main/daemon-client.ts
@@ -1,0 +1,195 @@
+/**
+ * Daemon Client
+ *
+ * Connects the Electron app to the daemon process via HTTP REST + WebSocket.
+ * Replaces direct TaskManager/Storage usage in the main process.
+ */
+
+import http from 'http';
+import { spawn, type ChildProcess } from 'child_process';
+import path from 'path';
+import WebSocket from 'ws';
+import type { BrowserWindow } from 'electron';
+
+const DAEMON_PORT = 9229;
+const DAEMON_URL = `http://127.0.0.1:${DAEMON_PORT}`;
+const WS_URL = `ws://127.0.0.1:${DAEMON_PORT}/ws`;
+
+let ws: WebSocket | null = null;
+let daemonProcess: ChildProcess | null = null;
+let mainWindow: BrowserWindow | null = null;
+
+// --- HTTP Client ---
+
+function request<T = unknown>(method: string, urlPath: string, body?: unknown): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const url = new URL(urlPath, DAEMON_URL);
+    const data = body ? JSON.stringify(body) : undefined;
+
+    const req = http.request(url, { method, headers: { 'Content-Type': 'application/json' } }, (res) => {
+      let raw = '';
+      res.on('data', (chunk) => { raw += chunk; });
+      res.on('end', () => {
+        const parsed = JSON.parse(raw) as T;
+        if (res.statusCode && res.statusCode >= 400) {
+          reject(new Error((parsed as Record<string, string>).error || `HTTP ${res.statusCode}`));
+        } else {
+          resolve(parsed);
+        }
+      });
+    });
+
+    req.on('error', reject);
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+export const daemon = {
+  // Health
+  health: () => request<{ status: string; pid: number; activeTasks: number }>('GET', '/health'),
+
+  // Tasks
+  startTask: (config: Record<string, unknown>) => request('POST', '/tasks', config),
+  listTasks: () => request('GET', '/tasks'),
+  getTask: (id: string) => request('GET', `/tasks/${id}`),
+  deleteTask: (id: string) => request('DELETE', `/tasks/${id}`),
+  cancelTask: (id: string) => request('POST', `/tasks/${id}/cancel`),
+  interruptTask: (id: string) => request('POST', `/tasks/${id}/interrupt`),
+  respondToTask: (id: string, response: string) => request('POST', `/tasks/${id}/respond`, { response }),
+
+  // Settings
+  getProviderSettings: () => request('GET', '/settings/providers'),
+  getSelectedModel: () => request('GET', '/settings/model'),
+  setSelectedModel: (model: unknown) => request('PUT', '/settings/model', model),
+
+  // API Keys
+  storeApiKey: (provider: string, key: string) => request('POST', `/api-keys/${provider}`, { key }),
+  deleteApiKey: (provider: string) => request('DELETE', `/api-keys/${provider}`),
+
+  // Shutdown
+  shutdown: () => request('POST', '/shutdown'),
+};
+
+// --- WebSocket Connection ---
+
+function connectWebSocket(): void {
+  if (ws) return;
+
+  ws = new WebSocket(WS_URL);
+
+  ws.on('open', () => {
+    console.log('[Daemon Client] WebSocket connected');
+  });
+
+  ws.on('message', (raw) => {
+    if (!mainWindow || mainWindow.isDestroyed()) return;
+    const event = JSON.parse(raw.toString()) as { type: string; taskId?: string; data?: unknown; status?: string; error?: string };
+
+    // Map daemon events to existing Electron IPC channels
+    const channelMap: Record<string, string> = {
+      'task:update': 'task:update:batch',
+      'task:progress': 'task:progress',
+      'task:status-change': 'task:status-change',
+      'task:complete': 'task:update',
+      'task:error': 'task:update',
+      'task:thought': 'task:thought',
+      'task:checkpoint': 'task:checkpoint',
+      'task:todo-update': 'todo:update',
+      'permission:request': 'permission:request',
+      'auth:error': 'auth:error',
+    };
+
+    const channel = channelMap[event.type];
+    if (!channel) return;
+
+    // Format data to match what the renderer expects
+    if (event.type === 'task:update') {
+      mainWindow.webContents.send(channel, { taskId: event.taskId, messages: event.data });
+    } else if (event.type === 'task:complete') {
+      mainWindow.webContents.send(channel, { taskId: event.taskId, type: 'complete', result: event.data });
+    } else if (event.type === 'task:error') {
+      mainWindow.webContents.send(channel, { taskId: event.taskId, type: 'error', error: event.error });
+    } else if (event.type === 'task:progress') {
+      mainWindow.webContents.send(channel, { taskId: event.taskId, ...event.data as object });
+    } else if (event.type === 'task:status-change') {
+      mainWindow.webContents.send(channel, { taskId: event.taskId, status: event.status });
+    } else if (event.type === 'task:todo-update') {
+      mainWindow.webContents.send(channel, { taskId: event.taskId, todos: event.data });
+    } else {
+      mainWindow.webContents.send(channel, event.data);
+    }
+  });
+
+  ws.on('close', () => {
+    console.log('[Daemon Client] WebSocket disconnected, reconnecting in 2s...');
+    ws = null;
+    setTimeout(connectWebSocket, 2000);
+  });
+
+  ws.on('error', (err) => {
+    console.warn('[Daemon Client] WebSocket error:', err.message);
+    ws?.close();
+    ws = null;
+  });
+}
+
+/**
+ * Send a message to the daemon via WebSocket (for permission/question responses).
+ */
+export function sendWsMessage(msg: Record<string, unknown>): void {
+  if (ws?.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify(msg));
+  }
+}
+
+// --- Daemon Lifecycle ---
+
+/**
+ * Check if the daemon is running by hitting the health endpoint.
+ */
+export async function isDaemonRunning(): Promise<boolean> {
+  return daemon.health().then(() => true).catch(() => false);
+}
+
+/**
+ * Spawn the daemon as a detached child process.
+ */
+export function spawnDaemon(): void {
+  const daemonScript = path.join(process.cwd(), 'apps', 'daemon', 'dist', 'index.js');
+  console.log('[Daemon Client] Spawning daemon:', daemonScript);
+
+  daemonProcess = spawn('node', [daemonScript], {
+    detached: true,
+    stdio: 'ignore',
+    env: { ...process.env },
+  });
+
+  daemonProcess.unref();
+  console.log('[Daemon Client] Daemon spawned with pid:', daemonProcess.pid);
+}
+
+/**
+ * Ensure the daemon is running, spawning it if needed.
+ * Then connect the WebSocket for real-time events.
+ */
+export async function ensureDaemon(window: BrowserWindow): Promise<void> {
+  mainWindow = window;
+
+  if (!(await isDaemonRunning())) {
+    spawnDaemon();
+
+    // Wait for daemon to be ready (poll health endpoint)
+    for (let i = 0; i < 30; i++) {
+      await new Promise((r) => setTimeout(r, 500));
+      if (await isDaemonRunning()) break;
+    }
+  }
+
+  connectWebSocket();
+}
+
+export function disconnectDaemon(): void {
+  ws?.close();
+  ws = null;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,28 @@ importers:
         specifier: ^19.0.0
         version: 19.2.3(react@19.2.3)
 
+  apps/daemon:
+    dependencies:
+      '@accomplish_ai/agent-core':
+        specifier: workspace:*
+        version: link:../../packages/agent-core
+      opencode-ai:
+        specifier: ^1.2.1
+        version: 1.2.1
+      ws:
+        specifier: ^8.18.0
+        version: 8.19.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.6
+        version: 22.19.3
+      '@types/ws':
+        specifier: ^8.5.13
+        version: 8.18.1
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+
   apps/desktop:
     dependencies:
       '@accomplish_ai/agent-core':
@@ -107,6 +129,9 @@ importers:
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.4.0
+      ws:
+        specifier: ^8.18.0
+        version: 8.19.0
       zod:
         specifier: ^3.24.1
         version: 3.25.76
@@ -144,6 +169,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.2
         version: 19.2.3(@types/react@19.2.7)
+      '@types/ws':
+        specifier: ^8.5.13
+        version: 8.18.1
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.7.0(vite@6.4.1(@types/node@22.19.3)(jiti@1.21.7))
@@ -4856,6 +4884,7 @@ packages:
   tar@7.5.7:
     resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   temp-file@3.4.0:
     resolution: {integrity: sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==}


### PR DESCRIPTION
## Summary
- Adds a new `apps/daemon/` package — a standalone Node.js daemon process with HTTP REST API (port 9229) + WebSocket for real-time events
- Daemon manages TaskManager, Storage (SQLite), and MCP HTTP bridges independently of the Electron UI
- Electron app connects to the daemon as a client, spawning it on startup if not already running
- Enables task execution from any HTTP client (curl, scripts, CLI tools, scheduled jobs) without the UI open

## New Files
- `apps/daemon/src/api.ts` — REST API: tasks, providers, settings, health, shutdown
- `apps/daemon/src/websocket.ts` — WebSocket server broadcasting task events
- `apps/daemon/src/mcp-bridges.ts` — MCP HTTP bridges (permission, question, thought stream)
- `apps/daemon/src/daemon-options.ts` — Standalone TaskManager options (no Electron deps)
- `apps/daemon/src/pid.ts` — PID file management for single-instance enforcement
- `apps/daemon/src/index.ts` — Daemon entry point with graceful shutdown
- `apps/desktop/src/main/daemon-client.ts` — Electron ↔ daemon HTTP + WebSocket client

## Modified Files
- `apps/desktop/src/main/index.ts` — Connects to daemon on startup
- `apps/desktop/package.json` — Added `ws` dependency

## API

- `GET /health` — check if daemon is running
- `POST /providers/:id/connect` — add API key and model
- `POST /tasks` — run a task
- `GET /tasks/:id` — get task status/result
- `GET /tasks` — list tasks
- `POST /tasks/:id/cancel` — cancel a task
- `POST /tasks/:id/respond` — reply to a task prompt
- `POST /shutdown` — stop the daemon


## Test plan
- [ ] Build daemon: `cd apps/daemon && pnpm build`
- [ ] Start daemon: `node apps/daemon/dist/index.js`
- [ ] Verify health: `curl http://127.0.0.1:9229/health`
- [ ] Connect provider: `POST /providers/anthropic/connect` with API key and model
- [ ] Start task: `POST /tasks` with prompt
- [ ] Verify task completes: `GET /tasks/:id`
- [ ] Start Electron app and verify it connects to daemon
- [ ] Close Electron app and verify daemon keeps running

Closes #402


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

- **Background Daemon Service:** Launched a standalone daemon process enabling task execution independent of the desktop app, with automatic lifecycle management
- **Real-Time Event Streaming:** Added WebSocket support for live task updates, progress tracking, and status changes
- **REST API:** Implemented comprehensive API endpoints for task management, provider configuration, API key storage, and daemon control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->