### PR TITLE
feat: add bug report and repeat task in debug mode

### DIFF
--- a/apps/desktop/__tests__/unit/main/ipc/handlers.unit.test.ts
+++ b/apps/desktop/__tests__/unit/main/ipc/handlers.unit.test.ts
@@ -63,6 +63,11 @@ vi.mock('electron', () => {
         webContents: {
           send: vi.fn(),
           isDestroyed: vi.fn(() => false),
+          capturePage: vi.fn(() => Promise.resolve({
+            toPNG: () => Buffer.from('fake-png-data'),
+            getSize: () => ({ width: 1920, height: 1080 }),
+          })),
+          executeJavaScript: vi.fn(() => Promise.resolve('{"tag":"body"}')),
         },
       })),
       getFocusedWindow: vi.fn(() => ({
@@ -71,12 +76,21 @@ vi.mock('electron', () => {
       })),
       getAllWindows: vi.fn(() => [{ id: 1, webContents: { send: vi.fn() } }]),
     },
+    dialog: {
+      showSaveDialog: vi.fn(() => Promise.resolve({ canceled: false, filePath: '/tmp/bug-report.json' })),
+      showOpenDialog: vi.fn(() => Promise.resolve({ canceled: false, filePaths: [] })),
+    },
+    nativeTheme: {
+      themeSource: 'system',
+      shouldUseDarkColors: false,
+    },
     shell: {
       openExternal: vi.fn(),
     },
     app: {
       isPackaged: false,
       getPath: vi.fn(() => '/tmp/test-app'),
+      getVersion: vi.fn(() => '1.0.0-test'),
     },
   };
 });
@@ -366,9 +380,27 @@ vi.mock('@main/permission-api', () => ({
   QUESTION_API_PORT: 9227,
 }));
 
+// Mock fs module for bug report file writes
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      writeFileSync: vi.fn(),
+      existsSync: vi.fn(() => false),
+      copyFileSync: vi.fn(),
+    },
+    writeFileSync: vi.fn(),
+    existsSync: vi.fn(() => false),
+    copyFileSync: vi.fn(),
+  };
+});
+
 // Import after mocks are set up
 import { registerIPCHandlers } from '@main/ipc/handlers';
-import { ipcMain, BrowserWindow, shell } from 'electron';
+import { ipcMain, BrowserWindow, shell, dialog } from 'electron';
+import fs from 'fs';
 
 // Type the mocked ipcMain with helpers
 type MockedIpcMain = typeof ipcMain & {
@@ -2054,4 +2086,233 @@ describe('IPC Handlers Integration', () => {
   // The callback logic is exercised through the task lifecycle tests above.
   // The utility functions (extractScreenshots, sanitizeToolOutput)
   // are tested in handlers-utils.unit.test.ts as pure function tests.
+
+  describe('Debug Bug Report Handlers', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      mockedIpcMain._clear();
+
+      // Reset BrowserWindow mock to include capturePage and executeJavaScript
+      (BrowserWindow.fromWebContents as Mock).mockReturnValue({
+        id: 1,
+        isDestroyed: vi.fn(() => false),
+        webContents: {
+          send: vi.fn(),
+          isDestroyed: vi.fn(() => false),
+          capturePage: vi.fn(() => Promise.resolve({
+            toPNG: () => Buffer.from('fake-png-data'),
+            getSize: () => ({ width: 1920, height: 1080 }),
+          })),
+          executeJavaScript: vi.fn(() => Promise.resolve('{"tag":"body","children":[]}')),
+        },
+      });
+      (BrowserWindow.getFocusedWindow as Mock).mockReturnValue({ id: 1, isDestroyed: () => false });
+      (BrowserWindow.getAllWindows as Mock).mockReturnValue([{ id: 1, webContents: { send: vi.fn() } }]);
+
+      // Reset dialog mock
+      (dialog.showSaveDialog as Mock).mockResolvedValue({
+        canceled: false,
+        filePath: '/tmp/bug-report.json',
+      });
+
+      // Reset fs mocks
+      (fs.writeFileSync as Mock).mockReset();
+
+      registerIPCHandlers();
+    });
+
+    it('should register all three debug handlers', () => {
+      const handlers = mockedIpcMain._getHandlers();
+      expect(handlers.has('debug:capture-screenshot')).toBe(true);
+      expect(handlers.has('debug:capture-axtree')).toBe(true);
+      expect(handlers.has('debug:generate-bug-report')).toBe(true);
+    });
+
+    it('debug:capture-screenshot should return base64 PNG data', async () => {
+      const result = await invokeHandler('debug:capture-screenshot') as {
+        success: boolean;
+        data: string;
+        width: number;
+        height: number;
+      };
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(Buffer.from('fake-png-data').toString('base64'));
+      expect(result.width).toBe(1920);
+      expect(result.height).toBe(1080);
+    });
+
+    it('debug:capture-screenshot should handle errors gracefully', async () => {
+      (BrowserWindow.fromWebContents as Mock).mockReturnValue({
+        id: 1,
+        isDestroyed: vi.fn(() => false),
+        webContents: {
+          send: vi.fn(),
+          isDestroyed: vi.fn(() => false),
+          capturePage: vi.fn(() => Promise.reject(new Error('Capture failed'))),
+          executeJavaScript: vi.fn(),
+        },
+      });
+
+      const result = await invokeHandler('debug:capture-screenshot') as {
+        success: boolean;
+        error: string;
+      };
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Capture failed');
+    });
+
+    it('debug:capture-axtree should return JSON string', async () => {
+      const result = await invokeHandler('debug:capture-axtree') as {
+        success: boolean;
+        data: string;
+      };
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe('{"tag":"body","children":[]}');
+    });
+
+    it('debug:capture-axtree should handle errors gracefully', async () => {
+      (BrowserWindow.fromWebContents as Mock).mockReturnValue({
+        id: 1,
+        isDestroyed: vi.fn(() => false),
+        webContents: {
+          send: vi.fn(),
+          isDestroyed: vi.fn(() => false),
+          capturePage: vi.fn(),
+          executeJavaScript: vi.fn(() => Promise.reject(new Error('Script execution failed'))),
+        },
+      });
+
+      const result = await invokeHandler('debug:capture-axtree') as {
+        success: boolean;
+        error: string;
+      };
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Script execution failed');
+    });
+
+    it('debug:generate-bug-report should save report via dialog and return success', async () => {
+      const reportData = {
+        taskId: 'task_123',
+        taskPrompt: 'Test prompt',
+        taskStatus: 'completed',
+        messages: [{ type: 'user', content: 'hello' }],
+        debugLogs: [{ type: 'info', message: 'log entry' }],
+      };
+
+      const result = await invokeHandler('debug:generate-bug-report', reportData) as {
+        success: boolean;
+        path: string;
+      };
+
+      expect(result.success).toBe(true);
+      expect(result.path).toBe('/tmp/bug-report.json');
+      expect(dialog.showSaveDialog).toHaveBeenCalled();
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+
+      const writtenContent = JSON.parse((fs.writeFileSync as Mock).mock.calls[0][1] as string);
+      expect(writtenContent.task.id).toBe('task_123');
+      expect(writtenContent.task.prompt).toBe('Test prompt');
+      expect(writtenContent.hasScreenshot).toBe(false);
+    });
+
+    it('debug:generate-bug-report should handle dialog cancellation', async () => {
+      (dialog.showSaveDialog as Mock).mockResolvedValue({
+        canceled: true,
+        filePath: undefined,
+      });
+
+      const result = await invokeHandler('debug:generate-bug-report', {}) as {
+        success: boolean;
+        reason: string;
+      };
+
+      expect(result.success).toBe(false);
+      expect(result.reason).toBe('cancelled');
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it('debug:generate-bug-report should handle write errors', async () => {
+      (fs.writeFileSync as Mock).mockImplementation(() => {
+        throw new Error('Permission denied');
+      });
+
+      const result = await invokeHandler('debug:generate-bug-report', {
+        taskId: 'task_err',
+      }) as {
+        success: boolean;
+        error: string;
+      };
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Permission denied');
+    });
+
+    it('debug:generate-bug-report should save screenshot file when provided', async () => {
+      const screenshotBase64 = Buffer.from('screenshot-png-data').toString('base64');
+      const reportData = {
+        taskId: 'task_with_screenshot',
+        taskPrompt: 'Screenshot test',
+        taskStatus: 'failed',
+        screenshot: screenshotBase64,
+      };
+
+      const result = await invokeHandler('debug:generate-bug-report', reportData) as {
+        success: boolean;
+        path: string;
+      };
+
+      expect(result.success).toBe(true);
+      // Should write both the JSON report and the PNG screenshot
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(2);
+
+      // First call: JSON report
+      const jsonContent = JSON.parse((fs.writeFileSync as Mock).mock.calls[0][1] as string);
+      expect(jsonContent.hasScreenshot).toBe(true);
+
+      // Second call: PNG screenshot (path.parse derives name correctly)
+      const screenshotCall = (fs.writeFileSync as Mock).mock.calls[1];
+      expect(screenshotCall[0]).toBe('/tmp/bug-report.png');
+      expect(Buffer.isBuffer(screenshotCall[1])).toBe(true);
+    });
+
+    it('debug:capture-screenshot should return error when no window found', async () => {
+      (BrowserWindow.fromWebContents as Mock).mockReturnValue(null);
+
+      const result = await invokeHandler('debug:capture-screenshot') as {
+        success: boolean;
+        error: string;
+      };
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('No window found');
+    });
+
+    it('debug:capture-axtree should return error when no window found', async () => {
+      (BrowserWindow.fromWebContents as Mock).mockReturnValue(null);
+
+      const result = await invokeHandler('debug:capture-axtree') as {
+        success: boolean;
+        error: string;
+      };
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('No window found');
+    });
+
+    it('debug:generate-bug-report should return error when no window found', async () => {
+      (BrowserWindow.fromWebContents as Mock).mockReturnValue(null);
+
+      const result = await invokeHandler('debug:generate-bug-report', { taskId: 'test' }) as {
+        success: boolean;
+        error: string;
+      };
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('No window found');
+    });
+  });
 });

--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import path from 'path';
 import { ipcMain, BrowserWindow, shell, app, dialog, nativeTheme } from 'electron';
 import type { IpcMainInvokeEvent } from 'electron';
 import { URL } from 'url';
@@ -1053,6 +1054,140 @@ export function registerIPCHandlers(): void {
       } else {
         const header = `Accomplish Application Logs\nExported: ${new Date().toISOString()}\nLog Directory: ${logDir}\n\nNo logs recorded yet.\n`;
         fs.writeFileSync(result.filePath, header);
+      }
+
+      return { success: true, path: result.filePath };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return { success: false, error: message };
+    }
+  });
+
+  handle('debug:capture-screenshot', async (event: IpcMainInvokeEvent) => {
+    const window = BrowserWindow.fromWebContents(event.sender);
+    if (!window) {
+      return { success: false, error: 'No window found' };
+    }
+
+    try {
+      const image = await window.webContents.capturePage();
+      const pngBuffer = image.toPNG();
+      const base64 = pngBuffer.toString('base64');
+      const size = image.getSize();
+      return { success: true, data: base64, width: size.width, height: size.height };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return { success: false, error: message };
+    }
+  });
+
+  handle('debug:capture-axtree', async (event: IpcMainInvokeEvent) => {
+    const window = BrowserWindow.fromWebContents(event.sender);
+    if (!window) {
+      return { success: false, error: 'No window found' };
+    }
+
+    try {
+      const axtree = await window.webContents.executeJavaScript(`
+        (function() {
+          var MAX_DEPTH = 15;
+          var MAX_TEXT = 200;
+          var MAX_NODES = 5000;
+          var nodeCount = 0;
+          function walk(el, depth) {
+            if (depth > MAX_DEPTH || nodeCount >= MAX_NODES) return null;
+            nodeCount++;
+            var tag = el.tagName ? el.tagName.toLowerCase() : '#text';
+            var node = { tag: tag };
+            var role = el.getAttribute ? el.getAttribute('role') : null;
+            if (role) node.role = role;
+            var ariaLabel = el.getAttribute ? el.getAttribute('aria-label') : null;
+            if (ariaLabel) node.ariaLabel = ariaLabel.substring(0, MAX_TEXT);
+            if (el.id) node.id = el.id;
+            var text = '';
+            for (var i = 0; i < el.childNodes.length; i++) {
+              if (el.childNodes[i].nodeType === 3) {
+                text += el.childNodes[i].textContent;
+              }
+            }
+            text = text.trim();
+            if (text) node.text = text.substring(0, MAX_TEXT);
+            var children = [];
+            for (var j = 0; j < el.children.length; j++) {
+              var child = walk(el.children[j], depth + 1);
+              if (child) children.push(child);
+            }
+            if (children.length > 0) node.children = children;
+            return node;
+          }
+          if (!document.body) return '{}';
+          return JSON.stringify(walk(document.body, 0));
+        })()
+      `);
+      return { success: true, data: axtree };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return { success: false, error: message };
+    }
+  });
+
+  handle('debug:generate-bug-report', async (event: IpcMainInvokeEvent, reportData: {
+    taskId?: string;
+    taskPrompt?: string;
+    taskStatus?: string;
+    messages?: unknown[];
+    debugLogs?: unknown[];
+    screenshot?: string;
+    axtree?: string;
+    appVersion?: string;
+    platform?: string;
+  }) => {
+    const window = BrowserWindow.fromWebContents(event.sender);
+    if (!window) {
+      return { success: false, error: 'No window found' };
+    }
+
+    try {
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+      const defaultFilename = `bug-report-${timestamp}.json`;
+
+      const result = await dialog.showSaveDialog(window, {
+        title: 'Save Bug Report',
+        defaultPath: defaultFilename,
+        filters: [
+          { name: 'JSON Files', extensions: ['json'] },
+          { name: 'All Files', extensions: ['*'] },
+        ],
+      });
+
+      if (result.canceled || !result.filePath) {
+        return { success: false, reason: 'cancelled' };
+      }
+
+      const report = {
+        version: 1,
+        generatedAt: new Date().toISOString(),
+        app: {
+          version: reportData.appVersion || app.getVersion(),
+          platform: reportData.platform || process.platform,
+        },
+        task: {
+          id: reportData.taskId,
+          prompt: reportData.taskPrompt,
+          status: reportData.taskStatus,
+        },
+        messages: reportData.messages,
+        debugLogs: reportData.debugLogs,
+        axtree: reportData.axtree,
+        hasScreenshot: Boolean(reportData.screenshot),
+      };
+
+      fs.writeFileSync(result.filePath, JSON.stringify(report, null, 2));
+
+      if (reportData.screenshot) {
+        const parsed = path.parse(result.filePath);
+        const screenshotPath = path.join(parsed.dir, `${parsed.name}.png`);
+        fs.writeFileSync(screenshotPath, Buffer.from(reportData.screenshot, 'base64'));
       }
 
       return { success: true, path: result.filePath };

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -316,6 +316,24 @@ const accomplishAPI = {
   exportLogs: (): Promise<{ success: boolean; path?: string; error?: string; reason?: string }> =>
     ipcRenderer.invoke('logs:export'),
 
+  // Debug bug report
+  captureScreenshot: (): Promise<{ success: boolean; data?: string; width?: number; height?: number; error?: string }> =>
+    ipcRenderer.invoke('debug:capture-screenshot'),
+  captureAxtree: (): Promise<{ success: boolean; data?: string; error?: string }> =>
+    ipcRenderer.invoke('debug:capture-axtree'),
+  generateBugReport: (data: {
+    taskId?: string;
+    taskPrompt?: string;
+    taskStatus?: string;
+    messages?: unknown[];
+    debugLogs?: unknown[];
+    screenshot?: string;
+    axtree?: string;
+    appVersion?: string;
+    platform?: string;
+  }): Promise<{ success: boolean; path?: string; error?: string; reason?: string }> =>
+    ipcRenderer.invoke('debug:generate-bug-report', data),
+
   // Speech-to-Text API
   speechIsConfigured: (): Promise<boolean> =>
     ipcRenderer.invoke('speech:is-configured'),

--- a/apps/desktop/src/renderer/components/BugReportActions.tsx
+++ b/apps/desktop/src/renderer/components/BugReportActions.tsx
@@ -1,0 +1,151 @@
+import { useState, useCallback, type ReactNode } from 'react';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Bug, Play, Check, AlertCircle } from 'lucide-react';
+import { getAccomplish } from '../lib/accomplish';
+import type { TaskMessage } from '@accomplish_ai/agent-core/common';
+
+type BugReportStatus = 'idle' | 'capturing' | 'saving' | 'saved' | 'error';
+
+const STATUS_LABELS: Record<BugReportStatus, string> = {
+  idle: 'Bug Report',
+  capturing: 'Capturing...',
+  saving: 'Saving...',
+  saved: 'Saved',
+  error: 'Failed',
+};
+
+const STATUS_ICONS_SM: Record<BugReportStatus, ReactNode> = {
+  idle: <Bug className="h-3 w-3 mr-1" />,
+  capturing: <Bug className="h-3 w-3 mr-1" />,
+  saving: <Bug className="h-3 w-3 mr-1" />,
+  saved: <Check className="h-3 w-3 mr-1 text-green-400" />,
+  error: <AlertCircle className="h-3 w-3 mr-1 text-red-400" />,
+};
+
+const STATUS_ICONS: Record<BugReportStatus, ReactNode> = {
+  idle: <Bug className="h-3.5 w-3.5 mr-1.5" />,
+  capturing: <Bug className="h-3.5 w-3.5 mr-1.5" />,
+  saving: <Bug className="h-3.5 w-3.5 mr-1.5" />,
+  saved: <Check className="h-3.5 w-3.5 mr-1.5 text-green-600" />,
+  error: <AlertCircle className="h-3.5 w-3.5 mr-1.5 text-red-600" />,
+};
+
+interface BugReportActionsProps {
+  taskId?: string;
+  taskPrompt?: string;
+  taskStatus?: string;
+  messages?: TaskMessage[];
+  debugLogs?: unknown[];
+  onRepeatTask?: () => void;
+  compact?: boolean;
+}
+
+export function BugReportActions({
+  taskId,
+  taskPrompt,
+  taskStatus,
+  messages,
+  debugLogs,
+  onRepeatTask,
+  compact = false,
+}: BugReportActionsProps) {
+  const [status, setStatus] = useState<BugReportStatus>('idle');
+  const accomplish = getAccomplish();
+
+  const handleBugReport = useCallback(async () => {
+    setStatus('capturing');
+
+    try {
+      const [screenshotResult, axtreeResult] = await Promise.all([
+        accomplish.captureScreenshot(),
+        accomplish.captureAxtree(),
+      ]);
+
+      setStatus('saving');
+
+      const result = await accomplish.generateBugReport({
+        taskId,
+        taskPrompt,
+        taskStatus,
+        messages,
+        debugLogs,
+        screenshot: screenshotResult.success ? screenshotResult.data : undefined,
+        axtree: axtreeResult.success ? axtreeResult.data : undefined,
+      });
+
+      if (result.success) {
+        setStatus('saved');
+        setTimeout(() => setStatus('idle'), 2000);
+      } else if (result.reason === 'cancelled') {
+        setStatus('idle');
+      } else {
+        setStatus('error');
+        setTimeout(() => setStatus('idle'), 3000);
+      }
+    } catch {
+      setStatus('error');
+      setTimeout(() => setStatus('idle'), 3000);
+    }
+  }, [accomplish, taskId, taskPrompt, taskStatus, messages, debugLogs]);
+
+  const label = STATUS_LABELS[status];
+  const isWorking = status === 'capturing' || status === 'saving';
+
+  if (compact) {
+    return (
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-6 px-2 text-xs text-muted-foreground hover:text-foreground hover:bg-accent"
+        onClick={(e) => {
+          e.stopPropagation();
+          handleBugReport();
+        }}
+        disabled={isWorking}
+      >
+        {STATUS_ICONS_SM[status]}
+        {label}
+      </Button>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleBugReport}
+            disabled={isWorking}
+          >
+            {STATUS_ICONS[status]}
+            {label}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <span>Capture screenshot, accessibility tree, and task data</span>
+        </TooltipContent>
+      </Tooltip>
+
+      {onRepeatTask && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onRepeatTask}
+            >
+              <Play className="h-3.5 w-3.5 mr-1.5" />
+              Repeat Task
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <span>Run the same task again</span>
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/lib/accomplish.ts
+++ b/apps/desktop/src/renderer/lib/accomplish.ts
@@ -214,6 +214,21 @@ interface AccomplishAPI {
   logEvent(payload: { level?: string; message: string; context?: Record<string, unknown> }): Promise<unknown>;
   exportLogs(): Promise<{ success: boolean; path?: string; error?: string; reason?: string }>;
 
+  // Debug bug report
+  captureScreenshot(): Promise<{ success: boolean; data?: string; width?: number; height?: number; error?: string }>;
+  captureAxtree(): Promise<{ success: boolean; data?: string; error?: string }>;
+  generateBugReport(data: {
+    taskId?: string;
+    taskPrompt?: string;
+    taskStatus?: string;
+    messages?: unknown[];
+    debugLogs?: unknown[];
+    screenshot?: string;
+    axtree?: string;
+    appVersion?: string;
+    platform?: string;
+  }): Promise<{ success: boolean; path?: string; error?: string; reason?: string }>;
+
   // Skills management
   getSkills(): Promise<Skill[]>;
   getEnabledSkills(): Promise<Skill[]>;

--- a/apps/desktop/src/renderer/pages/Execution.tsx
+++ b/apps/desktop/src/renderer/pages/Execution.tsx
@@ -28,6 +28,7 @@ import { ModelIndicator } from '../components/ui/ModelIndicator';
 import { useSpeechInput } from '../hooks/useSpeechInput';
 import { SpeechInputButton } from '../components/ui/SpeechInputButton';
 import { PlusMenu } from '../components/landing/PlusMenu';
+import { BugReportActions } from '../components/BugReportActions';
 
 // Debug log entry type
 interface DebugLogEntry {
@@ -566,6 +567,17 @@ export default function ExecutionPage() {
     setSettingsInitialTab('providers');
     setShowSettingsDialog(true);
   }, []);
+
+  const handleRepeatTask = useCallback(async () => {
+    if (!currentTask?.prompt) {
+      return;
+    }
+    const { startTask } = useTaskStore.getState();
+    const task = await startTask({ prompt: currentTask.prompt });
+    if (task) {
+      navigate(`/execution/${task.id}`);
+    }
+  }, [currentTask?.prompt, navigate]);
 
   useEffect(() => {
     if (!pendingSpeechFollowUpRef.current) {
@@ -1427,9 +1439,21 @@ export default function ExecutionPage() {
           <p className="text-sm text-muted-foreground mb-3">
             Task {currentTask.status === 'interrupted' ? 'stopped' : currentTask.status}
           </p>
-          <Button onClick={() => navigate('/')}>
-            Start New Task
-          </Button>
+          <div className="flex items-center justify-center gap-3">
+            <Button onClick={() => navigate('/')}>
+              Start New Task
+            </Button>
+            {debugModeEnabled && (
+              <BugReportActions
+                taskId={currentTask.id}
+                taskPrompt={currentTask.prompt}
+                taskStatus={currentTask.status}
+                messages={currentTask.messages}
+                debugLogs={debugLogs}
+                onRepeatTask={handleRepeatTask}
+              />
+            )}
+          </div>
         </div>
       )}
 
@@ -1461,6 +1485,14 @@ export default function ExecutionPage() {
               )}
             </div>
             <div className="flex items-center gap-2">
+              <BugReportActions
+                taskId={currentTask.id}
+                taskPrompt={currentTask.prompt}
+                taskStatus={currentTask.status}
+                messages={currentTask.messages}
+                debugLogs={debugLogs}
+                compact
+              />
               {debugLogs.length > 0 && (
                 <>
                   <Button


### PR DESCRIPTION
## Description

Add debug mode bug reporting that captures screenshots, accessibility tree (axtree), and task data into a structured JSON report + optional PNG screenshot. Add repeat task button to re-run the same prompt for reproducibility.

## Type of Change

- [x] `feat`: New feature or functionality
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation only changes
- [ ] `chore`: Maintenance, dependencies, or tooling
- [ ] `refactor`: Code refactoring (no feature change)
- [ ] `test`: Adding or updating tests
- [ ] `perf`: Performance improvement
- [ ] `ci`: CI/CD changes

## Summary

- **Bug Report button** captures app screenshot via Electron `capturePage()`, accessibility tree via bounded DOM serialization (MAX_DEPTH=15, MAX_NODES=5000), task metadata, and debug logs into a structured JSON report + sibling PNG screenshot, saved via native save dialog
- **Repeat Task button** re-runs the current task prompt in a new execution using `startTask` directly from the Zustand store
- Both buttons only visible when debug mode is enabled

## Changes

### IPC Handlers (`handlers.ts`)
- `debug:capture-screenshot` — captures window as base64-encoded PNG with dimensions
- `debug:capture-axtree` — serializes DOM with roles, labels, IDs, test IDs (depth and node bounded)
- `debug:generate-bug-report` — bundles report data, prompts native save dialog, writes JSON + optional PNG using `path.parse()` for safe filename derivation

### Preload & Renderer API
- Exposed 3 new methods via `contextBridge`: `captureScreenshot()`, `captureAxtree()`, `generateBugReport()`
- Added typed interface definitions in `accomplish.ts`

### UI (`BugReportActions.tsx` + `Execution.tsx`)
- Extracted `BugReportActions` component with status state machine (`idle → capturing → saving → saved/error`)
- Mapper objects for labels and icons (no nested ternaries)
- Full variant in task completion area (Bug Report + Repeat Task)
- Compact variant in debug panel toolbar (Bug Report only)
- Theme-aware styling using CSS variables (`text-muted-foreground`, `hover:bg-accent`)

### Tests
- 12 new unit tests covering all 3 handlers: happy paths, error handling, dialog cancellation, screenshot file writing, and null window guards
- All 496 desktop tests pass

## Test plan

- [x] TypeScript compiles without errors (`pnpm typecheck`)
- [x] All 496 desktop tests pass (`pnpm -F @accomplish/desktop test`)
- [x] Manual testing:
  - Enable Debug Mode in Settings
  - Run any task and wait for completion
  - Click **Bug Report** in debug panel toolbar — save dialog appears, saves `.json` + `.png`
  - Verify JSON contains app version, platform, task data, axtree, debug logs
  - Verify PNG screenshot is saved alongside the JSON
  - Cancel the save dialog — button resets to idle, no file written
  - After task completes, verify **Bug Report** and **Repeat Task** buttons appear in completion area
  - Click **Repeat Task** — new execution starts with same prompt

## Checklist

- [x] PR title follows conventional commit format
- [x] Changes have been tested locally
- [x] Any new dependencies are justified (none added)

## Related Issues

Closes #404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive debug reporting capabilities including screenshot capture and accessibility tree analysis for troubleshooting
  * Implemented bug report generation with save functionality, bundling diagnostic data (logs, task state, captured artifacts)
  * Added task repeat functionality for streamlined debugging workflows
  * Introduced dedicated UI components for debug actions with status feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->