### PR TITLE
fix(web): sync messages to sidebar tasks on completion for favicon display

### DIFF
--- a/apps/web/src/client/stores/taskStore.ts
+++ b/apps/web/src/client/stores/taskStore.ts
@@ -387,7 +387,15 @@ export const useTaskStore = create<TaskState>((set, get) => ({
       if (newStatus) {
         const finalStatus = newStatus;
         updatedTasks = state.tasks.map((t) =>
-          t.id === event.taskId ? { ...t, status: finalStatus } : t,
+          t.id === event.taskId
+            ? {
+                ...t,
+                status: finalStatus,
+                ...(isCurrentTask && updatedCurrentTask
+                  ? { messages: updatedCurrentTask.messages }
+                  : {}),
+              }
+            : t,
         );
       }
 


### PR DESCRIPTION
## Summary
- Sync `messages` from `currentTask` into the `tasks[]` array when a task completes or errors
- This ensures sidebar task entries have message data available for favicon display without requiring navigation

## Test plan
- [x] Typecheck passes
- [ ] Verify sidebar favicons appear after task completion without navigating to the task

🤖 Generated with [Claude Code](https://claude.com/claude-code)