### PR TITLE
fix(web): hide 'Completing task' pill from chat UI

### DIFF
--- a/apps/web/src/client/components/execution/MessageList.tsx
+++ b/apps/web/src/client/components/execution/MessageList.tsx
@@ -85,6 +85,10 @@ export const MessageBubble = memo(
       return null;
     }
 
+    if (isTool && message.toolName?.endsWith('complete_task')) {
+      return null;
+    }
+
     const showCopyButton = !isTool && !!message.content?.trim();
 
     const proseClasses = cn(


### PR DESCRIPTION
## Summary
- Filter out `complete_task` tool messages in MessageList to prevent duplicate "Completing task" pills when continuation sessions fire
- Follows the same pattern as the existing `todowrite` filter

Jira: https://accomplish-ai.atlassian.net/browse/ENG-176

## Test plan
- [ ] Run a task that triggers completion with incomplete todos
- [ ] Verify no "Completing task" pill is visible in chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Message list now correctly filters and hides certain tool completion messages to improve interface clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->