### PR TITLE
Remove dangerous fallback defaults across task/runtime flows

### DIFF
--- a/apps/desktop/__tests__/unit/main/opencode/task-manager.unit.test.ts
+++ b/apps/desktop/__tests__/unit/main/opencode/task-manager.unit.test.ts
@@ -331,7 +331,7 @@ describe('Task Manager Module', () => {
         // Arrange
         const manager = createTaskManager(createMockTaskManagerOptions());
         const callbacks = createMockCallbacks();
-        const config: TaskConfig = { prompt: 'Test task' };
+        const config: TaskConfig = { prompt: 'Test task', workingDirectory: '/mock/working-dir' };
 
         // Act
         const task = await manager.startTask('task-1', config, callbacks);
@@ -347,7 +347,7 @@ describe('Task Manager Module', () => {
         // Arrange
         const manager = createTaskManager(createMockTaskManagerOptions());
         const callbacks = createMockCallbacks();
-        const config: TaskConfig = { prompt: 'Test task' };
+        const config: TaskConfig = { prompt: 'Test task', workingDirectory: '/mock/working-dir' };
 
         await manager.startTask('task-1', config, callbacks);
 
@@ -362,9 +362,9 @@ describe('Task Manager Module', () => {
         const manager = createTaskManager(createMockTaskManagerOptions({ maxConcurrentTasks: 3 }));
 
         // Act
-        await manager.startTask('task-1', { prompt: 'Task 1' }, createMockCallbacks());
-        await manager.startTask('task-2', { prompt: 'Task 2' }, createMockCallbacks());
-        await manager.startTask('task-3', { prompt: 'Task 3' }, createMockCallbacks());
+        await manager.startTask('task-1', { prompt: 'Task 1', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
+        await manager.startTask('task-2', { prompt: 'Task 2', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
+        await manager.startTask('task-3', { prompt: 'Task 3', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
 
         // Assert
         expect(manager.getActiveTaskCount()).toBe(3);
@@ -379,11 +379,11 @@ describe('Task Manager Module', () => {
         const manager = createTaskManager(createMockTaskManagerOptions({ maxConcurrentTasks: 2 }));
 
         // Act
-        await manager.startTask('task-1', { prompt: 'Task 1' }, createMockCallbacks());
-        await manager.startTask('task-2', { prompt: 'Task 2' }, createMockCallbacks());
+        await manager.startTask('task-1', { prompt: 'Task 1', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
+        await manager.startTask('task-2', { prompt: 'Task 2', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
         const task3 = await manager.startTask(
           'task-3',
-          { prompt: 'Task 3' },
+          { prompt: 'Task 3', workingDirectory: '/mock/working-dir' },
           createMockCallbacks(),
         );
 
@@ -398,12 +398,12 @@ describe('Task Manager Module', () => {
         // Arrange
         const manager = createTaskManager(createMockTaskManagerOptions({ maxConcurrentTasks: 1 }));
 
-        await manager.startTask('task-1', { prompt: 'Task 1' }, createMockCallbacks());
-        await manager.startTask('task-2', { prompt: 'Task 2' }, createMockCallbacks());
+        await manager.startTask('task-1', { prompt: 'Task 1', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
+        await manager.startTask('task-2', { prompt: 'Task 2', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
 
         // Act & Assert
         await expect(
-          manager.startTask('task-3', { prompt: 'Task 3' }, createMockCallbacks()),
+          manager.startTask('task-3', { prompt: 'Task 3', workingDirectory: '/mock/working-dir' }, createMockCallbacks()),
         ).rejects.toThrow('Maximum queued tasks');
       });
     });
@@ -413,7 +413,7 @@ describe('Task Manager Module', () => {
         // Arrange
         const manager = createTaskManager(createMockTaskManagerOptions());
         const callbacks = createMockCallbacks();
-        await manager.startTask('task-1', { prompt: 'Test' }, callbacks);
+        await manager.startTask('task-1', { prompt: 'Test', workingDirectory: '/mock/working-dir' }, callbacks);
 
         // Note: In real implementation, adapter events would be forwarded
         // This tests the callback wiring
@@ -424,7 +424,7 @@ describe('Task Manager Module', () => {
         // Arrange
         const manager = createTaskManager(createMockTaskManagerOptions());
         const callbacks = createMockCallbacks();
-        await manager.startTask('task-1', { prompt: 'Test' }, callbacks);
+        await manager.startTask('task-1', { prompt: 'Test', workingDirectory: '/mock/working-dir' }, callbacks);
 
         // Progress is emitted during browser setup
         // Wait a bit for async operations
@@ -441,8 +441,8 @@ describe('Task Manager Module', () => {
         const callbacks1 = createMockCallbacks();
         const callbacks2 = createMockCallbacks();
 
-        await manager.startTask('task-1', { prompt: 'Task 1' }, callbacks1);
-        await manager.startTask('task-2', { prompt: 'Task 2' }, callbacks2);
+        await manager.startTask('task-1', { prompt: 'Task 1', workingDirectory: '/mock/working-dir' }, callbacks1);
+        await manager.startTask('task-2', { prompt: 'Task 2', workingDirectory: '/mock/working-dir' }, callbacks2);
 
         expect(manager.getActiveTaskCount()).toBe(1);
         expect(manager.getQueueLength()).toBe(1);
@@ -459,8 +459,8 @@ describe('Task Manager Module', () => {
         const callbacks1 = createMockCallbacks();
         const callbacks2 = createMockCallbacks();
 
-        await manager.startTask('task-1', { prompt: 'Task 1' }, callbacks1);
-        await manager.startTask('task-2', { prompt: 'Task 2' }, callbacks2);
+        await manager.startTask('task-1', { prompt: 'Task 1', workingDirectory: '/mock/working-dir' }, callbacks1);
+        await manager.startTask('task-2', { prompt: 'Task 2', workingDirectory: '/mock/working-dir' }, callbacks2);
 
         // Assert initial state
         expect(manager.hasActiveTask('task-1')).toBe(true);
@@ -473,7 +473,7 @@ describe('Task Manager Module', () => {
         // Arrange
         const manager = createTaskManager(createMockTaskManagerOptions());
         const callbacks = createMockCallbacks();
-        await manager.startTask('task-1', { prompt: 'Test' }, callbacks);
+        await manager.startTask('task-1', { prompt: 'Test', workingDirectory: '/mock/working-dir' }, callbacks);
 
         // Act
         await manager.cancelTask('task-1');
@@ -485,8 +485,8 @@ describe('Task Manager Module', () => {
       it('should cancel a queued task', async () => {
         // Arrange
         const manager = createTaskManager(createMockTaskManagerOptions({ maxConcurrentTasks: 1 }));
-        await manager.startTask('task-1', { prompt: 'Task 1' }, createMockCallbacks());
-        await manager.startTask('task-2', { prompt: 'Task 2' }, createMockCallbacks());
+        await manager.startTask('task-1', { prompt: 'Task 1', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
+        await manager.startTask('task-2', { prompt: 'Task 2', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
 
         expect(manager.isTaskQueued('task-2')).toBe(true);
 
@@ -511,8 +511,8 @@ describe('Task Manager Module', () => {
         const manager = createTaskManager(createMockTaskManagerOptions({ maxConcurrentTasks: 1 }));
         const callbacks2 = createMockCallbacks();
 
-        await manager.startTask('task-1', { prompt: 'Task 1' }, createMockCallbacks());
-        await manager.startTask('task-2', { prompt: 'Task 2' }, callbacks2);
+        await manager.startTask('task-1', { prompt: 'Task 1', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
+        await manager.startTask('task-2', { prompt: 'Task 2', workingDirectory: '/mock/working-dir' }, callbacks2);
 
         // Act
         await manager.cancelTask('task-1');
@@ -529,7 +529,7 @@ describe('Task Manager Module', () => {
       it('should interrupt a running task', async () => {
         // Arrange
         const manager = createTaskManager(createMockTaskManagerOptions());
-        await manager.startTask('task-1', { prompt: 'Test' }, createMockCallbacks());
+        await manager.startTask('task-1', { prompt: 'Test', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
 
         // Act & Assert - should not throw
         await manager.interruptTask('task-1');
@@ -548,8 +548,8 @@ describe('Task Manager Module', () => {
       it('should remove task from queue and return true', async () => {
         // Arrange
         const manager = createTaskManager(createMockTaskManagerOptions({ maxConcurrentTasks: 1 }));
-        await manager.startTask('task-1', { prompt: 'Task 1' }, createMockCallbacks());
-        await manager.startTask('task-2', { prompt: 'Task 2' }, createMockCallbacks());
+        await manager.startTask('task-1', { prompt: 'Task 1', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
+        await manager.startTask('task-2', { prompt: 'Task 2', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
 
         // Act
         const result = manager.cancelQueuedTask('task-2');
@@ -562,7 +562,7 @@ describe('Task Manager Module', () => {
       it('should return false for non-queued task', async () => {
         // Arrange
         const manager = createTaskManager(createMockTaskManagerOptions());
-        await manager.startTask('task-1', { prompt: 'Test' }, createMockCallbacks());
+        await manager.startTask('task-1', { prompt: 'Test', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
 
         // Act
         const result = manager.cancelQueuedTask('task-1');
@@ -576,7 +576,7 @@ describe('Task Manager Module', () => {
       it('should attempt to send response to active task', async () => {
         // Arrange
         const manager = createTaskManager(createMockTaskManagerOptions());
-        await manager.startTask('task-1', { prompt: 'Test' }, createMockCallbacks());
+        await manager.startTask('task-1', { prompt: 'Test', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
 
         // Act & Assert - The adapter throws "No active process" because there's no real PTY
         // in the test environment. This verifies that the task manager correctly delegates
@@ -601,7 +601,7 @@ describe('Task Manager Module', () => {
       it('should return session ID for active task after adapter starts', async () => {
         // Arrange
         const manager = createTaskManager(createMockTaskManagerOptions());
-        await manager.startTask('task-1', { prompt: 'Test' }, createMockCallbacks());
+        await manager.startTask('task-1', { prompt: 'Test', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
 
         // Wait for async adapter initialization
         await new Promise((resolve) => setTimeout(resolve, 100));
@@ -635,7 +635,7 @@ describe('Task Manager Module', () => {
         expect(manager.hasRunningTask()).toBe(false);
 
         // Act
-        await manager.startTask('task-1', { prompt: 'Test' }, createMockCallbacks());
+        await manager.startTask('task-1', { prompt: 'Test', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
 
         // Assert
         expect(manager.hasRunningTask()).toBe(true);
@@ -644,8 +644,8 @@ describe('Task Manager Module', () => {
       it('should return all active task IDs', async () => {
         // Arrange
         const manager = createTaskManager(createMockTaskManagerOptions({ maxConcurrentTasks: 3 }));
-        await manager.startTask('task-1', { prompt: 'Task 1' }, createMockCallbacks());
-        await manager.startTask('task-2', { prompt: 'Task 2' }, createMockCallbacks());
+        await manager.startTask('task-1', { prompt: 'Task 1', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
+        await manager.startTask('task-2', { prompt: 'Task 2', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
 
         // Act
         const activeIds = manager.getActiveTaskIds();
@@ -659,7 +659,7 @@ describe('Task Manager Module', () => {
       it('should return first active task ID', async () => {
         // Arrange
         const manager = createTaskManager(createMockTaskManagerOptions());
-        await manager.startTask('task-1', { prompt: 'Test' }, createMockCallbacks());
+        await manager.startTask('task-1', { prompt: 'Test', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
 
         // Act
         const activeId = manager.getActiveTaskId();
@@ -684,8 +684,8 @@ describe('Task Manager Module', () => {
       it('should dispose all active tasks', async () => {
         // Arrange
         const manager = createTaskManager(createMockTaskManagerOptions());
-        await manager.startTask('task-1', { prompt: 'Task 1' }, createMockCallbacks());
-        await manager.startTask('task-2', { prompt: 'Task 2' }, createMockCallbacks());
+        await manager.startTask('task-1', { prompt: 'Task 1', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
+        await manager.startTask('task-2', { prompt: 'Task 2', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
 
         // Act
         manager.dispose();
@@ -698,8 +698,8 @@ describe('Task Manager Module', () => {
       it('should clear the task queue', async () => {
         // Arrange
         const manager = createTaskManager(createMockTaskManagerOptions({ maxConcurrentTasks: 1 }));
-        await manager.startTask('task-1', { prompt: 'Task 1' }, createMockCallbacks());
-        await manager.startTask('task-2', { prompt: 'Task 2' }, createMockCallbacks());
+        await manager.startTask('task-1', { prompt: 'Task 1', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
+        await manager.startTask('task-2', { prompt: 'Task 2', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
 
         expect(manager.getQueueLength()).toBe(1);
 
@@ -769,10 +769,10 @@ describe('Task Manager Module', () => {
       const callbacks4 = createMockCallbacks();
 
       // Start tasks - first 2 run, next 2 queue
-      await manager.startTask('task-1', { prompt: 'Task 1' }, callbacks1);
-      await manager.startTask('task-2', { prompt: 'Task 2' }, callbacks2);
-      await manager.startTask('task-3', { prompt: 'Task 3' }, callbacks3);
-      await manager.startTask('task-4', { prompt: 'Task 4' }, callbacks4);
+      await manager.startTask('task-1', { prompt: 'Task 1', workingDirectory: '/mock/working-dir' }, callbacks1);
+      await manager.startTask('task-2', { prompt: 'Task 2', workingDirectory: '/mock/working-dir' }, callbacks2);
+      await manager.startTask('task-3', { prompt: 'Task 3', workingDirectory: '/mock/working-dir' }, callbacks3);
+      await manager.startTask('task-4', { prompt: 'Task 4', workingDirectory: '/mock/working-dir' }, callbacks4);
 
       // Assert queue state
       expect(manager.getActiveTaskCount()).toBe(2);
@@ -784,10 +784,10 @@ describe('Task Manager Module', () => {
       const manager = createTaskManager(createMockTaskManagerOptions({ maxConcurrentTasks: 2 }));
 
       // Add multiple tasks
-      await manager.startTask('task-1', { prompt: 'Task 1' }, createMockCallbacks());
-      await manager.startTask('task-2', { prompt: 'Task 2' }, createMockCallbacks());
-      await manager.startTask('task-3', { prompt: 'Task 3' }, createMockCallbacks());
-      await manager.startTask('task-4', { prompt: 'Task 4' }, createMockCallbacks());
+      await manager.startTask('task-1', { prompt: 'Task 1', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
+      await manager.startTask('task-2', { prompt: 'Task 2', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
+      await manager.startTask('task-3', { prompt: 'Task 3', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
+      await manager.startTask('task-4', { prompt: 'Task 4', workingDirectory: '/mock/working-dir' }, createMockCallbacks());
 
       // Assert
       expect(manager.getActiveTaskCount()).toBe(2);

--- a/apps/desktop/src/main/opencode/electron-options.ts
+++ b/apps/desktop/src/main/opencode/electron-options.ts
@@ -284,7 +284,7 @@ export function createElectronTaskManagerOptions(): TaskManagerOptions {
       getModelDisplayName,
       buildCliArgs,
     },
-    defaultWorkingDirectory: app.getPath('temp'),
+    defaultWorkingDirectory: app.getPath('home'),
     maxConcurrentTasks: 10,
     isCliAvailable,
     onBeforeTaskStart,

--- a/apps/web/src/client/components/settings/providers/BedrockProviderForm.tsx
+++ b/apps/web/src/client/components/settings/providers/BedrockProviderForm.tsx
@@ -57,6 +57,12 @@ export function BedrockProviderForm({
     setError(null);
 
     try {
+      if (authTab === 'profile' && !profileName.trim()) {
+        setError('Profile name is required');
+        setConnecting(false);
+        return;
+      }
+
       const accomplish = getAccomplish();
 
       const credentialsMap = {
@@ -74,7 +80,7 @@ export function BedrockProviderForm({
         },
         profile: {
           authType: 'profile' as const,
-          profileName: profileName.trim() || 'default',
+          profileName: profileName.trim(),
           region,
         },
       };
@@ -113,7 +119,7 @@ export function BedrockProviderForm({
             ? { apiKeyPrefix: bedrockApiKey.substring(0, 8) + '...' }
             : authTab === 'accessKey'
               ? { accessKeyIdPrefix: accessKeyId.substring(0, 8) + '...' }
-              : { profileName: profileName.trim() || 'default' }),
+              : { profileName: profileName.trim() }),
         } as BedrockProviderCredentials,
         lastConnectedAt: new Date().toISOString(),
         availableModels: fetchedModels,
@@ -316,7 +322,7 @@ export function BedrockProviderForm({
                       type="text"
                       value={
                         (connectedProvider?.credentials as BedrockProviderCredentials)
-                          ?.profileName || 'default'
+                          ?.profileName || 'N/A'
                       }
                       disabled
                       className="w-full rounded-md border border-input bg-muted/50 px-3 py-2.5 text-sm text-muted-foreground"
@@ -330,8 +336,7 @@ export function BedrockProviderForm({
                   <input
                     type="text"
                     value={
-                      (connectedProvider?.credentials as BedrockProviderCredentials)?.region ||
-                      'us-east-1'
+                      (connectedProvider?.credentials as BedrockProviderCredentials)?.region || 'N/A'
                     }
                     disabled
                     className="w-full rounded-md border border-input bg-muted/50 px-3 py-2.5 text-sm text-muted-foreground"

--- a/apps/web/src/client/pages/Execution.tsx
+++ b/apps/web/src/client/pages/Execution.tsx
@@ -313,12 +313,24 @@ export function ExecutionPage() {
   ) => {
     if (!permissionRequest || !currentTask) return;
 
+    const normalizedCustomText = customText?.trim() || undefined;
+    const normalizedSelectedOptions = selectedOpts
+      ?.map((opt) => opt.trim())
+      .filter((opt): opt is string => opt.length > 0);
+    const message = allowed
+      ? permissionRequest.type === 'question'
+        ? normalizedCustomText ||
+          (normalizedSelectedOptions?.length ? normalizedSelectedOptions.join(', ') : undefined)
+        : 'yes'
+      : undefined;
+
     await respondToPermission({
       requestId: permissionRequest.id,
       taskId: permissionRequest.taskId,
       decision: allowed ? 'allow' : 'deny',
-      selectedOptions: selectedOpts,
-      customText: customText,
+      message,
+      selectedOptions: normalizedSelectedOptions,
+      customText: normalizedCustomText,
     });
 
     if (!allowed && permissionRequest.type === 'question') {

--- a/packages/agent-core/mcp-tools/dev-browser-mcp/src/connection.test.ts
+++ b/packages/agent-core/mcp-tools/dev-browser-mcp/src/connection.test.ts
@@ -13,7 +13,7 @@ describe('connection', () => {
     delete process.env.CDP_ENDPOINT;
     delete process.env.CDP_SECRET;
     delete process.env.DEV_BROWSER_PORT;
-    delete process.env.ACCOMPLISH_TASK_ID;
+    process.env.ACCOMPLISH_TASK_ID = 'task-default';
   });
 
   describe('configureFromEnv', () => {
@@ -49,9 +49,11 @@ describe('connection', () => {
       expect(cfg.taskId).toBe('task-abc');
     });
 
-    it('defaults taskId to "default" when ACCOMPLISH_TASK_ID is not set', () => {
-      const cfg = configureFromEnv();
-      expect(cfg.taskId).toBe('default');
+    it('throws when ACCOMPLISH_TASK_ID is not set', () => {
+      delete process.env.ACCOMPLISH_TASK_ID;
+      expect(() => configureFromEnv()).toThrow(
+        'ACCOMPLISH_TASK_ID is required for browser task isolation',
+      );
     });
 
     it('does not include cdpHeaders when CDP_SECRET is not set', () => {

--- a/packages/agent-core/mcp-tools/dev-browser-mcp/src/connection.ts
+++ b/packages/agent-core/mcp-tools/dev-browser-mcp/src/connection.ts
@@ -55,7 +55,10 @@ export function configure(cfg: ConnectionConfig): void {
  */
 export function configureFromEnv(): ConnectionConfig {
   const cdpEndpoint = process.env.CDP_ENDPOINT;
-  const taskId = process.env.ACCOMPLISH_TASK_ID || 'default';
+  const taskId = process.env.ACCOMPLISH_TASK_ID?.trim();
+  if (!taskId) {
+    throw new Error('ACCOMPLISH_TASK_ID is required for browser task isolation');
+  }
 
   if (cdpEndpoint) {
     const headers: Record<string, string> = {};

--- a/packages/agent-core/tests/unit/opencode/task-manager.test.ts
+++ b/packages/agent-core/tests/unit/opencode/task-manager.test.ts
@@ -275,18 +275,16 @@ describe('TaskManager', () => {
   describe('Working directory handling', () => {
     it('should use task config working directory if provided', () => {
       const taskConfig = { prompt: 'test', workingDirectory: '/project/src' };
-      const defaultDir = '/home/user';
 
-      const workingDirectory = taskConfig.workingDirectory || defaultDir;
+      const workingDirectory = taskConfig.workingDirectory?.trim();
       expect(workingDirectory).toBe('/project/src');
     });
 
-    it('should fall back to default working directory', () => {
+    it('should require an explicit working directory', () => {
       const taskConfig = { prompt: 'test' };
-      const defaultDir = '/home/user';
 
-      const workingDirectory = taskConfig.workingDirectory || defaultDir;
-      expect(workingDirectory).toBe('/home/user');
+      const workingDirectory = taskConfig.workingDirectory?.trim();
+      expect(workingDirectory).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary
- remove unsafe browser task isolation fallback by requiring `ACCOMPLISH_TASK_ID` in dev-browser MCP
- require explicit allow-message content for permission responses (no implicit "yes" fallback) and pass explicit message payloads from renderer
- require explicit task working directories through TaskManager/OpenCodeAdapter and default desktop task launches to home directory instead of temp
- remove Bedrock runtime fallbacks (`region`, `profileName`) and skip config generation when required values are missing
- remove Azure Foundry legacy deployment fallback to "default"
- restrict packaged MCP runtime fallback behavior: fail fast when bundled Node/tsx prerequisites are missing

## Validation
- updated unit tests for changed behavior in:
  - `packages/agent-core/mcp-tools/dev-browser-mcp/src/connection.test.ts`
  - `apps/desktop/__tests__/unit/main/ipc/handlers.unit.test.ts`
  - `packages/agent-core/tests/unit/opencode/config-generator.test.ts`
  - `packages/agent-core/tests/unit/opencode/task-manager.test.ts`
  - `apps/desktop/__tests__/unit/main/opencode/task-manager.unit.test.ts`
- attempted repo typecheck, but local deps/toolchain are missing in this workspace:
  - `pnpm -r --parallel run typecheck` failed with `tsc: command not found` and missing `node_modules` warnings
