### PR TITLE
fix(web): restore dark mode support

### DIFF
--- a/apps/web/src/client/components/TodoSidebar.tsx
+++ b/apps/web/src/client/components/TodoSidebar.tsx
@@ -46,7 +46,7 @@ export function TodoSidebar({ todos }: TodoSidebarProps) {
                 i === total - 1 && 'rounded-r-full',
                 todo.status === 'completed' || todo.status === 'cancelled'
                   ? 'bg-foreground'
-                  : 'bg-[#d9d9d9]',
+                  : 'bg-border',
               )}
             />
           ))}
@@ -70,8 +70,8 @@ function TodoListItem({ todo }: { todo: TodoItem }) {
     <li
       className={cn(
         'flex items-start gap-2 rounded-lg pl-2 pr-1 py-3',
-        todo.status === 'completed' && 'bg-[#f5f4f1]',
-        todo.status === 'in_progress' && 'bg-[#f9f9f9]',
+        todo.status === 'completed' && 'bg-muted',
+        todo.status === 'in_progress' && 'bg-muted/50',
         todo.status === 'cancelled' && 'opacity-50',
       )}
     >

--- a/apps/web/src/client/components/layout/ConversationListItem.tsx
+++ b/apps/web/src/client/components/layout/ConversationListItem.tsx
@@ -53,9 +53,9 @@ export function ConversationListItem({ task }: ConversationListItemProps) {
       title={task.summary || task.prompt}
       className={cn(
         'w-full text-left p-2 rounded-lg text-xs font-medium transition-colors duration-200',
-        'text-foreground hover:bg-[#E8E8E8] hover:text-foreground',
+        'text-foreground hover:bg-accent hover:text-foreground',
         'flex items-center gap-3 group relative cursor-pointer',
-        isActive && 'bg-[#EDEBE7] text-foreground',
+        isActive && 'bg-accent text-foreground',
       )}
     >
       <span className="flex items-center justify-center shrink-0 w-3 h-3">
@@ -73,7 +73,7 @@ export function ConversationListItem({ task }: ConversationListItemProps) {
               <span
                 key={domain}
                 className={cn(
-                  'flex items-center p-0.5 rounded-full bg-white shrink-0 relative',
+                  'flex items-center p-0.5 rounded-full bg-card shrink-0 relative',
                   i > 0 && '-ml-1',
                   i === 0 && 'z-30',
                   i === 1 && 'z-20',

--- a/apps/web/src/client/components/layout/SettingsDialog.tsx
+++ b/apps/web/src/client/components/layout/SettingsDialog.tsx
@@ -16,6 +16,7 @@ import { DebugSection } from '@/components/settings/DebugSection';
 import { ConnectorsPanel } from '@/components/settings/connectors';
 import { Key, Zap, Mic, Info, Cable } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import logoImage from '/assets/logo-1.png';
 
 const TABS = [
   { id: 'providers' as const, labelKey: 'tabs.providers', icon: Key },
@@ -290,8 +291,9 @@ export function SettingsDialog({
         <nav className="w-48 shrink-0 border-r border-border bg-muted/30 p-3 flex flex-col gap-1">
           <div className="px-3 py-2 mb-1">
             <img
-              src="/assets/logo-1.png"
+              src={logoImage}
               alt="Accomplish"
+              className="dark:invert"
               style={{ height: '20px', paddingLeft: '6px' }}
             />
           </div>

--- a/apps/web/src/client/pages/Execution.tsx
+++ b/apps/web/src/client/pages/Execution.tsx
@@ -357,8 +357,8 @@ export function ExecutionPage() {
         );
       case 'running':
         return (
-          <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-primary/10 shrink-0">
-            <span className="animate-shimmer bg-gradient-to-r from-primary via-primary/50 to-primary bg-[length:200%_100%] bg-clip-text text-transparent">
+          <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-primary/10 dark:bg-primary/5 shrink-0">
+            <span className="animate-shimmer bg-gradient-to-r from-primary via-primary/50 to-primary dark:from-primary/70 dark:via-primary/30 dark:to-primary/70 bg-[length:200%_100%] bg-clip-text text-transparent">
               {t('status.running')}
             </span>
           </span>

--- a/apps/web/src/client/styles/globals.css
+++ b/apps/web/src/client/styles/globals.css
@@ -65,6 +65,44 @@
   --input: 0 0% 84.7%; /* #d8d8d8 */
   --ring: 20 25% 33%; /* #644a40 */
   --radius: 0.5rem;
+  --warning-subtle: 36 95% 95%;
+  --success-subtle: 152 60% 93%;
+  --provider-bg: 40 20% 93%;
+  --provider-bg-active: 130 40% 93%;
+  --provider-bg-hover: 40 15% 96%;
+  --provider-border-active: 40 30% 25%;
+  --provider-accent: 123 30% 30%;
+  --provider-accent-text: 123 30% 15%;
+}
+
+.dark {
+  --background: 0 0% 9%;
+  --foreground: 0 0% 95%;
+  --card: 0 0% 11%;
+  --card-foreground: 0 0% 95%;
+  --popover: 0 0% 11%;
+  --popover-foreground: 0 0% 95%;
+  --primary: 123 30% 45%;
+  --primary-foreground: 0 0% 9%;
+  --secondary: 120 10% 20%;
+  --secondary-foreground: 120 14% 85%;
+  --muted: 0 0% 15%;
+  --muted-foreground: 0 0% 64%;
+  --accent: 0 0% 18%;
+  --accent-foreground: 0 0% 95%;
+  --destructive: 8 78% 54%;
+  --destructive-foreground: 0 0% 100%;
+  --border: 0 0% 20%;
+  --input: 0 0% 25%;
+  --ring: 20 25% 55%;
+  --warning-subtle: 30 60% 15%;
+  --success-subtle: 150 40% 12%;
+  --provider-bg: 0 0% 15%;
+  --provider-bg-active: 130 20% 15%;
+  --provider-bg-hover: 0 0% 13%;
+  --provider-border-active: 40 30% 50%;
+  --provider-accent: 123 30% 45%;
+  --provider-accent-text: 123 30% 75%;
 }
 
 /* Custom scrollbar */

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -3,6 +3,7 @@ import tailwindcssAnimate from 'tailwindcss-animate';
 import tailwindcssTypography from '@tailwindcss/typography';
 
 const config: Config = {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- Restored `darkMode: 'class'` in Tailwind config and the `.dark {}` CSS variable block in `globals.css` that were deleted
- Replaced hardcoded light-mode hex colors with theme-aware tokens in TodoSidebar, ConversationListItem, Execution page, and SettingsDialog
- Fixed Settings dialog logo not inverting in dark mode

## Test plan
- [x] `pnpm typecheck` passes
- [x] Visual verification: dark mode toggles correctly, task cards/todo items/sidebar use dark backgrounds
- [ ] Reviewer: toggle between light and dark mode in Settings and verify all pages

ENG-190

🤖 Generated with [Claude Code](https://claude.com/claude-code)