### PR TITLE
fix(web): wire provider color tokens into Tailwind config

### DIFF
--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -58,6 +58,12 @@ const config: Config = {
         success: {
           DEFAULT: '#019E55',
         },
+        'provider-bg': 'hsl(var(--provider-bg))',
+        'provider-bg-active': 'hsl(var(--provider-bg-active))',
+        'provider-bg-hover': 'hsl(var(--provider-bg-hover))',
+        'provider-border-active': 'hsl(var(--provider-border-active))',
+        'provider-accent': 'hsl(var(--provider-accent))',
+        'provider-accent-text': 'hsl(var(--provider-accent-text))',
       },
       boxShadow: {
         sm: '0 1px 3px 0px hsl(0 0% 0% / 0.10), 0 1px 2px -1px hsl(0 0% 0% / 0.10)',


### PR DESCRIPTION
## Summary


[Jira ticket](https://accomplish-ai.atlassian.net/jira/software/c/projects/ENG/boards/150?selectedIssue=ENG-189)


- Wire 6 provider CSS variable tokens (`--provider-bg`, `--provider-bg-active`, `--provider-bg-hover`, `--provider-border-active`, `--provider-accent`, `--provider-accent-text`) into `tailwind.config.ts` so Tailwind actually generates utility classes for them
- Restores provider card highlight (active green background, selected border) that broke after PR #408 replaced hardcoded hex colors with semantic tokens without adding the Tailwind mappings

### Dark mode
<img width="966" height="634" alt="image" src="https://github.com/user-attachments/assets/950900a0-be5c-43d1-a5e4-fc4fec4bb05b" />

### Light Mode
<img width="983" height="714" alt="image" src="https://github.com/user-attachments/assets/069134b8-f264-480f-8fed-cb4faaa59303" />




## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint:eslint` passes (no new errors)
- [x] Visual: active provider card shows light green background in light mode
- [ x] Visual: selected (clicked) card shows darker 2px border in light mode
- [ x] Visual: dark mode still looks correct


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added six new color tokens to the design system for enhanced UI customization and styling consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->