### PR TITLE
build: explicitly declare ES module type in package.json to fix Node warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "accomplish",
   "version": "0.1.0",
+  "type": "module",
   "private": true,
   "description": "The open source AI coworker that lives on your desktop",
   "author": "Accomplish Inc",


### PR DESCRIPTION
## Description
Currently, running `pnpm lint` or other scripts triggers an annoying NodeJS warning indicating that `eslint.config.js` is treated as a CommonJS file.

This PR adds `"type": "module"` to the root `package.json` to eliminate this warning. Because all scripts under `scripts/` explicitly use the `.cjs` extension, they are unaffected, making this a safe, backward-compatible fix.

## Testing
Verified by running `pnpm lint` and `pnpm typecheck` successfully with no warnings locally.

Fixes # (No existing issue, proactively fixing a warning)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to use ES Modules (ESM) for module resolution instead of CommonJS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->