### PR TITLE
chore(web): use stable keys for mapped lists

### DIFF
--- a/apps/web/src/client/components/execution/DebugPanel.tsx
+++ b/apps/web/src/client/components/execution/DebugPanel.tsx
@@ -92,11 +92,11 @@ export function DebugPanel({ debugLogs, taskId, onClearLogs }: DebugPanelProps) 
     const parts = text.split(new RegExp(`(${query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi'));
     return parts.map((part, i) =>
       part.toLowerCase() === query.toLowerCase() ? (
-        <mark key={i} className="bg-yellow-500/40 text-yellow-200 rounded px-0.5">
+        <mark key={`${i}-${part}`} className="bg-yellow-500/40 text-yellow-200 rounded px-0.5">
           {part}
         </mark>
       ) : (
-        part
+        <span key={`${i}-${part}`}>{part}</span>
       ),
     );
   }, []);
@@ -265,7 +265,7 @@ export function DebugPanel({ debugLogs, taskId, onClearLogs }: DebugPanelProps) 
                   <div className="space-y-1">
                     {filteredDebugLogs.map((log, index) => (
                       <div
-                        key={index}
+                        key={`${log.timestamp}-${log.type}-${log.message}`}
                         ref={(el) => {
                           if (el) debugLogRefs.current.set(index, el);
                           else debugLogRefs.current.delete(index);

--- a/apps/web/src/client/pages/Home.tsx
+++ b/apps/web/src/client/pages/Home.tsx
@@ -50,6 +50,7 @@ export function HomePage() {
   // Build use case examples from translations
   const useCaseExamples = useMemo(() => {
     return USE_CASE_KEYS.map(({ key, image }) => ({
+      key,
       title: t(`useCases.${key}.title`),
       description: t(`useCases.${key}.description`),
       prompt: t(`useCases.${key}.prompt`),
@@ -218,7 +219,7 @@ export function HomePage() {
                         >
                           {useCaseExamples.map((example, index) => (
                             <motion.button
-                              key={index}
+                              key={example.key}
                               data-testid={`home-example-${index}`}
                               variants={staggerItem}
                               transition={springs.gentle}


### PR DESCRIPTION
## Description

Replaces "key={index}" usage with stable, content-based keys in "Home.tsx" and "DebugPanel.tsx".

Using array indices as keys can cause React reconciliation issues when items are reordered or dynamically updated. This change uses stable identifiers derived from content instead.

No functional behavior changes.

## Type of Change


- [ ] `feat`: New feature or functionality
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation only changes
- [X] `chore`: Maintenance, dependencies, or tooling
- [ ] `refactor`: Code refactoring (no feature change)
- [ ] `test`: Adding or updating tests
- [ ] `perf`: Performance improvement
- [ ] `ci`: CI/CD changes

## Checklist

- [X] PR title follows conventional commit format (e.g., `feat: add dark mode support`)
- [X] Changes have been tested locally
- [X] Any new dependencies are justified

## Related Issues

No related Issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved rendering stability in the debug panel's highlight segments and log list.
  * Enhanced reliability of use case example list rendering on the home page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->