### PR TITLE
fix(agent-core): prevent continuation loops from housekeeping tools

### DIFF
--- a/packages/agent-core/src/internal/classes/OpenCodeAdapter.ts
+++ b/packages/agent-core/src/internal/classes/OpenCodeAdapter.ts
@@ -10,6 +10,7 @@ import {
   CompletionEnforcer,
   CompletionEnforcerCallbacks,
 } from '../../opencode/completion/index.js';
+import { isNonTaskContinuationToolName } from '../../opencode/tool-classification.js';
 import type { TaskConfig, Task, TaskMessage, TaskResult } from '../../common/types/task.js';
 import type { OpenCodeMessage } from '../../common/types/opencode.js';
 import type { PermissionRequest } from '../../common/types/permission.js';
@@ -792,29 +793,8 @@ export class OpenCodeAdapter extends EventEmitter<OpenCodeAdapterEvents> {
     return false;
   }
 
-  private static readonly NON_TASK_TOOLS = new Set([
-    'discard',
-    'todowrite',
-    'complete_task',
-    'AskUserQuestion',
-    'report_checkpoint',
-    'report_thought',
-    'request_file_permission',
-  ]);
-
   private isNonTaskContinuationTool(toolName: string): boolean {
-    if (toolName === 'skill' || toolName.endsWith('_skill')) {
-      return true;
-    }
-    if (this.isStartTaskTool(toolName)) {
-      return true;
-    }
-    for (const tool of OpenCodeAdapter.NON_TASK_TOOLS) {
-      if (toolName === tool || toolName.endsWith(`_${tool}`)) {
-        return true;
-      }
-    }
-    return false;
+    return isNonTaskContinuationToolName(toolName);
   }
 
   private emitPlanMessage(input: StartTaskInput, sessionId: string): void {

--- a/packages/agent-core/src/opencode/message-processor.ts
+++ b/packages/agent-core/src/opencode/message-processor.ts
@@ -1,6 +1,7 @@
 import type { OpenCodeMessage, OpenCodeToolUseMessage } from '../common/types/opencode.js';
 import type { TaskMessage } from '../common/types/task.js';
 import { createMessageId } from '../common/index.js';
+import { isHiddenToolName } from './tool-classification.js';
 
 /**
  * Delay in milliseconds for batching messages before sending to renderer.
@@ -77,9 +78,6 @@ const TOOL_DISPLAY_NAMES: Record<string, string | null> = {
   browser_script: 'Running script',
   browser_click: 'Clicking element',
   browser_keyboard: 'Typing',
-  discard: null,
-  extract: null,
-  context_info: null,
 };
 
 const INSTRUCTION_BLOCK_RE = /<instruction\b[^>]*>[\s\S]*?<\/instruction>/gi;
@@ -113,6 +111,9 @@ export function sanitizeAssistantTextForDisplay(text: string): string | null {
 }
 
 export function getToolDisplayName(toolName: string): string | null {
+  if (isHiddenToolName(toolName)) {
+    return null;
+  }
   if (Object.prototype.hasOwnProperty.call(TOOL_DISPLAY_NAMES, toolName)) {
     return TOOL_DISPLAY_NAMES[toolName];
   }

--- a/packages/agent-core/src/opencode/tool-classification.ts
+++ b/packages/agent-core/src/opencode/tool-classification.ts
@@ -1,0 +1,29 @@
+const HIDDEN_TOOL_BASENAMES = ['discard', 'extract', 'context_info', 'prune', 'distill'] as const;
+
+export const NON_TASK_CONTINUATION_TOOLS = [
+  ...HIDDEN_TOOL_BASENAMES,
+  'todowrite',
+  'complete_task',
+  'AskUserQuestion',
+  'report_checkpoint',
+  'report_thought',
+  'request_file_permission',
+] as const;
+
+function matchesToolNameOrSuffix(toolName: string, baseName: string): boolean {
+  return toolName === baseName || toolName.endsWith(`_${baseName}`);
+}
+
+export function isNonTaskContinuationToolName(toolName: string): boolean {
+  if (toolName === 'skill' || toolName.endsWith('_skill')) {
+    return true;
+  }
+  if (toolName === 'start_task' || toolName.endsWith('_start_task')) {
+    return true;
+  }
+  return NON_TASK_CONTINUATION_TOOLS.some((tool) => matchesToolNameOrSuffix(toolName, tool));
+}
+
+export function isHiddenToolName(toolName: string): boolean {
+  return HIDDEN_TOOL_BASENAMES.some((tool) => matchesToolNameOrSuffix(toolName, tool));
+}

--- a/packages/agent-core/tests/unit/opencode/adapter.test.ts
+++ b/packages/agent-core/tests/unit/opencode/adapter.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { OpenCodeCliNotFoundError } from '../../../src/internal/classes/OpenCodeAdapter.js';
+import {
+  NON_TASK_CONTINUATION_TOOLS,
+  isNonTaskContinuationToolName,
+} from '../../../src/opencode/tool-classification.js';
 import { serializeError } from '../../../src/utils/error.js';
 
 /**
@@ -88,7 +92,7 @@ describe('Shell escaping utilities', () => {
 
     function buildShellCommand(command: string, args: string[]): string {
       const escapedCommand = escapeShellArgWin32(command);
-      const escapedArgs = args.map(arg => escapeShellArgWin32(arg));
+      const escapedArgs = args.map((arg) => escapeShellArgWin32(arg));
       return [escapedCommand, ...escapedArgs].join(' ');
     }
 
@@ -97,7 +101,8 @@ describe('Shell escaping utilities', () => {
     }
 
     it('should wrap the full command in outer quotes for cmd.exe /s /c', () => {
-      const command = 'C:\\Users\\Li Yao\\AppData\\Local\\Programs\\@accomplishdesktop\\opencode.exe';
+      const command =
+        'C:\\Users\\Li Yao\\AppData\\Local\\Programs\\@accomplishdesktop\\opencode.exe';
       const args = ['run', '--format', 'json', '--prompt', 'hello world'];
       const fullCommand = buildShellCommand(command, args);
       const shellArgs = getShellArgsWin32(fullCommand);
@@ -105,7 +110,9 @@ describe('Shell escaping utilities', () => {
       // shellArgs[2] must have outer quotes wrapping the entire command
       expect(shellArgs[2]).toBe(`"${fullCommand}"`);
       // The inner path with spaces must still be individually quoted
-      expect(fullCommand).toContain('"C:\\Users\\Li Yao\\AppData\\Local\\Programs\\@accomplishdesktop\\opencode.exe"');
+      expect(fullCommand).toContain(
+        '"C:\\Users\\Li Yao\\AppData\\Local\\Programs\\@accomplishdesktop\\opencode.exe"',
+      );
       // The full shell args should be ['/s', '/c', '"..."']
       expect(shellArgs[0]).toBe('/s');
       expect(shellArgs[1]).toBe('/c');
@@ -234,6 +241,26 @@ describe('Start task detection', () => {
     expect(isExemptTool('mcp_todowrite')).toBe(true);
     expect(isExemptTool('start_task')).toBe(true);
     expect(isExemptTool('read_file')).toBe(false);
+  });
+});
+
+describe('Non-task continuation tool detection', () => {
+  it('should include housekeeping tools in NON_TASK_CONTINUATION_TOOLS', () => {
+    expect(NON_TASK_CONTINUATION_TOOLS).toContain('prune');
+    expect(NON_TASK_CONTINUATION_TOOLS).toContain('distill');
+    expect(NON_TASK_CONTINUATION_TOOLS).toContain('extract');
+    expect(NON_TASK_CONTINUATION_TOOLS).toContain('context_info');
+  });
+
+  it('should classify housekeeping tool calls as non-task continuation tools', () => {
+    expect(isNonTaskContinuationToolName('prune')).toBe(true);
+    expect(isNonTaskContinuationToolName('distill')).toBe(true);
+    expect(isNonTaskContinuationToolName('extract')).toBe(true);
+    expect(isNonTaskContinuationToolName('context_info')).toBe(true);
+    expect(isNonTaskContinuationToolName('mcp_prune')).toBe(true);
+    expect(isNonTaskContinuationToolName('mcp_distill')).toBe(true);
+    expect(isNonTaskContinuationToolName('mcp_extract')).toBe(true);
+    expect(isNonTaskContinuationToolName('mcp_context_info')).toBe(true);
   });
 });
 

--- a/packages/agent-core/tests/unit/opencode/message-processor.test.ts
+++ b/packages/agent-core/tests/unit/opencode/message-processor.test.ts
@@ -170,6 +170,10 @@ describe('getToolDisplayName', () => {
     expect(getToolDisplayName('discard')).toBeNull();
     expect(getToolDisplayName('extract')).toBeNull();
     expect(getToolDisplayName('context_info')).toBeNull();
+    expect(getToolDisplayName('prune')).toBeNull();
+    expect(getToolDisplayName('distill')).toBeNull();
+    expect(getToolDisplayName('mcp_prune')).toBeNull();
+    expect(getToolDisplayName('mcp_distill')).toBeNull();
   });
 
   it('returns display name for mapped tools', () => {

--- a/packages/agent-core/tests/unit/opencode/tool-classification.test.ts
+++ b/packages/agent-core/tests/unit/opencode/tool-classification.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import {
+  NON_TASK_CONTINUATION_TOOLS,
+  isHiddenToolName,
+  isNonTaskContinuationToolName,
+} from '../../../src/opencode/tool-classification.js';
+
+describe('tool-classification', () => {
+  it('should treat helper tools as non-task continuation tools', () => {
+    expect(NON_TASK_CONTINUATION_TOOLS).toContain('prune');
+    expect(NON_TASK_CONTINUATION_TOOLS).toContain('distill');
+    expect(NON_TASK_CONTINUATION_TOOLS).toContain('extract');
+    expect(NON_TASK_CONTINUATION_TOOLS).toContain('context_info');
+
+    expect(isNonTaskContinuationToolName('start_task')).toBe(true);
+    expect(isNonTaskContinuationToolName('skill')).toBe(true);
+    expect(isNonTaskContinuationToolName('mcp_prune')).toBe(true);
+    expect(isNonTaskContinuationToolName('mcp_distill')).toBe(true);
+    expect(isNonTaskContinuationToolName('mcp_extract')).toBe(true);
+    expect(isNonTaskContinuationToolName('mcp_context_info')).toBe(true);
+  });
+
+  it('should keep real task tools counting toward continuation', () => {
+    expect(isNonTaskContinuationToolName('browser_click')).toBe(false);
+    expect(isNonTaskContinuationToolName('read_file')).toBe(false);
+    expect(isNonTaskContinuationToolName('bash')).toBe(false);
+  });
+
+  it('should identify hidden housekeeping tools', () => {
+    expect(isHiddenToolName('discard')).toBe(true);
+    expect(isHiddenToolName('extract')).toBe(true);
+    expect(isHiddenToolName('context_info')).toBe(true);
+    expect(isHiddenToolName('prune')).toBe(true);
+    expect(isHiddenToolName('distill')).toBe(true);
+    expect(isHiddenToolName('mcp_prune')).toBe(true);
+    expect(isHiddenToolName('browser_click')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- centralize tool classification for continuation logic and hidden/internal tool rendering
- treat `prune` and `distill` as non-task continuation tools (fixes false continuation loops)
- also classify `extract` and `context_info` as housekeeping/non-task tools for consistency
- wire `OpenCodeAdapter` and `message-processor` to the shared classifier to avoid future drift

## Why
When housekeeping tools were counted as real task tools, conversational turns in resumed sessions could be misclassified as unfinished tasks, triggering continuation retries ("nothing to do").

## Validation
- `pnpm -F @accomplish_ai/agent-core test -- --run tests/unit/opencode`
- `pnpm -F @accomplish_ai/agent-core typecheck`

## Files
- `packages/agent-core/src/opencode/tool-classification.ts`
- `packages/agent-core/src/internal/classes/OpenCodeAdapter.ts`
- `packages/agent-core/src/opencode/message-processor.ts`
- `packages/agent-core/tests/unit/opencode/tool-classification.test.ts`
- `packages/agent-core/tests/unit/opencode/adapter.test.ts`
- `packages/agent-core/tests/unit/opencode/message-processor.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated tool classification system into centralized utilities for improved consistency and maintainability.
  * Simplified internal tool detection logic by replacing hardcoded checks with a unified classifier function.

* **Tests**
  * Added comprehensive test coverage for tool classification utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Jira: https://accomplish-ai.atlassian.net/browse/ENG-216
