### PR TITLE
fix(web): replace hardcoded colors with theme tokens for dark mode

### DIFF
--- a/apps/web/src/client/styles/globals.css
+++ b/apps/web/src/client/styles/globals.css
@@ -89,7 +89,7 @@
   --border: 12 8% 90%; /* #eae2e1 */
   --input: 0 0% 84.7%; /* #d8d8d8 */
   --ring: 20 25% 33%; /* #644a40 */
-  --radius: 0.25rem;
+  --radius: 0.25rem; /* Border radius for cards, inputs, and buttons */
   --warning-subtle: 36 95% 95%;
   --success-subtle: 152 60% 93%;
   --provider-bg: 40 20% 93%;
@@ -116,7 +116,7 @@
   --secondary: 120 8% 18%;
   --secondary-foreground: 120 14% 85%;
   --muted: 220 8% 16%;
-  --muted-foreground: 0 0% 58%;
+  --muted-foreground: 0 0% 61%;
   --accent: 220 10% 10%;
   --accent-foreground: 0 0% 93%;
   --destructive: 8 78% 54%;
@@ -132,9 +132,9 @@
   --provider-border-active: 123 30% 40%;
   --provider-accent: 123 30% 45%;
   --provider-accent-text: 123 30% 75%;
-  --todo-progress-pending: 0 0% 24%;
-  --todo-item-completed: 0 0% 14%;
-  --todo-item-in-progress: 0 0% 11%;
+  --todo-progress-pending: 220 8% 24%;
+  --todo-item-completed: 220 8% 14%;
+  --todo-item-in-progress: 220 8% 11%;
 }
 
 /* Custom scrollbar — auto-hide, shown only while scrolling */


### PR DESCRIPTION
## Description
Replace hardcoded zinc/gray colors with CSS variable-based theme tokens and improve dark mode color palette for better contrast and visual hierarchy.

### Changes
- Reworked dark theme CSS variables with proper color hierarchy and subtle blue tint
- Replaced ~30 hardcoded `zinc-*` classes in debug panel with `bg-muted`, `text-foreground`, `border-border` etc.
- Added `dark:` variants for status badges, permission dialog warnings, and search highlights
- Fixed Home page card styling — removed shadow in dark mode, improved example card contrast
- Fixed sidebar text colors for cancelled tasks and delete buttons

## Demo

https://github.com/user-attachments/assets/c10079bc-dc1b-43a0-8636-5b8fe9a0634d


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally

## Related Issues
Fixes #373

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced dark theme with a blue-tinted color palette, transitioning from the previous grayscale design. Comprehensive color adjustments applied throughout the interface including backgrounds, foregrounds, cards, popovers, inputs, borders, accent elements, and status indicators to improve visual cohesion and overall consistency across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->