### PR TITLE
fix: skills submenu closing in task execution plus menu

### DIFF
--- a/apps/web/locales/en/settings.json
+++ b/apps/web/locales/en/settings.json
@@ -306,7 +306,7 @@
     "builtByYou": "Built By You",
     "loading": "Loading skills...",
     "searchPlaceholder": "Search skills...",
-    "refresh": "Refresh skills",
+    "refresh": "Refresh",
     "noSkillsFound": "No skills found",
     "scrollForMore": "Scroll for more skills",
     "disableSkill": "Disable skill",

--- a/apps/web/locales/zh-CN/settings.json
+++ b/apps/web/locales/zh-CN/settings.json
@@ -306,7 +306,7 @@
     "builtByYou": "自建",
     "loading": "加载技能中...",
     "searchPlaceholder": "搜索技能...",
-    "refresh": "刷新技能",
+    "refresh": "刷新",
     "noSkillsFound": "未找到技能",
     "scrollForMore": "滚动查看更多技能",
     "disableSkill": "停用技能",

--- a/apps/web/src/client/components/landing/PlusMenu/SkillsSubmenu.tsx
+++ b/apps/web/src/client/components/landing/PlusMenu/SkillsSubmenu.tsx
@@ -48,6 +48,9 @@ export function SkillsSubmenu({
           placeholder={t('skills.searchPlaceholder')}
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
+          onPointerDown={(event) => event.stopPropagation()}
+          onClick={(event) => event.stopPropagation()}
+          onKeyDown={(event) => event.stopPropagation()}
           className="h-8 text-sm"
           autoFocus
         />
@@ -146,7 +149,12 @@ export function SkillsSubmenu({
           {t('skills.manage')}
         </button>
         <motion.button
-          onClick={onRefresh}
+          onPointerDown={(event) => event.stopPropagation()}
+          onClick={(event) => {
+            event.stopPropagation();
+            onRefresh();
+          }}
+          onKeyDown={(event) => event.stopPropagation()}
           disabled={isRefreshing}
           className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 text-[11px] text-muted-foreground bg-secondary border border-border rounded-md hover:bg-accent hover:text-foreground transition-colors disabled:opacity-50"
           whileTap={{ scale: 0.95 }}


### PR DESCRIPTION
## Summary
- add integration regression tests for plus-menu skills behavior in TaskInputBar and Execution page
- keep skills submenu open when clicking/typing in the skills search input
- keep skills submenu open when clicking Refresh, and simplify label to `Refresh`

## Testing
- pnpm vitest run --config vitest.integration.config.ts __tests__/integration/renderer/components/TaskInputBar.integration.test.tsx __tests__/integration/renderer/pages/Execution.integration.test.tsx

Jira: https://accomplish-ai.atlassian.net/browse/ENG-217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event handling for skills search input and refresh button to prevent unintended interactions.

* **Localization**
  * Updated "Refresh skills" button label to "Refresh" in English and Chinese locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->