### PR TITLE
Feat(desktop): implement native dark mode and appearance settings  Fixes #373

### DIFF
--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -1354,6 +1354,19 @@ export function registerIPCHandlers(): void {
     storage.deleteConnectorTokens(connectorId);
     storage.setConnectorStatus(connectorId, 'disconnected');
   });
+
+  // React to OS-level theme changes (e.g. macOS System Preferences → Appearance)
+  nativeTheme.on('updated', () => {
+    const preference = storage.getTheme();
+    if (preference === 'system') {
+      const resolved = nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
+      for (const win of BrowserWindow.getAllWindows()) {
+        if (!win.isDestroyed()) {
+          win.webContents.send('settings:theme-changed', { theme: 'system', resolved });
+        }
+      }
+    }
+  });
 }
 
 // In-memory store for pending OAuth flows (keyed by state parameter)

--- a/apps/web/src/client/components/TaskLauncher/TaskLauncher.tsx
+++ b/apps/web/src/client/components/TaskLauncher/TaskLauncher.tsx
@@ -137,7 +137,7 @@ export function TaskLauncher() {
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}
                 transition={{ duration: 0.15 }}
-                className="fixed inset-0 z-50 bg-white/60 backdrop-blur-[12px]"
+                className="fixed inset-0 z-50 bg-background/60 backdrop-blur-[12px]"
               />
             </DialogPrimitive.Overlay>
 

--- a/apps/web/src/client/components/TaskLauncher/TaskLauncherItem.tsx
+++ b/apps/web/src/client/components/TaskLauncher/TaskLauncherItem.tsx
@@ -37,7 +37,7 @@ export function TaskLauncherItem({ task, isSelected, onClick }: TaskLauncherItem
             <span
               key={domain}
               className={cn(
-                'flex items-center p-0.5 rounded-full bg-white shrink-0 relative',
+                'flex items-center p-0.5 rounded-full bg-background shrink-0 relative',
                 i > 0 && '-ml-1',
                 i === 0 && 'z-30',
                 i === 1 && 'z-20',

--- a/apps/web/src/client/components/execution/PermissionDialog.tsx
+++ b/apps/web/src/client/components/execution/PermissionDialog.tsx
@@ -20,7 +20,7 @@ function getOperationBadgeClasses(operation?: string): string {
     case 'move':
       return 'bg-blue-500/10 text-blue-600';
     default:
-      return 'bg-gray-500/10 text-gray-600';
+      return 'bg-muted text-muted-foreground';
   }
 }
 

--- a/apps/web/src/client/components/ui/dialog.tsx
+++ b/apps/web/src/client/components/ui/dialog.tsx
@@ -71,7 +71,7 @@ const DialogContent = React.forwardRef<
           initial={{ opacity: 0 }}
           animate={{ opacity: isOpen ? 1 : 0 }}
           transition={{ duration: EXIT_ANIMATION_DURATION / 1000 }}
-          className="fixed inset-0 z-50 bg-white/60 backdrop-blur-[12px]"
+          className="fixed inset-0 z-50 bg-background/60 backdrop-blur-[12px]"
         />
       </DialogPrimitive.Overlay>
       <DialogPrimitive.Content

--- a/apps/web/src/client/pages/Execution.tsx
+++ b/apps/web/src/client/pages/Execution.tsx
@@ -442,7 +442,7 @@ export function ExecutionPage() {
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}
-                className="fixed inset-0 z-50 flex items-center justify-center bg-white/60 backdrop-blur-[12px]"
+                className="fixed inset-0 z-50 flex items-center justify-center bg-background/60 backdrop-blur-[12px]"
               >
                 <motion.div
                   initial={{ opacity: 0, scale: 0.95 }}
@@ -674,7 +674,7 @@ export function ExecutionPage() {
                 <button
                   onClick={interruptTask}
                   title={t('stopAgent')}
-                  className="flex h-6 w-6 items-center justify-center rounded-full bg-[#e54d2e] text-white hover:bg-[#d4442a] transition-colors shrink-0"
+                  className="flex h-6 w-6 items-center justify-center rounded-full bg-destructive text-white hover:bg-destructive/90 transition-colors shrink-0"
                   data-testid="execution-stop-button"
                 >
                   <span className="block h-2.5 w-2.5 rounded-[2px] bg-white" />


### PR DESCRIPTION
# feat(desktop): implement native dark mode and appearance settings

Fixes #373

---

## Summary

Implements native dark mode for the Accomplish desktop application by closing the 4 remaining gaps in the existing infrastructure. The approach leverages the **already-built IPC bridge** (`getTheme`/`setTheme`/`onThemeChange`), the **Tailwind `.dark` class strategy** (`darkMode: 'class'`), and the **existing CSS variable overrides** in `globals.css`.

## What Changed

### 1. OS Theme Change Detection (`handlers.ts`)
Added a `nativeTheme.on('updated')` listener inside `registerIPCHandlers()`. When the user's preference is `system`, OS-level appearance changes (e.g. macOS System Settings → Appearance) are now detected and broadcast to all renderer windows via the `settings:theme-changed` IPC event in real-time.

### 2. Appearance Tab (`SettingsDialog.tsx`)
Added a new **Appearance** tab (Palette icon) to the Settings dialog with a 3-option segmented control:
- **System** — follows OS preference
- **Light** — always light
- **Dark** — always dark

Calls `applyTheme()` for instant visual feedback and `accomplish.setTheme()` for IPC persistence to SQLite.

### 3. Semantic Color Token Migration (6 components)
Replaced hardcoded color values with theme-aware Tailwind tokens:

| File | Before | After |
|---|---|---|
| `Execution.tsx` | `bg-white/60` | `bg-background/60` |
| `Execution.tsx` | `bg-[#e54d2e]` | `bg-destructive` |
| `dialog.tsx` | `bg-white/60` | `bg-background/60` |
| `TaskLauncher.tsx` | `bg-white/60` | `bg-background/60` |
| `TaskLauncherItem.tsx` | `bg-white` | `bg-background` |
| `PermissionDialog.tsx` | `bg-gray-500/10 text-gray-600` | `bg-muted text-muted-foreground` |

> **Note:** Toggle switch knobs (`bg-white` in `SkillCard`, `DebugSection`, `ConnectorCard`, `ConnectorsSubmenu`) were intentionally left unchanged — white knobs on colored tracks are the correct design pattern regardless of theme.

### 4. Unit Tests (`handlers.unit.test.ts`)
Added `nativeTheme` mock to the Electron mock and `getTheme`/`setTheme` to the agent-core storage mock. 4 new test cases:
- `settings:theme` returns current preference
- `settings:set-theme` updates to `dark`
- `settings:set-theme` updates to `system`
- `settings:theme` returns `system` as default

## Files Changed (8)

- `apps/desktop/src/main/ipc/handlers.ts`
- `apps/web/src/client/components/layout/SettingsDialog.tsx`
- `apps/web/src/client/pages/Execution.tsx`
- `apps/web/src/client/components/ui/dialog.tsx`
- `apps/web/src/client/components/TaskLauncher/TaskLauncher.tsx`
- `apps/web/src/client/components/TaskLauncher/TaskLauncherItem.tsx`
- `apps/web/src/client/components/execution/PermissionDialog.tsx`
- `apps/desktop/__tests__/unit/main/ipc/handlers.unit.test.ts`

## Local QA Checklist

- [x] `pnpm format` — ✅ Pass
- [x] `pnpm lint:eslint` — ✅ Pass (0 errors, 0 warnings)
- [x] `pnpm typecheck` — ✅ Pass (3 workspaces: agent-core, desktop, web)
- [x] `pnpm -F @accomplish/web test:unit` — ✅ 176/176 tests pass
- [x] `pnpm -F @accomplish/desktop test:unit` — ✅ 92/92 tests pass (incl. 4 new)
- [x] `pnpm build` — ✅ All workspaces compile


## How to Test

1. Launch the app → **Settings (⚙)** → **Appearance** tab
2. Toggle between **System**, **Light**, and **Dark**
3. Verify the UI updates instantly (overlay dimming, text readability, backgrounds)
4. Change macOS System Settings → Appearance while set to **System** — verify app follows OS
5. Relaunch the app — verify the preference persists


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added appearance settings tab with theme preferences (system, light, dark).
  * System now responds to OS theme changes when system preference is selected.

* **Style**
  * Updated UI backgrounds and components to use theme-aware colors.
  * Refined button styling for visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->