### PR TITLE
fix(skills): import full skill folder instead of single SKILL.md file

### DIFF
--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -1175,15 +1175,11 @@ export function registerIPCHandlers(): void {
     return skillsManager.getUserSkillsPath();
   });
 
-  handle('skills:pick-file', async () => {
+  handle('skills:pick-folder', async () => {
     const mainWindow = BrowserWindow.getAllWindows()[0];
     const result = await dialog.showOpenDialog(mainWindow, {
-      title: 'Select a SKILL.md file',
-      filters: [
-        { name: 'Skill Files', extensions: ['md'] },
-        { name: 'All Files', extensions: ['*'] },
-      ],
-      properties: ['openFile'],
+      title: 'Select a skill folder',
+      properties: ['openDirectory'],
     });
     if (result.canceled || result.filePaths.length === 0) {
       return null;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -437,7 +437,7 @@ const accomplishAPI = {
   getSkillContent: (id: string): Promise<string | null> =>
     ipcRenderer.invoke('skills:get-content', id),
   getUserSkillsPath: (): Promise<string> => ipcRenderer.invoke('skills:get-user-skills-path'),
-  pickSkillFile: (): Promise<string | null> => ipcRenderer.invoke('skills:pick-file'),
+  pickSkillFolder: (): Promise<string | null> => ipcRenderer.invoke('skills:pick-folder'),
   addSkillFromFile: (filePath: string): Promise<Skill> =>
     ipcRenderer.invoke('skills:add-from-file', filePath),
   addSkillFromGitHub: (rawUrl: string): Promise<Skill> =>

--- a/apps/web/locales/en/settings.json
+++ b/apps/web/locales/en/settings.json
@@ -319,7 +319,7 @@
     "buildWithAccomplish": "Build with Accomplish",
     "buildDescription": "Create skills through conversation",
     "uploadSkill": "Upload a skill",
-    "uploadDescription": "Upload a SKILL.md file",
+    "uploadDescription": "Upload a skill folder",
     "importFromGitHub": "Import from GitHub",
     "importDescription": "Paste a repository link",
     "importDialogDescription": "Enter the URL of a GitHub repository containing a SKILL.md file.",

--- a/apps/web/locales/zh-CN/settings.json
+++ b/apps/web/locales/zh-CN/settings.json
@@ -319,7 +319,7 @@
     "buildWithAccomplish": "使用 Accomplish 构建",
     "buildDescription": "通过对话创建技能",
     "uploadSkill": "上传技能",
-    "uploadDescription": "上传 SKILL.md 文件",
+    "uploadDescription": "上传技能文件夹",
     "importFromGitHub": "从 GitHub 导入",
     "importDescription": "粘贴仓库链接",
     "importDialogDescription": "输入包含 SKILL.md 文件的 GitHub 仓库 URL。",

--- a/apps/web/src/client/components/settings/skills/AddSkillDropdown.tsx
+++ b/apps/web/src/client/components/settings/skills/AddSkillDropdown.tsx
@@ -39,7 +39,7 @@ export function AddSkillDropdown({ onSkillAdded, onClose }: AddSkillDropdownProp
     try {
       setIsLoading(true);
       setUploadError(null);
-      const filePath = await window.accomplish.pickSkillFile();
+      const filePath = await window.accomplish.pickSkillFolder();
       if (!filePath) {
         setIsLoading(false);
         return; // User cancelled

--- a/apps/web/src/client/lib/accomplish.ts
+++ b/apps/web/src/client/lib/accomplish.ts
@@ -351,7 +351,7 @@ interface AccomplishAPI {
   setSkillEnabled(id: string, enabled: boolean): Promise<void>;
   getSkillContent(id: string): Promise<string | null>;
   getUserSkillsPath(): Promise<string>;
-  pickSkillFile(): Promise<string | null>;
+  pickSkillFolder(): Promise<string | null>;
   addSkillFromFile(filePath: string): Promise<Skill>;
   addSkillFromGitHub(rawUrl: string): Promise<Skill>;
   deleteSkill(id: string): Promise<void>;

--- a/packages/agent-core/src/internal/classes/SkillsManager.ts
+++ b/packages/agent-core/src/internal/classes/SkillsManager.ts
@@ -122,6 +122,11 @@ export class SkillsManager {
       return this.addFromUrl(sourcePath);
     }
 
+    const stat = fs.statSync(sourcePath);
+    if (stat.isDirectory()) {
+      return this.addFromFolder(sourcePath);
+    }
+
     return this.addFromFile(sourcePath);
   }
 
@@ -236,6 +241,27 @@ export class SkillsManager {
     const destPath = this.prepareSkillDir(frontmatter);
     fs.copyFileSync(sourcePath, destPath);
     return this.persistSkill(frontmatter, destPath, 'custom');
+  }
+
+  private addFromFolder(sourceDir: string): Skill {
+    const skillMdPath = path.join(sourceDir, 'SKILL.md');
+    if (!fs.existsSync(skillMdPath)) {
+      throw new Error('Selected folder does not contain a SKILL.md file');
+    }
+
+    const content = fs.readFileSync(skillMdPath, 'utf-8');
+    const frontmatter = this.validateSkillFrontmatter(content);
+    const destSkillMdPath = this.prepareSkillDir(frontmatter);
+    const destDir = path.dirname(destSkillMdPath);
+
+    const entries = fs.readdirSync(sourceDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isFile()) {
+        fs.copyFileSync(path.join(sourceDir, entry.name), path.join(destDir, entry.name));
+      }
+    }
+
+    return this.persistSkill(frontmatter, destSkillMdPath, 'custom');
   }
 
   private async addFromUrl(rawUrl: string): Promise<Skill> {

--- a/packages/agent-core/tests/unit/skills/skills-manager.test.ts
+++ b/packages/agent-core/tests/unit/skills/skills-manager.test.ts
@@ -479,6 +479,56 @@ Content.
     });
   });
 
+  describe('addSkill from folder', () => {
+    it('should add skill from a folder and copy all companion files', async () => {
+      if (!moduleAvailable || !manager) return;
+
+      await manager.initialize();
+
+      const sourceDir = path.join(testDir, 'source-folder');
+      fs.mkdirSync(sourceDir, { recursive: true });
+
+      const skillContent = `---
+name: Folder Skill
+description: A skill imported from a folder
+---
+
+Folder skill content.
+`;
+      fs.writeFileSync(path.join(sourceDir, 'SKILL.md'), skillContent);
+      fs.writeFileSync(path.join(sourceDir, 'template.md'), '# Template\nSome template content.');
+      fs.writeFileSync(path.join(sourceDir, 'data.json'), '{"key": "value"}');
+
+      const skill = await manager.addSkill(sourceDir);
+
+      expect(skill).not.toBeNull();
+      expect(skill?.name).toBe('Folder Skill');
+      expect(skill?.source).toBe('custom');
+
+      // Verify SKILL.md was copied
+      const destDir = path.join(userSkillsPath, 'Folder-Skill');
+      expect(fs.existsSync(path.join(destDir, 'SKILL.md'))).toBe(true);
+
+      // Verify companion files were also copied
+      expect(fs.existsSync(path.join(destDir, 'template.md'))).toBe(true);
+      expect(fs.existsSync(path.join(destDir, 'data.json'))).toBe(true);
+    });
+
+    it('should throw error when folder has no SKILL.md', async () => {
+      if (!moduleAvailable || !manager) return;
+
+      await manager.initialize();
+
+      const sourceDir = path.join(testDir, 'source-no-skill-md');
+      fs.mkdirSync(sourceDir, { recursive: true });
+      fs.writeFileSync(path.join(sourceDir, 'readme.txt'), 'Not a skill folder.');
+
+      await expect(manager.addSkill(sourceDir)).rejects.toThrow(
+        'does not contain a SKILL.md file',
+      );
+    });
+  });
+
   describe('deleteSkill', () => {
     it('should delete custom skills', async () => {
       if (!moduleAvailable || !manager) return;


### PR DESCRIPTION
## Summary

Fixes #656

When importing a local skill via **Settings → Skills → Add → Upload a skill**, only the `SKILL.md` file was copied. Any companion files bundled alongside the skill (e.g. `template_layouts.md`, `template.pptx`, `data.json`) were silently ignored, making locally-authored multi-file skills unusable after import.

This PR changes the import flow to select an entire **folder** instead of a single file, then copies all files within that folder into the user skills directory.

---

## Problem

Skills can contain companion files that the agent reads at runtime (templates, reference data, etc.). The previous file-picker dialog only accepted a single `.md` file, so importing a skill stripped out everything except `SKILL.md`.

**Before:**
- Dialog: "Select a SKILL.md file" (single-file picker)
- Result: only `SKILL.md` copied → companion files lost

**After:**
- Dialog: "Select a skill folder" (directory picker)
- Result: all files in the selected folder are copied → full skill preserved

---

## Changes

| File | Change |
|------|--------|
| `packages/agent-core/src/internal/classes/SkillsManager.ts` | `addSkill()` detects directory vs file; new `addFromFolder()` copies all sibling files |
| `apps/desktop/src/main/ipc/handlers.ts` | `skills:pick-file` → `skills:pick-folder` with `openDirectory` property |
| `apps/desktop/src/preload/index.ts` | `pickSkillFile()` → `pickSkillFolder()` |
| `apps/web/src/client/lib/accomplish.ts` | `AccomplishAPI` interface updated to `pickSkillFolder()` |
| `apps/web/src/client/components/settings/skills/AddSkillDropdown.tsx` | Calls `pickSkillFolder()` instead of `pickSkillFile()` |
| `apps/web/locales/en/settings.json` | Description updated to "Upload a skill folder" |
| `apps/web/locales/zh-CN/settings.json` | Description updated to "上传技能文件夹" |
| `packages/agent-core/tests/unit/skills/skills-manager.test.ts` | New tests: folder import copies all files; error when SKILL.md missing |

---

## Testing

- [x] TypeScript typecheck passes (`pnpm typecheck`) — all 3 workspaces clean
- [x] ESLint passes (`pnpm lint:eslint`) — no new issues
- [x] New unit tests added for `addSkill from folder`:
  - Copies `SKILL.md` **and** all companion files to the destination directory
  - Throws a descriptive error when the selected folder has no `SKILL.md`
- [x] Backward-compatible: passing a file path (not a directory) to `addSkill()` still works via the existing `addFromFile()` path

---

## Notes

- Sub-directories inside the skill folder are intentionally **not** recursively copied — skills are expected to be flat folders (matching how bundled skills are structured).
- The `addSkillFromFile` IPC channel and preload method are renamed to `addSkillFromFolder` / `pickSkillFolder` for clarity. The underlying `addSkill(sourcePath)` API in agent-core remains unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skills can now be uploaded as complete folders; all companion files are automatically included during upload.

* **Localization**
  * Updated skill upload descriptions in English and Simplified Chinese to reflect folder-based uploads.

* **Tests**
  * Added test coverage for folder-based skill uploads and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->