### PR TITLE
feat(release): add Linux AppImage release support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ on:
         options:
           - all
           - macos-only
+          - linux-only
         default: all
       dry_run:
         description: 'Test mode - skips push to main, creates test release'
@@ -331,6 +332,55 @@ jobs:
             apps/desktop/release/*-x64.zip
           retention-days: 30
 
+  build-linux-x64:
+    name: Build Linux (x64 AppImage)
+    needs: version-bump
+    if: needs.version-bump.outputs.platforms == 'all' || needs.version-bump.outputs.platforms == 'linux-only'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: v${{ needs.version-bump.outputs.new_version }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download Node.js binaries
+        run: pnpm -F @accomplish/desktop download:nodejs
+
+      - name: Build desktop app
+        run: pnpm -F @accomplish/desktop build
+
+      - name: Package AppImage (unsigned)
+        run: node scripts/package.cjs --linux --x64 --publish never
+        working-directory: apps/desktop
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PYTHON: python
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Accomplish-linux-x64
+          path: apps/desktop/release/*-linux-x64.AppImage
+          retention-days: 30
+
   # build-windows-x64:
   #   name: Build Windows (x64)
   #   needs: version-bump
@@ -376,7 +426,7 @@ jobs:
 
   create-release:
     name: Create GitHub Release
-    needs: [version-bump, build-mac-arm64, build-mac-x64]
+    needs: [version-bump, build-mac-arm64, build-mac-x64, build-linux-x64]
     if: always() && needs.version-bump.result == 'success'
     runs-on: ubuntu-latest
     steps:
@@ -385,9 +435,10 @@ jobs:
           PLATFORMS="${{ needs.version-bump.outputs.platforms }}"
           MAC_ARM64="${{ needs.build-mac-arm64.result }}"
           MAC_X64="${{ needs.build-mac-x64.result }}"
+          LINUX_X64="${{ needs.build-linux-x64.result }}"
 
           echo "Requested platforms: $PLATFORMS"
-          echo "Build results: macOS-arm64=$MAC_ARM64, macOS-x64=$MAC_X64"
+          echo "Build results: macOS-arm64=$MAC_ARM64, macOS-x64=$MAC_X64, linux-x64=$LINUX_X64"
 
           # Validate all requested platform builds succeeded
           FAILED=0
@@ -399,6 +450,13 @@ jobs:
             fi
             if [ "$MAC_X64" != "success" ]; then
               echo "Error: macOS x64 build failed (result: $MAC_X64)"
+              FAILED=1
+            fi
+          fi
+
+          if [ "$PLATFORMS" == "all" ] || [ "$PLATFORMS" == "linux-only" ]; then
+            if [ "$LINUX_X64" != "success" ]; then
+              echo "Error: Linux x64 build failed (result: $LINUX_X64)"
               FAILED=1
             fi
           fi
@@ -438,6 +496,13 @@ jobs:
           name: Accomplish-macOS-x64
           path: ./release/x64
 
+      - name: Download Linux x64 AppImage artifact
+        if: needs.build-linux-x64.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: Accomplish-linux-x64
+          path: ./release/linux-x64
+
       # - name: Download Windows x64 artifacts
       #   if: needs.build-windows-x64.result == 'success'
       #   uses: actions/download-artifact@v4
@@ -461,6 +526,7 @@ jobs:
           files: |
             ./release/arm64/*
             ./release/x64/*
+            ./release/linux-x64/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   <a href="https://github.com/accomplish-ai/accomplish/commits"><img src="https://img.shields.io/github/last-commit/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="Last Commit" /></a>
   <a href="https://downloads.accomplish.ai/downloads/0.3.10/macos/Accomplish-0.3.10-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="Download for macOS (Apple Silicon)" /></a>
   <a href="https://downloads.accomplish.ai/downloads/0.3.10/macos/Accomplish-0.3.10-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="Download for macOS (Intel)" /></a>
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><img src="https://img.shields.io/badge/Download-Linux_(AppImage)-0ea5e9?style=flat-square" alt="Download for Linux (AppImage)" /></a>
   <a href="https://downloads.accomplish.ai/downloads/0.3.10/windows/Accomplish-0.3.10-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Download for Windows 11" /></a>
   <a href="https://discord.gg/MepaTT55"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
@@ -29,6 +30,8 @@ Accomplish is an open source AI desktop agent that automates file management, do
   <a href="https://downloads.accomplish.ai/downloads/0.3.10/macos/Accomplish-0.3.10-mac-arm64.dmg"><strong>Download for Mac (Apple Silicon)</strong></a>
   ·
   <a href="https://downloads.accomplish.ai/downloads/0.3.10/macos/Accomplish-0.3.10-mac-x64.dmg"><strong>Download for Mac (Intel)</strong></a>
+  ·
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><strong>Download for Linux (AppImage)</strong></a>
   ·
   <a href="https://downloads.accomplish.ai/downloads/0.3.10/windows/Accomplish-0.3.10-win-x64.exe"><strong>Download for Windows 11</strong></a>
   ·
@@ -189,7 +192,7 @@ Accomplish runs locally on your machine. Your files stay on your device, and you
 
 <div align="center">
 
-[**Download for Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.3.10/macos/Accomplish-0.3.10-mac-arm64.dmg) · [**Download for Mac (Intel)**](https://downloads.accomplish.ai/downloads/0.3.10/macos/Accomplish-0.3.10-mac-x64.dmg) · [**Download for Windows 11**](https://downloads.accomplish.ai/downloads/0.3.10/windows/Accomplish-0.3.10-win-x64.exe)
+[**Download for Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.3.10/macos/Accomplish-0.3.10-mac-arm64.dmg) · [**Download for Mac (Intel)**](https://downloads.accomplish.ai/downloads/0.3.10/macos/Accomplish-0.3.10-mac-x64.dmg) · [**Download for Linux (AppImage)**](https://github.com/accomplish-ai/accomplish/releases/latest) · [**Download for Windows 11**](https://downloads.accomplish.ai/downloads/0.3.10/windows/Accomplish-0.3.10-win-x64.exe)
 
 </div>
 


### PR DESCRIPTION
## Summary
- add Linux x64 AppImage build job to the release workflow
- include Linux AppImage artifacts in GitHub release publishing
- add Linux AppImage download links in README

## Why
Directly committing AppImage binaries is blocked by GitHub size limits (>100MB). This change adds Linux compatibility via release artifacts instead.

## Notes
- Supports `platforms: all` and new `platforms: linux-only` option in release workflow.
- AppImage downloads are exposed via `releases/latest` links in README.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Linux (x64) platform support is now available with AppImage-based releases and automated build pipelines.

* **Documentation**
  * Added Linux download links and badges to the README, providing installation options alongside macOS and Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->