### PR TITLE
fix: update window reference on every task start to prevent Question API 503

### DIFF
--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -153,8 +153,11 @@ export function registerIPCHandlers(): void {
       );
     }
 
+    // Always update the window reference so the permission/question APIs
+    // use the current window (handles window recreation on macOS reactivation)
+    initPermissionApi(window, () => taskManager.getActiveTaskId());
+
     if (!permissionApiInitialized) {
-      initPermissionApi(window, () => taskManager.getActiveTaskId());
       startPermissionApiServer();
       startQuestionApiServer();
       permissionApiInitialized = true;


### PR DESCRIPTION
Fixes #679

## Summary

The `AskUserQuestion` MCP tool was returning a `503: Question API not initialized` error because the `mainWindow` reference became stale after window recreation.

### Root cause

In `apps/desktop/src/main/ipc/handlers.ts`, `initPermissionApi(window, ...)` was called inside a one-time initialization guard (`if (!permissionApiInitialized)`). This meant the `mainWindow` reference was set exactly once on the first task start and never updated.

When the `BrowserWindow` was recreated (e.g., macOS app reactivation after quit, or window close/reopen), the old `mainWindow` reference pointed to a destroyed window. The Question API server's handler checks `mainWindow.isDestroyed()` and returns 503 when true.

### Fix

Move `initPermissionApi()` outside the one-time guard so the window reference is refreshed on every `task:start` call, while keeping the HTTP server startup (`startPermissionApiServer` / `startQuestionApiServer`) as a one-time operation.

```diff
-    if (!permissionApiInitialized) {
-      initPermissionApi(window, () => taskManager.getActiveTaskId());
+    initPermissionApi(window, () => taskManager.getActiveTaskId());
+
+    if (!permissionApiInitialized) {
       startPermissionApiServer();
       startQuestionApiServer();
       permissionApiInitialized = true;
     }
```

### How to test

1. Start a task, verify AskUserQuestion works
2. Close and reopen the app window (or trigger macOS reactivation)
3. Start a new task that calls AskUserQuestion
4. Should get a valid response instead of 503

This contribution was developed with AI assistance (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed permission and question API window references to remain current after window recreation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->