### PR TITLE
fix: pass Z.ai API key in provider options for authentication

### DIFF
--- a/packages/agent-core/src/opencode/config-builder.ts
+++ b/packages/agent-core/src/opencode/config-builder.ts
@@ -528,7 +528,7 @@ export async function buildProviderConfigs(
       id: 'zai-coding-plan',
       npm: '@ai-sdk/openai-compatible',
       name: 'Z.AI Coding Plan',
-      options: { baseURL: zaiEndpoint },
+      options: { baseURL: zaiEndpoint, ...(zaiKey ? { apiKey: zaiKey } : {}) },
       models: zaiModels,
     });
     console.log('[OpenCode Config Builder] Z.AI Coding Plan configured, region:', zaiRegion);


### PR DESCRIPTION
## Summary

- Fix Z.ai authentication by including `apiKey` in the provider options passed to `@ai-sdk/openai-compatible`
- The API key was being stored correctly but not forwarded to the OpenAI-compatible SDK when building the OpenCode config

Fixes #678

## Root Cause

In `config-builder.ts`, the Z.ai provider configuration only set `baseURL` in the options object:

```typescript
options: { baseURL: zaiEndpoint }
```

Other OpenAI-compatible providers (Moonshot at line 252, LiteLLM at line 397) correctly include the API key:

```typescript
options: { baseURL: ..., ...(apiKey ? { apiKey } : {}) }
```

This caused the SDK to make unauthenticated requests to the Z.ai API, resulting in "Authentication parameter not received in Header" errors.

## Fix

Added `apiKey` to the Z.ai provider options, matching the pattern used by Moonshot and LiteLLM.

## Test plan

- [ ] Configure Z.ai provider with International region and a valid API key
- [ ] Verify connection test succeeds
- [ ] Verify task execution works with GLM models
- [ ] Verify China region still works correctly

This contribution was developed with AI assistance (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced Z.AI Coding Plan provider configuration to improve API key handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->