### PR TITLE
fix(csp): allow unsafe-inline script-src in dev to unblock React HMR …

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -162,11 +162,14 @@ function createWindow() {
   }
 
   mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
+    // In dev mode, @vitejs/plugin-react injects an inline HMR preamble script that
+    // requires 'unsafe-inline'. This is safe since dev builds are never distributed.
+    const scriptSrc = app.isPackaged ? "'self'" : "'self' 'unsafe-inline'";
     callback({
       responseHeaders: {
         ...details.responseHeaders,
         'Content-Security-Policy': [
-          "default-src 'self' https:; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https: ws: wss:; font-src 'self' https: data:",
+          `default-src 'self' https:; script-src ${scriptSrc}; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https: ws: wss:; font-src 'self' https: data:`,
         ],
       },
     });


### PR DESCRIPTION
- The @vitejs/plugin-react plugin injects an inline <script type="module"> to bootstrap React Fast Refresh (HMR preamble)
- The strict script-src 'self' CSP in Electron's onHeadersReceived was blocking it, causing:
  - CSP violation for the inline script
  - "@vitejs/plugin-react can't detect preamble"
- Fix: include 'unsafe-inline' in script-src only when app.isPackaged === false (dev); production CSP unchanged

## Test plan
- [x] pnpm dev in apps/desktop — no CSP errors in DevTools console
- [x] React HMR works (hot-reload on component edits)
- [x] Packaged build still uses strict script-src 'self'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted Content-Security-Policy header configuration to apply environment-specific script source settings for mainWindow webRequests, with different policy strictness between development and production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->