### PR TITLE
docs: add Linux (Ubuntu Arm64, Ubuntu x64) download links to README (ENG-867)

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -14,6 +14,8 @@
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="تحميل لـ macOS (Apple Silicon)" /></a>
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="تحميل لـ macOS (Intel)" /></a>
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="تحميل لـ Windows 11" /></a>
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><img src="https://img.shields.io/badge/Download-Linux_(Ubuntu_Arm64)-0ea5e9?style=flat-square" alt="تحميل لـ Linux (Ubuntu Arm64)" /></a>
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><img src="https://img.shields.io/badge/Download-Linux_(Ubuntu_x64)-0ea5e9?style=flat-square" alt="تحميل لـ Linux (Ubuntu x64)" /></a>
   <a href="https://discord.gg/YH86b2P8"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
@@ -31,6 +33,10 @@ Accomplish هو وكيل سطح مكتب ذكاء اصطناعي مفتوح ال
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg"><strong>تحميل لـ Mac (Intel)</strong></a>
   ·
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe"><strong>تحميل لـ Windows 11</strong></a>
+  ·
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><strong>تحميل لـ Linux (Ubuntu Arm64)</strong></a>
+  ·
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><strong>تحميل لـ Linux (Ubuntu x64)</strong></a>
   ·
   <a href="https://www.accomplish.ai/">موقع Accomplish</a>
   ·
@@ -189,7 +195,7 @@ Accomplish هو وكيل سطح مكتب ذكاء اصطناعي مفتوح ال
 
 <div align="center">
 
-[**تحميل لـ Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg) · [**تحميل لـ Mac (Intel)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg) · [**تحميل لـ Windows 11**](https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe)
+[**تحميل لـ Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg) · [**تحميل لـ Mac (Intel)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg) · [**تحميل لـ Windows 11**](https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe) · [**تحميل لـ Linux (Ubuntu Arm64)**](https://github.com/accomplish-ai/accomplish/releases/latest) · [**تحميل لـ Linux (Ubuntu x64)**](https://github.com/accomplish-ai/accomplish/releases/latest)
 
 </div>
 

--- a/README.es.md
+++ b/README.es.md
@@ -14,6 +14,8 @@
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="Descargar para macOS (Apple Silicon)" /></a>
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="Descargar para macOS (Intel)" /></a>
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Descargar para Windows 11" /></a>
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><img src="https://img.shields.io/badge/Download-Linux_(Ubuntu_Arm64)-0ea5e9?style=flat-square" alt="Descargar para Linux (Ubuntu Arm64)" /></a>
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><img src="https://img.shields.io/badge/Download-Linux_(Ubuntu_x64)-0ea5e9?style=flat-square" alt="Descargar para Linux (Ubuntu x64)" /></a>
   <a href="https://discord.gg/YH86b2P8"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
@@ -31,6 +33,10 @@ Accomplish es un agente de escritorio de IA de código abierto que automatiza la
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg"><strong>Descargar para Mac (Intel)</strong></a>
   ·
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe"><strong>Descargar para Windows 11</strong></a>
+  ·
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><strong>Descargar para Linux (Ubuntu Arm64)</strong></a>
+  ·
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><strong>Descargar para Linux (Ubuntu x64)</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Sitio web de Accomplish</a>
   ·
@@ -189,7 +195,7 @@ Accomplish se ejecuta localmente en tu máquina. Tus archivos permanecen en tu d
 
 <div align="center">
 
-[**Descargar para Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg) · [**Descargar para Mac (Intel)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg) · [**Descargar para Windows 11**](https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe)
+[**Descargar para Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg) · [**Descargar para Mac (Intel)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg) · [**Descargar para Windows 11**](https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe) · [**Descargar para Linux (Ubuntu Arm64)**](https://github.com/accomplish-ai/accomplish/releases/latest) · [**Descargar para Linux (Ubuntu x64)**](https://github.com/accomplish-ai/accomplish/releases/latest)
 
 </div>
 

--- a/README.hi.md
+++ b/README.hi.md
@@ -14,6 +14,8 @@
   <a href="https://downloads.accomplish.ai/downloads/0.3.10/macos/Accomplish-0.3.10-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="macOS (Apple Silicon) के लिए डाउनलोड करें" /></a>
   <a href="https://downloads.accomplish.ai/downloads/0.3.10/macos/Accomplish-0.3.10-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="macOS (Intel) के लिए डाउनलोड करें" /></a>
   <a href="https://downloads.accomplish.ai/downloads/0.3.10/windows/Accomplish-0.3.10-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Windows 11 के लिए डाउनलोड करें" /></a>
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><img src="https://img.shields.io/badge/Download-Linux_(Ubuntu_Arm64)-0ea5e9?style=flat-square" alt="Linux (Ubuntu Arm64) के लिए डाउनलोड करें" /></a>
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><img src="https://img.shields.io/badge/Download-Linux_(Ubuntu_x64)-0ea5e9?style=flat-square" alt="Linux (Ubuntu x64) के लिए डाउनलोड करें" /></a>
   <a href="https://discord.gg/MepaTT55"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
@@ -31,6 +33,10 @@ Accomplish एक ओपन सोर्स AI डेस्कटॉप एज�
   <a href="https://downloads.accomplish.ai/downloads/0.3.10/macos/Accomplish-0.3.10-mac-x64.dmg"><strong>Mac (Intel) के लिए डाउनलोड करें</strong></a>
   ·
   <a href="https://downloads.accomplish.ai/downloads/0.3.10/windows/Accomplish-0.3.10-win-x64.exe"><strong>Windows 11 के लिए डाउनलोड करें</strong></a>
+  ·
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><strong>Linux (Ubuntu Arm64) के लिए डाउनलोड करें</strong></a>
+  ·
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><strong>Linux (Ubuntu x64) के लिए डाउनलोड करें</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Accomplish वेबसाइट</a>
   ·
@@ -189,7 +195,7 @@ Accomplish आपकी मशीन पर स्थानीय रूप स�
 
 <div align="center">
 
-[**Mac (Apple Silicon) के लिए डाउनलोड करें**](https://downloads.accomplish.ai/downloads/0.3.10/macos/Accomplish-0.3.10-mac-arm64.dmg) · [**Mac (Intel) के लिए डाउनलोड करें**](https://downloads.accomplish.ai/downloads/0.3.10/macos/Accomplish-0.3.10-mac-x64.dmg) · [**Windows 11 के लिए डाउनलोड करें**](https://downloads.accomplish.ai/downloads/0.3.10/windows/Accomplish-0.3.10-win-x64.exe)
+[**Mac (Apple Silicon) के लिए डाउनलोड करें**](https://downloads.accomplish.ai/downloads/0.3.10/macos/Accomplish-0.3.10-mac-arm64.dmg) · [**Mac (Intel) के लिए डाउनलोड करें**](https://downloads.accomplish.ai/downloads/0.3.10/macos/Accomplish-0.3.10-mac-x64.dmg) · [**Windows 11 के लिए डाउनलोड करें**](https://downloads.accomplish.ai/downloads/0.3.10/windows/Accomplish-0.3.10-win-x64.exe) · [**Linux (Ubuntu Arm64) के लिए डाउनलोड करें**](https://github.com/accomplish-ai/accomplish/releases/latest) · [**Linux (Ubuntu x64) के लिए डाउनलोड करें**](https://github.com/accomplish-ai/accomplish/releases/latest)
 
 </div>
 

--- a/README.id.md
+++ b/README.id.md
@@ -14,6 +14,8 @@
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="Unduh untuk macOS (Apple Silicon)" /></a>
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="Unduh untuk macOS (Intel)" /></a>
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Unduh untuk Windows 11" /></a>
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><img src="https://img.shields.io/badge/Download-Linux_(Ubuntu_Arm64)-0ea5e9?style=flat-square" alt="Unduh untuk Linux (Ubuntu Arm64)" /></a>
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><img src="https://img.shields.io/badge/Download-Linux_(Ubuntu_x64)-0ea5e9?style=flat-square" alt="Unduh untuk Linux (Ubuntu x64)" /></a>
   <a href="https://discord.gg/YH86b2P8"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
@@ -31,6 +33,10 @@ Accomplish adalah agen desktop AI open source yang mengotomatisasi manajemen fil
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg"><strong>Unduh untuk Mac (Intel)</strong></a>
   ·
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe"><strong>Unduh untuk Windows 11</strong></a>
+  ·
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><strong>Unduh untuk Linux (Ubuntu Arm64)</strong></a>
+  ·
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><strong>Unduh untuk Linux (Ubuntu x64)</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Website Accomplish</a>
   ·
@@ -189,7 +195,7 @@ Accomplish berjalan secara lokal di mesin Anda. File Anda tetap di perangkat And
 
 <div align="center">
 
-[**Unduh untuk Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg) · [**Unduh untuk Mac (Intel)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg) · [**Unduh untuk Windows 11**](https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe)
+[**Unduh untuk Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg) · [**Unduh untuk Mac (Intel)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg) · [**Unduh untuk Windows 11**](https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe) · [**Unduh untuk Linux (Ubuntu Arm64)**](https://github.com/accomplish-ai/accomplish/releases/latest) · [**Unduh untuk Linux (Ubuntu x64)**](https://github.com/accomplish-ai/accomplish/releases/latest)
 
 </div>
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -14,6 +14,8 @@
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="macOS用ダウンロード (Apple Silicon)" /></a>
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="macOS用ダウンロード (Intel)" /></a>
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Windows 11用ダウンロード" /></a>
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><img src="https://img.shields.io/badge/Download-Linux_(Ubuntu_Arm64)-0ea5e9?style=flat-square" alt="Linux用ダウンロード（Ubuntu Arm64）" /></a>
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><img src="https://img.shields.io/badge/Download-Linux_(Ubuntu_x64)-0ea5e9?style=flat-square" alt="Linux用ダウンロード（Ubuntu x64）" /></a>
   <a href="https://discord.gg/YH86b2P8"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
@@ -31,6 +33,10 @@ Accomplishは、お使いのマシン上でローカルにファイル管理、�
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg"><strong>Mac用ダウンロード（Intel）</strong></a>
   ·
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe"><strong>Windows 11用ダウンロード</strong></a>
+  ·
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><strong>Linux用ダウンロード（Ubuntu Arm64）</strong></a>
+  ·
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><strong>Linux用ダウンロード（Ubuntu x64）</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Accomplishウェブサイト</a>
   ·
@@ -189,7 +195,7 @@ Accomplishはお使いのマシン上でローカルに実行されます。フ�
 
 <div align="center">
 
-[**Mac用ダウンロード（Apple Silicon）**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg) · [**Mac用ダウンロード（Intel）**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg) · [**Windows 11用ダウンロード**](https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe)
+[**Mac用ダウンロード（Apple Silicon）**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg) · [**Mac用ダウンロード（Intel）**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg) · [**Windows 11用ダウンロード**](https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe) · [**Linux用ダウンロード（Ubuntu Arm64）**](https://github.com/accomplish-ai/accomplish/releases/latest) · [**Linux用ダウンロード（Ubuntu x64）**](https://github.com/accomplish-ai/accomplish/releases/latest)
 
 </div>
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -14,6 +14,8 @@
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="macOS 다운로드 (Apple Silicon)" /></a>
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="macOS 다운로드 (Intel)" /></a>
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Windows 11 다운로드" /></a>
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><img src="https://img.shields.io/badge/Download-Linux_(Ubuntu_Arm64)-0ea5e9?style=flat-square" alt="Linux 다운로드 (Ubuntu Arm64)" /></a>
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><img src="https://img.shields.io/badge/Download-Linux_(Ubuntu_x64)-0ea5e9?style=flat-square" alt="Linux 다운로드 (Ubuntu x64)" /></a>
   <a href="https://discord.gg/YH86b2P8"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
@@ -31,6 +33,10 @@ Accomplish는 로컬 머신에서 파일 관리, 문서 작성, 브라우저 작
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg"><strong>Mac용 다운로드 (Intel)</strong></a>
   ·
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe"><strong>Windows 11용 다운로드</strong></a>
+  ·
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><strong>Linux용 다운로드 (Ubuntu Arm64)</strong></a>
+  ·
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><strong>Linux용 다운로드 (Ubuntu x64)</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Accomplish 웹사이트</a>
   ·
@@ -189,7 +195,7 @@ Accomplish는 로컬 머신에서 실행됩니다. 파일은 기기에 저장되
 
 <div align="center">
 
-[**Mac용 다운로드 (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg) · [**Mac용 다운로드 (Intel)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg) · [**Windows 11용 다운로드**](https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe)
+[**Mac용 다운로드 (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg) · [**Mac용 다운로드 (Intel)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg) · [**Windows 11용 다운로드**](https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe) · [**Linux용 다운로드 (Ubuntu Arm64)**](https://github.com/accomplish-ai/accomplish/releases/latest) · [**Linux용 다운로드 (Ubuntu x64)**](https://github.com/accomplish-ai/accomplish/releases/latest)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="Download for macOS (Apple Silicon)" /></a>
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="Download for macOS (Intel)" /></a>
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Download for Windows 11" /></a>
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><img src="https://img.shields.io/badge/Download-Linux_(Ubuntu_Arm64)-0ea5e9?style=flat-square" alt="Download for Linux (Ubuntu Arm64)" /></a>
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><img src="https://img.shields.io/badge/Download-Linux_(Ubuntu_x64)-0ea5e9?style=flat-square" alt="Download for Linux (Ubuntu x64)" /></a>
   <a href="https://discord.gg/YH86b2P8"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
@@ -31,6 +33,10 @@ Accomplish is an open source AI desktop agent that automates file management, do
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg"><strong>Download for Mac (Intel)</strong></a>
   ·
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe"><strong>Download for Windows 11</strong></a>
+  ·
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><strong>Download for Linux (Ubuntu Arm64)</strong></a>
+  ·
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><strong>Download for Linux (Ubuntu x64)</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Accomplish website</a>
   ·
@@ -189,7 +195,7 @@ Accomplish runs locally on your machine. Your files stay on your device, and you
 
 <div align="center">
 
-[**Download for Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg) · [**Download for Mac (Intel)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg) · [**Download for Windows 11**](https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe)
+[**Download for Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg) · [**Download for Mac (Intel)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg) · [**Download for Windows 11**](https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe) · [**Download for Linux (Ubuntu Arm64)**](https://github.com/accomplish-ai/accomplish/releases/latest) · [**Download for Linux (Ubuntu x64)**](https://github.com/accomplish-ai/accomplish/releases/latest)
 
 </div>
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -14,6 +14,8 @@
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="Скачать для macOS (Apple Silicon)" /></a>
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="Скачать для macOS (Intel)" /></a>
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Скачать для Windows 11" /></a>
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><img src="https://img.shields.io/badge/Download-Linux_(Ubuntu_Arm64)-0ea5e9?style=flat-square" alt="Скачать для Linux (Ubuntu Arm64)" /></a>
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><img src="https://img.shields.io/badge/Download-Linux_(Ubuntu_x64)-0ea5e9?style=flat-square" alt="Скачать для Linux (Ubuntu x64)" /></a>
   <a href="https://discord.gg/YH86b2P8"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
@@ -31,6 +33,10 @@ Accomplish — это открытый ИИ-агент для рабочего �
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg"><strong>Скачать для Mac (Intel)</strong></a>
   ·
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe"><strong>Скачать для Windows 11</strong></a>
+  ·
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><strong>Скачать для Linux (Ubuntu Arm64)</strong></a>
+  ·
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><strong>Скачать для Linux (Ubuntu x64)</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Сайт Accomplish</a>
   ·
@@ -189,7 +195,7 @@ Accomplish работает локально на вашем компьютер�
 
 <div align="center">
 
-[**Скачать для Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg) · [**Скачать для Mac (Intel)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg) · [**Скачать для Windows 11**](https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe)
+[**Скачать для Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg) · [**Скачать для Mac (Intel)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg) · [**Скачать для Windows 11**](https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe) · [**Скачать для Linux (Ubuntu Arm64)**](https://github.com/accomplish-ai/accomplish/releases/latest) · [**Скачать для Linux (Ubuntu x64)**](https://github.com/accomplish-ai/accomplish/releases/latest)
 
 </div>
 

--- a/README.ta.md
+++ b/README.ta.md
@@ -14,6 +14,8 @@
   <a href="https://downloads.accomplish.ai/downloads/0.3.10/macos/Accomplish-0.3.10-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="macOS (Apple Silicon) க்கான பதிவிறக்கம்" /></a>
   <a href="https://downloads.accomplish.ai/downloads/0.3.10/macos/Accomplish-0.3.10-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="macOS (Intel) க்கான பதிவிறக்கம்" /></a>
   <a href="https://downloads.accomplish.ai/downloads/0.3.10/windows/Accomplish-0.3.10-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Windows 11 க்கான பதிவிறக்கம்" /></a>
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><img src="https://img.shields.io/badge/Download-Linux_(Ubuntu_Arm64)-0ea5e9?style=flat-square" alt="Linux (Ubuntu Arm64) க்கான பதிவிறக்கம்" /></a>
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><img src="https://img.shields.io/badge/Download-Linux_(Ubuntu_x64)-0ea5e9?style=flat-square" alt="Linux (Ubuntu x64) க்கான பதிவிறக்கம்" /></a>
   <a href="https://discord.gg/MepaTT55"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
@@ -31,6 +33,10 @@ Accomplish என்பது உங்கள் கணினியிலேய�
   <a href="https://downloads.accomplish.ai/downloads/0.3.10/macos/Accomplish-0.3.10-mac-x64.dmg"><strong>Mac (Intel) க்கான பதிவிறக்கம்</strong></a>
   ·
   <a href="https://downloads.accomplish.ai/downloads/0.3.10/windows/Accomplish-0.3.10-win-x64.exe"><strong>Windows 11 க்கான பதிவிறக்கம்</strong></a>
+  ·
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><strong>Linux (Ubuntu Arm64) க்கான பதிவிறக்கம்</strong></a>
+  ·
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><strong>Linux (Ubuntu x64) க்கான பதிவிறக்கம்</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Accomplish வலைத்தளம்</a>
   ·
@@ -189,7 +195,7 @@ Accomplish உங்கள் கணினியிலேயே இயங்க�
 
 <div align="center">
 
-[**Mac (Apple Silicon) க்கான பதிவிறக்கம்**](https://downloads.accomplish.ai/downloads/0.3.10/macos/Accomplish-0.3.10-mac-arm64.dmg) · [**Mac (Intel) க்கான பதிவிறக்கம்**](https://downloads.accomplish.ai/downloads/0.3.10/macos/Accomplish-0.3.10-mac-x64.dmg) · [**Windows 11 க்கான பதிவிறக்கம்**](https://downloads.accomplish.ai/downloads/0.3.10/windows/Accomplish-0.3.10-win-x64.exe)
+[**Mac (Apple Silicon) க்கான பதிவிறக்கம்**](https://downloads.accomplish.ai/downloads/0.3.10/macos/Accomplish-0.3.10-mac-arm64.dmg) · [**Mac (Intel) க்கான பதிவிறக்கம்**](https://downloads.accomplish.ai/downloads/0.3.10/macos/Accomplish-0.3.10-mac-x64.dmg) · [**Windows 11 க்கான பதிவிறக்கம்**](https://downloads.accomplish.ai/downloads/0.3.10/windows/Accomplish-0.3.10-win-x64.exe) · [**Linux (Ubuntu Arm64) க்கான பதிவிறக்கம்**](https://github.com/accomplish-ai/accomplish/releases/latest) · [**Linux (Ubuntu x64) க்கான பதிவிறக்கம்**](https://github.com/accomplish-ai/accomplish/releases/latest)
 
 </div>
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -14,6 +14,8 @@
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="macOS için İndir (Apple Silicon)" /></a>
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="macOS için İndir (Intel)" /></a>
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Windows 11 için İndir" /></a>
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><img src="https://img.shields.io/badge/Download-Linux_(Ubuntu_Arm64)-0ea5e9?style=flat-square" alt="Linux için İndir (Ubuntu Arm64)" /></a>
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><img src="https://img.shields.io/badge/Download-Linux_(Ubuntu_x64)-0ea5e9?style=flat-square" alt="Linux için İndir (Ubuntu x64)" /></a>
   <a href="https://discord.gg/YH86b2P8"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
@@ -31,6 +33,10 @@ Accomplish, bilgisayarınızda yerel olarak dosya yönetimi, belge oluşturma ve
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg"><strong>Mac için İndirin (Intel)</strong></a>
   ·
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe"><strong>Windows 11 için İndirin</strong></a>
+  ·
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><strong>Linux için İndirin (Ubuntu Arm64)</strong></a>
+  ·
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><strong>Linux için İndirin (Ubuntu x64)</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Accomplish web sitesi</a>
   ·
@@ -189,7 +195,7 @@ Accomplish bilgisayarınızda yerel olarak çalışır. Dosyalarınız cihazın�
 
 <div align="center">
 
-[**Mac için İndirin (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg) · [**Mac için İndirin (Intel)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg) · [**Windows 11 için İndirin**](https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe)
+[**Mac için İndirin (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg) · [**Mac için İndirin (Intel)**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg) · [**Windows 11 için İndirin**](https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe) · [**Linux için İndirin (Ubuntu Arm64)**](https://github.com/accomplish-ai/accomplish/releases/latest) · [**Linux için İndirin (Ubuntu x64)**](https://github.com/accomplish-ai/accomplish/releases/latest)
 
 </div>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,6 +14,8 @@
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="下载 macOS 版 (Apple Silicon)" /></a>
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="下载 macOS 版 (Intel)" /></a>
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="下载 Windows 11 版" /></a>
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><img src="https://img.shields.io/badge/Download-Linux_(Ubuntu_Arm64)-0ea5e9?style=flat-square" alt="下载 Linux 版（Ubuntu Arm64）" /></a>
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><img src="https://img.shields.io/badge/Download-Linux_(Ubuntu_x64)-0ea5e9?style=flat-square" alt="下载 Linux 版（Ubuntu x64）" /></a>
   <a href="https://discord.gg/YH86b2P8"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
@@ -31,6 +33,10 @@ Accomplish 是一款开源 AI 桌面代理，可在您的本地机器上自动�
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg"><strong>下载 Mac 版（Intel）</strong></a>
   ·
   <a href="https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe"><strong>下载 Windows 11 版</strong></a>
+  ·
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><strong>下载 Linux 版（Ubuntu Arm64）</strong></a>
+  ·
+  <a href="https://github.com/accomplish-ai/accomplish/releases/latest"><strong>下载 Linux 版（Ubuntu x64）</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Accomplish 官网</a>
   ·
@@ -189,7 +195,7 @@ Accomplish 在您的机器上本地运行。您的文件保留在您的设备上
 
 <div align="center">
 
-[**下载 Mac 版（Apple Silicon）**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg) · [**下载 Mac 版（Intel）**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg) · [**下载 Windows 11 版**](https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe)
+[**下载 Mac 版（Apple Silicon）**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-arm64.dmg) · [**下载 Mac 版（Intel）**](https://downloads.accomplish.ai/downloads/0.4.0/macos/Accomplish-0.4.0-mac-x64.dmg) · [**下载 Windows 11 版**](https://downloads.accomplish.ai/downloads/0.4.0/windows/Accomplish-0.4.0-win-x64.exe) · [**下载 Linux 版（Ubuntu Arm64）**](https://github.com/accomplish-ai/accomplish/releases/latest) · [**下载 Linux 版（Ubuntu x64）**](https://github.com/accomplish-ai/accomplish/releases/latest)
 
 </div>
 


### PR DESCRIPTION
## Summary

Adds Linux (Ubuntu Arm64 and Ubuntu x64 AppImage) download links to README.md and all localized README variants.

Links point to the GitHub releases page until dedicated Linux builds are available via the release pipeline (ENG-866).

## Changes
- README.md: Added Linux download badges/links in all download sections
- All localized READMEs (ar, es, hi, id, ja, ko, ru, ta, tr, zh-CN): Same additions

## Related Issues
Closes ENG-867

---

> Thank you to everyone who has been contributing Linux support PRs — this docs update surfaces the download path for users as soon as the builds land! 🐧

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added Linux download options (Ubuntu Arm64 and Ubuntu x64) across README files in multiple languages, including Arabic, Spanish, Hindi, Indonesian, Japanese, Korean, English, Russian, Tamil, Turkish, and Simplified Chinese.
* New download badges and links now appear in the top download section and additional content areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->