### PR TITLE
fix(windows): handle spaces and special chars in opencode.exe spawn path (ENG-605)

### DIFF
--- a/packages/agent-core/src/internal/classes/OpenCodeAdapter.ts
+++ b/packages/agent-core/src/internal/classes/OpenCodeAdapter.ts
@@ -442,8 +442,14 @@ export class OpenCodeAdapter extends EventEmitter<OpenCodeAdapterEvents> {
 
   private escapeShellArg(arg: string): string {
     if (this.options.platform === 'win32') {
-      if (arg.includes(' ') || arg.includes('"')) {
-        return `"${arg.replace(/"/g, '""')}"`;
+      // Quote if the argument contains spaces, double-quotes, or any cmd.exe
+      // metacharacter (&, |, <, >, ^, %) that would be misinterpreted when
+      // executing via cmd.exe /s /c. See: https://github.com/accomplish-ai/accomplish/issues/596
+      if (/[ "&|<>^%]/.test(arg)) {
+        // Double embedded quotes per cmd.exe rules; escape % as ^% to prevent
+        // environment variable expansion (e.g. %PATH%) inside the quoted string.
+        const escaped = arg.replace(/"/g, '""').replace(/%/g, '^%');
+        return `"${escaped}"`;
       }
       return arg;
     } else {
@@ -878,12 +884,18 @@ export class OpenCodeAdapter extends EventEmitter<OpenCodeAdapterEvents> {
 
   private buildPtySpawnArgs(command: string, args: string[]): { file: string; args: string[] } {
     if (this.options.platform === 'win32') {
-      // Windows policy: always spawn the real .exe, never cmd wrappers.
-      if (command.toLowerCase().endsWith('.exe')) {
-        return { file: command, args };
+      if (!command.toLowerCase().endsWith('.exe')) {
+        throw new Error(`Windows CLI command must resolve to an .exe path. Received: ${command}`);
       }
 
-      throw new Error(`Windows CLI command must resolve to an .exe path. Received: ${command}`);
+      // Route through cmd.exe /s /c with proper inner quoting so that
+      // installation paths containing spaces (e.g. "C:\Users\My Name\...")
+      // are handled correctly in both ConPTY and WinPTY fallback modes.
+      // Passing the raw .exe path directly to pty.spawn works for ConPTY
+      // but fails in WinPTY where the unquoted path is split at every space.
+      // See: https://github.com/accomplish-ai/accomplish/issues/596
+      const fullCommand = this.buildShellCommand(command, args);
+      return { file: 'cmd.exe', args: ['/s', '/c', `"${fullCommand}"`] };
     }
 
     const shell =

--- a/packages/agent-core/tests/unit/opencode/adapter.test.ts
+++ b/packages/agent-core/tests/unit/opencode/adapter.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { OpenCodeCliNotFoundError } from '../../../src/internal/classes/OpenCodeAdapter.js';
+import os from 'os';
+import {
+  OpenCodeAdapter,
+  OpenCodeCliNotFoundError,
+  type AdapterOptions,
+} from '../../../src/internal/classes/OpenCodeAdapter.js';
 import {
   NON_TASK_CONTINUATION_TOOLS,
   isNonTaskContinuationToolName,
@@ -161,6 +166,125 @@ describe('Shell escaping utilities', () => {
 
       expect(fullCommand).toContain('"C:\\Users\\李 耀\\AppData\\opencode.exe"');
       expect(shellArgs[2]).toBe(`"${fullCommand}"`);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Issue #596 – Windows: opencode.exe fails to spawn when path has spaces
+  //
+  // buildPtySpawnArgs on win32 routes through cmd.exe /s /c with per-token
+  // quoting. These tests call the real private method via a minimal win32
+  // adapter instance so they stay in sync with the production implementation.
+  // ---------------------------------------------------------------------------
+  describe('Windows spawn via cmd.exe /s /c – Issue #596 (paths with spaces)', () => {
+    let win32Adapter: OpenCodeAdapter;
+
+    beforeEach(() => {
+      const opts: AdapterOptions = {
+        platform: 'win32',
+        isPackaged: false,
+        tempPath: os.tmpdir(),
+        getCliCommand: () => ({ command: 'C:\\Programs\\opencode.exe', args: [] }),
+        buildEnvironment: async () => ({}),
+        buildCliArgs: async () => [],
+      };
+      win32Adapter = new OpenCodeAdapter(opts);
+    });
+
+    afterEach(() => {
+      win32Adapter.dispose();
+    });
+
+    function spawnArgs(exe: string, args: string[]) {
+      return (
+        win32Adapter as unknown as {
+          buildPtySpawnArgs: (c: string, a: string[]) => { file: string; args: string[] };
+        }
+      ).buildPtySpawnArgs(exe, args);
+    }
+
+    it('uses cmd.exe /s /c as the spawn file for a Windows exe', () => {
+      const { file, args } = spawnArgs('C:\\Programs\\opencode.exe', ['run']);
+
+      expect(file).toBe('cmd.exe');
+      expect(args[0]).toBe('/s');
+      expect(args[1]).toBe('/c');
+    });
+
+    it('inner-quotes an exe path containing spaces', () => {
+      const exe =
+        'C:\\Users\\Anish Maheshwari\\AppData\\Local\\Programs\\@accomplishdesktop\\resources\\app.asar.unpacked\\node_modules\\opencode-windows-x64\\bin\\opencode.exe';
+      const { file, args } = spawnArgs(exe, ['run', '--format', 'json']);
+
+      expect(file).toBe('cmd.exe');
+
+      const outerArg = args[2];
+      expect(outerArg.startsWith('"')).toBe(true);
+      expect(outerArg.endsWith('"')).toBe(true);
+      expect(outerArg).toContain('"C:\\Users\\Anish Maheshwari\\');
+
+      // Issue #596: inner command must be a clean quoted-exe invocation.
+      const innerCommand = outerArg.slice(1, -1);
+      expect(innerCommand.startsWith('"C:\\')).toBe(true);
+      expect(innerCommand.startsWith('""')).toBe(false);
+    });
+
+    it('does NOT inner-quote a path that has no spaces', () => {
+      const exe = 'C:\\Programs\\opencode.exe';
+      const { args } = spawnArgs(exe, ['run']);
+
+      expect(args[2]).not.toContain('"C:\\Programs\\opencode.exe"');
+      expect(args[2].startsWith('"')).toBe(true);
+      expect(args[2].endsWith('"')).toBe(true);
+    });
+
+    it('inner-quotes CLI args that contain spaces', () => {
+      const exe = 'C:\\Users\\My User\\opencode.exe';
+      const { args } = spawnArgs(exe, ['run', '--prompt', 'fix the login bug']);
+
+      expect(args[2]).toContain('"C:\\Users\\My User\\opencode.exe"');
+      expect(args[2]).toContain('"fix the login bug"');
+      expect(args[2]).toContain(' run ');
+    });
+
+    it('handles a username with Unicode / CJK characters and spaces', () => {
+      const exe = 'C:\\Users\\李 四 Wang\\AppData\\Programs\\opencode.exe';
+      const { file, args } = spawnArgs(exe, ['run']);
+
+      expect(file).toBe('cmd.exe');
+      expect(args[2]).toContain('"C:\\Users\\李 四 Wang\\AppData\\Programs\\opencode.exe"');
+    });
+
+    it('escapes embedded double-quotes in the exe path', () => {
+      const exe = 'C:\\Users\\Li "test" User\\opencode.exe';
+      const { args } = spawnArgs(exe, ['run']);
+
+      expect(args[2]).toContain('"C:\\Users\\Li ""test"" User\\opencode.exe"');
+    });
+
+    it('quotes args containing cmd.exe metacharacters to prevent injection', () => {
+      // A user prompt like "foo&bar" must not be interpreted as two commands by
+      // cmd.exe. Without quoting, cmd.exe parses "&" as a command separator.
+      const exe = 'C:\\Programs\\opencode.exe';
+      const { args } = spawnArgs(exe, ['run', '--prompt', 'foo&bar']);
+
+      expect(args[2]).toContain('"foo&bar"');
+    });
+
+    it('escapes lone percent signs in args to prevent cmd.exe variable expansion', () => {
+      const exe = 'C:\\Programs\\opencode.exe';
+      const { args } = spawnArgs(exe, ['run', '--prompt', '100%']);
+
+      // % is escaped to ^% so cmd.exe does not attempt variable expansion
+      expect(args[2]).toContain('"100^%"');
+    });
+
+    it('escapes %VAR% patterns in args to prevent environment variable expansion', () => {
+      const exe = 'C:\\Programs\\opencode.exe';
+      const { args } = spawnArgs(exe, ['run', '--prompt', '%PATH%']);
+
+      // Both % signs must be escaped to break the %VAR% expansion pattern
+      expect(args[2]).toContain('"^%PATH^%"');
     });
   });
 

--- a/packages/agent-core/tests/unit/opencode/cli-resolver.test.ts
+++ b/packages/agent-core/tests/unit/opencode/cli-resolver.test.ts
@@ -192,6 +192,22 @@ describe('CLI Resolver', () => {
   });
 
   describe('getCliVersion', () => {
+    it('returns null and does not throw when called with a path that has spaces', async () => {
+      // Regression test for Issue #596.
+      // execFileSync (no shell) must be used so the path is passed to the OS
+      // verbatim rather than through cmd.exe quoting, which fails with
+      // double-leading-quote errors when spaces appear in the username.
+      const pathWithSpaces =
+        process.platform === 'win32'
+          ? 'C:\\Users\\Anish Maheshwari\\AppData\\Local\\Programs\\opencode.exe'
+          : '/home/my user with spaces/opencode';
+
+      const version = await getCliVersion(pathWithSpaces);
+
+      // Must return null (file not found) rather than throwing
+      expect(version).toBeNull();
+    });
+
     it('returns version from package.json when available', async () => {
       let packageName: string;
       if (process.platform === 'win32') {


### PR DESCRIPTION
## Summary

Fixes [#596](https://github.com/accomplish-ai/accomplish/issues/596) — Windows: opencode.exe fails to spawn when install path contains spaces.

### Changes
- Extend `escapeShellArg` win32 branch to also quote args containing cmd.exe metacharacters (`&`, `|`, `<`, `>`, `^`, `%`) and escape `%` as `^%` to prevent environment variable expansion
- Route Windows PTY through `cmd.exe /s /c` with inner quoting so installation paths with spaces work in both ConPTY and WinPTY fallback modes
- Add regression tests for special character and space escaping in `adapter.test.ts`
- Add regression test for `getCliVersion` with path containing spaces

### Files changed (3 only)
- `packages/agent-core/src/internal/classes/OpenCodeAdapter.ts` — bug fix
- `packages/agent-core/tests/unit/opencode/adapter.test.ts` — regression tests
- `packages/agent-core/tests/unit/opencode/cli-resolver.test.ts` — regression test

## Credit
Consolidates fix from @RajdeepKushwaha5 in #631 — thank you! 🙏

Closes #596
Closes ENG-605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows command execution to properly handle installation paths containing spaces and special characters.
  * Enhanced argument quoting and escaping for Windows cmd.exe metacharacters.
  * Fixed command spawning compatibility issues on Windows environments with special characters in paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->