### PR TITLE
fix: always register selected xAI model as final guard (ENG-598)

### DIFF
--- a/packages/agent-core/src/opencode/config-builder.ts
+++ b/packages/agent-core/src/opencode/config-builder.ts
@@ -283,8 +283,11 @@ export async function buildProviderConfigs(
           const mId = model.id.replace(/^xai\//, '');
           xaiModels[mId] = { name: model.name, tools: true };
         }
-      } else {
-        // Fallback: at minimum register the selected model
+      }
+
+      // Final guard: always ensure the selected model is registered,
+      // even if availableModels is stale/partial and doesn't include it.
+      if (!xaiModels[modelId]) {
         xaiModels[modelId] = { name: modelId, tools: true };
       }
 


### PR DESCRIPTION
## Summary

Addresses CodeRabbit nitpick on PR #744.

## Change

The previous implementation used an `else` fallback — meaning if `availableModels` was present but stale/partial and **didn't include** the selected model, the fallback wouldn't run and `ProviderModelNotFoundError` could still occur.

**Fix:** Always check after populating the models map and ensure the selected `modelId` is registered as a final guard, regardless of the `availableModels` source.

```diff
-      } else {
-        // Fallback: at minimum register the selected model
+      }
+      // Final guard: always ensure the selected model is registered,
+      // even if availableModels is stale/partial and doesn't include it.
+      if (!xaiModels[modelId]) {
         xaiModels[modelId] = { name: modelId, tools: true };
       }
```

## Related

Part of ENG-598 / Closes #676
Companion fix to PR #744