### PR TITLE
chore(docs): clarify JIRA_ACCOUNT_ID vs JIRA_USER_ACCOUNT_ID in .env.example

### DIFF
--- a/.claude/.env.example
+++ b/.claude/.env.example
@@ -11,11 +11,15 @@ JIRA_API_TOKEN=your_api_token_here
 
 # ── User (the person running these skills) ────────────────────────────────
 JIRA_EMAIL=your.email@company.com
-# Find your accountId:
+# JIRA_ACCOUNT_ID: the account ID of the API token owner (used for auth context).
+# JIRA_USER_ACCOUNT_ID: YOUR personal Jira account ID (used for assignee on new tickets).
+# These may differ if the API token belongs to a shared/bot account.
+# Find your personal accountId:
 #   curl -s -u "$JIRA_LOGIN:$JIRA_API_TOKEN" \
 #     "$JIRA_SERVER/rest/api/3/user/search?query=your.name" \
 #     | python3 -c "import sys,json; [print(u['accountId'], u['displayName']) for u in json.load(sys.stdin)]"
 JIRA_ACCOUNT_ID=
+JIRA_USER_ACCOUNT_ID=
 
 # ── GitHub ────────────────────────────────────────────────────────────────
 # Format: owner/repo  (gh CLI must already be authenticated via `gh auth login`)


### PR DESCRIPTION
## Summary

- Adds `JIRA_USER_ACCOUNT_ID` variable (missing from the example) — the personal account ID used for assignee on new tickets
- Clarifies the difference between `JIRA_ACCOUNT_ID` (API token owner) and `JIRA_USER_ACCOUNT_ID` (the person running the skills), since these differ when the token belongs to a shared/bot account

## Test plan
- [ ] Copy `.env.example` to `.env` and confirm both fields are present and documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Jira setup documentation with clearer guidance on distinguishing authentication credentials from assignee account identifiers.

* **Chores**
  * Added new environment variable configuration for Jira user account assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->