### PR TITLE
fix(settings): validate OpenAI base URL on frontend before IPC call (ENG-875)

### DIFF
--- a/apps/web/src/client/components/settings/providers/ClassicProviderForm.tsx
+++ b/apps/web/src/client/components/settings/providers/ClassicProviderForm.tsx
@@ -102,6 +102,19 @@ export function ClassicProviderForm({
       return;
     }
 
+    if (isOpenAI && openAiBaseUrl.trim()) {
+      try {
+        const parsed = new URL(openAiBaseUrl.trim());
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+          setError(t('connectors.urlMustBeHttp'));
+          return;
+        }
+      } catch {
+        setError(t('connectors.invalidUrl'));
+        return;
+      }
+    }
+
     setConnecting(true);
     setError(null);
 


### PR DESCRIPTION
## Summary
- Adds client-side URL validation in `ClassicProviderForm` before calling the `setOpenAiBaseUrl` IPC handler
- When a non-empty base URL is entered that is not a valid http/https URL, shows an inline error immediately without reaching the main process
- Prevents Sentry from capturing this user-input validation error as an unhandled exception in the main process

## Root Cause
When users entered an invalid OpenAI base URL and clicked "Connect", `validateHttpUrl` in the main process IPC handler threw an error. Sentry captured it at that point even though the renderer's `try-catch` eventually handled it and showed it in the UI.

## Test plan
- [ ] Enter an invalid string (e.g., `not-a-url`) as the OpenAI base URL and click Connect → should show "Please enter a valid URL" error immediately
- [ ] Enter a non-http URL (e.g., `ftp://example.com`) and click Connect → should show "URL must start with http:// or https://" error
- [ ] Leave base URL empty and enter a valid API key → should connect normally
- [ ] Enter a valid `https://...` base URL and a valid API key → should connect normally

Fixes [ENG-875](https://accomplish-ai.atlassian.net/browse/ENG-875)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced OpenAI provider configuration with improved URL validation to ensure only valid HTTP/HTTPS URLs are accepted, with clear error messages for invalid formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->