### PR TITLE
fix(settings): use OAuth access token to fetch full OpenAI model list (ENG-876)

### DIFF
--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -43,7 +43,11 @@ import {
   validateLMStudioConfig,
 } from '@accomplish_ai/agent-core';
 import { getStorage } from '../store/storage';
-import { getOpenAiOauthStatus, getSlackMcpOauthStatus } from '@accomplish_ai/agent-core';
+import {
+  getOpenAiOauthStatus,
+  getOpenAiOauthAccessToken,
+  getSlackMcpOauthStatus,
+} from '@accomplish_ai/agent-core';
 import { loginOpenAiWithChatGpt } from '../opencode/auth-browser';
 import { loginSlackMcp, logoutSlackMcp } from '../opencode/slack-auth';
 import type {
@@ -907,7 +911,8 @@ export function registerIPCHandlers(): void {
         return { success: false, error: 'No models endpoint configured for this provider' };
       }
 
-      const apiKey = getApiKey(providerId);
+      const storedApiKey = getApiKey(providerId);
+      const apiKey = storedApiKey || (providerId === 'openai' ? getOpenAiOauthAccessToken() : null);
       if (!apiKey) {
         return { success: false, error: 'No API key found for this provider' };
       }

--- a/apps/web/src/client/components/settings/providers/ClassicProviderForm.tsx
+++ b/apps/web/src/client/components/settings/providers/ClassicProviderForm.tsx
@@ -76,10 +76,12 @@ export function ClassicProviderForm({
   // Get translated provider name
   const providerName = t(`providers.${providerId}`, { defaultValue: meta.name });
 
-  // Auto-fetch models for already-connected providers that don't have availableModels yet
+  // Auto-fetch models for already-connected providers that don't have availableModels yet,
+  // or for OAuth-connected OpenAI users (who may only have the hardcoded fallback list).
   useEffect(() => {
     if (!isConnected) return;
-    if (connectedProvider?.availableModels?.length) return;
+    const isOAuth = connectedProvider?.credentials?.type === 'oauth';
+    if (!isOAuth && connectedProvider?.availableModels?.length) return;
     if (!providerConfig?.modelsEndpoint) return;
 
     const accomplish = getAccomplish();
@@ -190,8 +192,16 @@ export function ClassicProviderForm({
       const status = await accomplish.getOpenAiOauthStatus();
 
       if (status.connected) {
-        // OAuth stores a refresh token — no API key is available for /v1/models.
-        // Use a hardcoded fallback list so the model dropdown works.
+        // Try to fetch the full model list using the OAuth access token.
+        // Fall back to the static list if the fetch fails.
+        let availableModels = OPENAI_OAUTH_FALLBACK_MODELS;
+        if (providerConfig?.modelsEndpoint) {
+          const fetchResult = await accomplish.fetchProviderModels(providerId, {});
+          if (fetchResult.success && fetchResult.models?.length) {
+            availableModels = fetchResult.models;
+          }
+        }
+
         const defaultModelId = providerConfig?.defaultModelId ?? null;
         const provider: ConnectedProvider = {
           providerId,
@@ -202,7 +212,7 @@ export function ClassicProviderForm({
             oauthProvider: 'chatgpt',
           } as OAuthCredentials,
           lastConnectedAt: new Date().toISOString(),
-          availableModels: OPENAI_OAUTH_FALLBACK_MODELS,
+          availableModels,
         };
         onConnect(provider);
       }

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -126,6 +126,7 @@ export {
   getOpenCodeAuthJsonPath,
   getOpenCodeMcpAuthJsonPath,
   getOpenAiOauthStatus,
+  getOpenAiOauthAccessToken,
   getSlackMcpOauthStatus,
   getSlackMcpCallbackUrl,
   setSlackMcpPendingAuth,

--- a/packages/agent-core/src/opencode/auth.ts
+++ b/packages/agent-core/src/opencode/auth.ts
@@ -92,6 +92,20 @@ export function getOpenAiOauthStatus(): { connected: boolean; expires?: number }
   return { connected, expires: oauth.expires };
 }
 
+export function getOpenAiOauthAccessToken(): string | null {
+  const authJson = readOpenCodeAuthJson();
+  if (!authJson) return null;
+
+  const entry = authJson.openai;
+  if (!entry || typeof entry !== 'object') return null;
+
+  const oauth = entry as OpenCodeOauthAuthEntry;
+  if (oauth.type !== 'oauth') return null;
+
+  const access = oauth.access;
+  return typeof access === 'string' && access.trim().length > 0 ? access : null;
+}
+
 export function getOpenCodeAuthPath(): string {
   const homeDir = os.homedir();
   if (process.platform === 'win32') {

--- a/packages/agent-core/tests/unit/opencode/auth.test.ts
+++ b/packages/agent-core/tests/unit/opencode/auth.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as fs from 'fs';
+import { getOpenAiOauthAccessToken } from '../../../src/opencode/auth.js';
+
+vi.mock('fs');
+
+const mockFs = vi.mocked(fs);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('getOpenAiOauthAccessToken', () => {
+  it('returns null when auth file does not exist', () => {
+    mockFs.existsSync.mockReturnValue(false);
+    expect(getOpenAiOauthAccessToken()).toBeNull();
+  });
+
+  it('returns null when openai entry is missing', () => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readFileSync.mockReturnValue(JSON.stringify({}));
+    expect(getOpenAiOauthAccessToken()).toBeNull();
+  });
+
+  it('returns null when openai entry is not oauth type', () => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readFileSync.mockReturnValue(
+      JSON.stringify({ openai: { type: 'api_key', key: 'sk-test' } }),
+    );
+    expect(getOpenAiOauthAccessToken()).toBeNull();
+  });
+
+  it('returns null when oauth entry has no access token', () => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readFileSync.mockReturnValue(
+      JSON.stringify({ openai: { type: 'oauth', refresh: 'rt_123' } }),
+    );
+    expect(getOpenAiOauthAccessToken()).toBeNull();
+  });
+
+  it('returns the access token when oauth entry is valid', () => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readFileSync.mockReturnValue(
+      JSON.stringify({ openai: { type: 'oauth', access: 'at_abc123', refresh: 'rt_xyz' } }),
+    );
+    expect(getOpenAiOauthAccessToken()).toBe('at_abc123');
+  });
+
+  it('returns null when access token is an empty string', () => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readFileSync.mockReturnValue(
+      JSON.stringify({ openai: { type: 'oauth', access: '   ', refresh: 'rt_xyz' } }),
+    );
+    expect(getOpenAiOauthAccessToken()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Closes [ENG-876](https://accomplish-ai.atlassian.net/browse/ENG-876)

- When connecting OpenAI via **OAuth (ChatGPT sign-in)**, the model dropdown previously showed only a hardcoded 4-model fallback because there was no API key available to call `/v1/models`
- Now the app uses the stored OAuth access token to call `/v1/models` and shows the full model list, matching what API key users see
- Existing OAuth users (already connected) also benefit: the auto-fetch effect now re-runs on mount for OAuth sessions and fetches the real model list

## Changes

- `packages/agent-core/src/opencode/auth.ts` — add `getOpenAiOauthAccessToken()` to read the access token from opencode's `auth.json`
- `packages/agent-core/src/index.ts` — export the new function
- `apps/desktop/src/main/ipc/handlers.ts` — `provider:fetch-models` falls back to the OAuth access token for OpenAI when no stored API key is found
- `apps/web/…/ClassicProviderForm.tsx` — fetch models immediately after OAuth connect (fallback to static list if fetch fails); fix auto-fetch `useEffect` to re-run for OAuth users
- `packages/agent-core/tests/unit/opencode/auth.test.ts` — 6 unit tests for the new function

## Test plan

- [ ] Connect OpenAI via ChatGPT Sign-In — model dropdown should show the full list from `/v1/models`
- [ ] If already connected via OAuth, reload settings page — model list refreshes automatically
- [ ] If `/v1/models` call fails (e.g. expired token), fallback 4-model list is shown instead of an empty dropdown
- [ ] API key users are unaffected — their flow still fetches models using the stored API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced model discovery for OAuth-authenticated providers with fallback to predefined model lists

* **Refactor**
  * Improved authentication token handling to better manage API key and OAuth credential flows for provider connections
  * Streamlined provider model fetching logic to prioritize dynamically retrieved models over static defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->