### PR TITLE
feat(providers): re-add Venice AI inference provider (ENG-685)

### DIFF
--- a/apps/web/src/client/components/settings/ProviderGrid.tsx
+++ b/apps/web/src/client/components/settings/ProviderGrid.tsx
@@ -26,6 +26,7 @@ const PROVIDER_ORDER: ProviderId[] = [
   'together',
   'fireworks',
   'groq',
+  'venice',
   'custom',
 ];
 

--- a/apps/web/src/client/lib/provider-logos.ts
+++ b/apps/web/src/client/lib/provider-logos.ts
@@ -18,6 +18,7 @@ import nebiusLogo from '/assets/ai-logos/nebius.svg';
 import togetherLogo from '/assets/ai-logos/together.svg';
 import fireworksLogo from '/assets/ai-logos/fireworks.svg';
 import groqLogo from '/assets/ai-logos/groq.svg';
+import veniceLogo from '/assets/ai-logos/venice.svg';
 import customLogo from '/assets/ai-logos/custom.svg';
 
 export const PROVIDER_LOGOS: Record<ProviderId, string> = {
@@ -40,6 +41,7 @@ export const PROVIDER_LOGOS: Record<ProviderId, string> = {
   together: togetherLogo,
   fireworks: fireworksLogo,
   groq: groqLogo,
+  venice: veniceLogo,
   custom: customLogo,
 };
 

--- a/packages/agent-core/src/common/constants/model-display.ts
+++ b/packages/agent-core/src/common/constants/model-display.ts
@@ -73,6 +73,7 @@ export const PROVIDER_PREFIXES = [
   'together/',
   'fireworks/',
   'groq/',
+  'venice/',
   'custom/',
 ];
 

--- a/packages/agent-core/src/common/types/provider.ts
+++ b/packages/agent-core/src/common/types/provider.ts
@@ -25,7 +25,8 @@ export type ProviderType =
   | 'nebius'
   | 'together'
   | 'fireworks'
-  | 'groq';
+  | 'groq'
+  | 'venice';
 
 export type ApiKeyProvider =
   | 'anthropic'
@@ -47,6 +48,7 @@ export type ApiKeyProvider =
   | 'together'
   | 'fireworks'
   | 'groq'
+  | 'venice'
   | 'elevenlabs';
 
 /**
@@ -74,6 +76,7 @@ export const ALLOWED_API_KEY_PROVIDERS: ReadonlySet<string> = new Set<string>([
   'together',
   'fireworks',
   'groq',
+  'venice',
   'elevenlabs',
 ]);
 
@@ -96,6 +99,7 @@ export const STANDARD_VALIDATION_PROVIDERS: ReadonlySet<string> = new Set<string
   'together',
   'fireworks',
   'groq',
+  'venice',
 ]);
 
 export interface ModelsEndpointConfig {
@@ -428,6 +432,21 @@ export const DEFAULT_PROVIDERS: ProviderConfig[] = [
     },
     models: [],
     defaultModelId: 'groq/llama3-70b-8192',
+  },
+  {
+    id: 'venice',
+    name: 'Venice AI',
+    requiresApiKey: true,
+    apiKeyEnvVar: 'VENICE_API_KEY',
+    baseUrl: 'https://api.venice.ai/api/v1',
+    defaultModelId: 'venice/llama-3.3-70b',
+    modelsEndpoint: {
+      url: 'https://api.venice.ai/api/v1/models',
+      authStyle: 'bearer',
+      responseFormat: 'openai',
+      modelIdPrefix: 'venice/',
+    },
+    models: [],
   },
 ];
 

--- a/packages/agent-core/src/common/types/providerSettings.ts
+++ b/packages/agent-core/src/common/types/providerSettings.ts
@@ -18,6 +18,7 @@ export type ProviderId =
   | 'together'
   | 'fireworks'
   | 'groq'
+  | 'venice'
   | 'custom';
 
 export type ProviderCategory = 'classic' | 'aws' | 'gcp' | 'azure' | 'local' | 'proxy' | 'hybrid';
@@ -166,6 +167,14 @@ export const PROVIDER_META: Record<ProviderId, ProviderMeta> = {
     label: 'Ultra-fast Llama models',
     logoKey: 'groq',
     helpUrl: 'https://console.groq.com/keys',
+  },
+  venice: {
+    id: 'venice',
+    name: 'Venice AI',
+    category: 'classic',
+    label: 'Service',
+    logoKey: 'venice',
+    helpUrl: 'https://venice.ai/settings/api',
   },
   custom: {
     id: 'custom',
@@ -317,6 +326,7 @@ export const DEFAULT_MODELS: Partial<Record<ProviderId, string>> = {
   together: 'together/meta-llama/Llama-3-70b-chat-hf',
   fireworks: 'fireworks/accounts/fireworks/models/llama-v3-70b-instruct',
   groq: 'groq/llama3-70b-8192',
+  venice: 'venice/llama-3.3-70b',
 };
 
 export function getDefaultModelForProvider(providerId: ProviderId): string | null {
@@ -347,5 +357,6 @@ export const PROVIDER_ID_TO_OPENCODE: Record<ProviderId, string> = {
   together: 'together',
   fireworks: 'fireworks',
   groq: 'groq',
+  venice: 'venice',
   custom: 'custom',
 };

--- a/packages/agent-core/src/opencode/config-builder.ts
+++ b/packages/agent-core/src/opencode/config-builder.ts
@@ -20,7 +20,13 @@ import {
 } from '../storage/repositories/index.js';
 
 /** Providers that use the @ai-sdk/openai-compatible adapter */
-const OPENAI_COMPATIBLE_PROVIDER_IDS = ['nebius', 'together', 'fireworks', 'groq'] as const;
+const OPENAI_COMPATIBLE_PROVIDER_IDS = [
+  'nebius',
+  'together',
+  'fireworks',
+  'groq',
+  'venice',
+] as const;
 
 /**
  * Paths required for config generation (Electron-specific resolution stays in desktop)


### PR DESCRIPTION
## Summary

- Venice.ai was accidentally dropped in #736 when the `OPENAI_COMPATIBLE_PROVIDER_IDS` refactor replaced the hardcoded `'venice'` entry in `baseProviders` with a spread of the new constant — Venice was not included in it
- Restores full Venice.ai support by adding `'venice'` to `OPENAI_COMPATIBLE_PROVIDER_IDS` so the existing generic config-builder loop handles it automatically (including `AUTH_KEY_MAPPING`)
- Rebuilds all type registrations: `ProviderType`, `ApiKeyProvider`, `ProviderId`, `PROVIDER_META`, `DEFAULT_MODELS`, `PROVIDER_ID_TO_OPENCODE`, `ALLOWED_API_KEY_PROVIDERS`, `STANDARD_VALIDATION_PROVIDERS`, `DEFAULT_PROVIDERS`, `PROVIDER_PREFIXES`
- Restores the Venice SVG logo and re-registers it in `provider-logos.ts` and `ProviderGrid.tsx`

## Test plan

- [ ] Typecheck passes: `pnpm typecheck`
- [ ] Venice AI appears in the provider grid in Settings
- [ ] Connecting with a Venice API key works and fetches available models from `https://api.venice.ai/api/v1/models`
- [ ] Selected Venice model is passed through to OpenCode config correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated Venice AI as a new supported provider with API key authentication and model selection capabilities.
  * Added Venice provider display in the UI with branded logo and proper model identifier formatting.
  * Configured OpenAI-compatible API integration for seamless Venice provider functionality across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->