### PR TITLE
fix(dev-browser): bind HTTP server to localhost only

### DIFF
--- a/packages/agent-core/mcp-tools/dev-browser/src/index.ts
+++ b/packages/agent-core/mcp-tools/dev-browser/src/index.ts
@@ -204,7 +204,7 @@ export async function serve(options: ServeOptions = {}): Promise<DevBrowserServe
     res.status(404).json({ error: 'page not found' });
   });
 
-  const server = app.listen(port, () => {
+  const server = app.listen(port, '127.0.0.1', () => {
     console.log(`HTTP API server running on port ${port}`);
   });
 


### PR DESCRIPTION
The Express server was listening on 0.0.0.0, exposing sensitive browser control endpoints (CDP, page creation, JS injection) to the LAN without authentication. Restrict to 127.0.0.1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Development browser server now binds exclusively to localhost, restricting server access to local connections only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->