### PR TITLE
fix(summarizer): extract first line only to prevent multiple-title output (ENG-843)

### DIFF
--- a/packages/agent-core/src/services/summarizer.ts
+++ b/packages/agent-core/src/services/summarizer.ts
@@ -9,7 +9,8 @@ import type { ApiKeyProvider } from '../common/types/provider.js';
 
 const SUMMARY_PROMPT = `Generate a very short title (3-5 words max) that summarizes this task request.
 The title should be in sentence case, no quotes, no punctuation at end.
-Examples: "Check calendar", "Download invoice", "Search flights to Paris"
+Output ONLY the title on a single line, nothing else.
+Examples: Check calendar, Download invoice, Search flights to Paris
 
 Task: `;
 
@@ -192,11 +193,20 @@ async function callXAI(apiKey: string, prompt: string): Promise<string> {
 }
 
 /**
- * Clean up the generated summary
+ * Clean up the generated summary.
+ * Extracts only the first non-empty line to handle cases where the LLM
+ * returns multiple titles or additional explanation text.
  */
 function cleanSummary(text: string): string {
-  return (
+  // Take only the first non-empty line — LLMs sometimes return multiple titles
+  const firstLine =
     text
+      .split('\n')
+      .map((l) => l.trim())
+      .find((l) => l.length > 0) ?? text.trim();
+
+  return (
+    firstLine
       // Remove surrounding quotes
       .replace(/^["']|["']$/g, '')
       // Remove trailing punctuation

--- a/packages/agent-core/tests/unit/services/summarizer.test.ts
+++ b/packages/agent-core/tests/unit/services/summarizer.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { generateTaskSummary } from '../../../src/services/summarizer.js';
+
+describe('generateTaskSummary', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('returns a single-line title when the LLM response contains multiple lines', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        content: [{ type: 'text', text: 'Check calendar\nDownload invoice\nSearch flights' }],
+      }),
+    } as Response);
+
+    const result = await generateTaskSummary('Book a flight to Paris', (p) =>
+      p === 'anthropic' ? 'sk-ant-test' : null,
+    );
+
+    expect(result).toBe('Check calendar');
+  });
+
+  it('strips surrounding quotes from the title', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        content: [{ type: 'text', text: '"Check calendar"' }],
+      }),
+    } as Response);
+
+    const result = await generateTaskSummary('What is on my calendar?', (p) =>
+      p === 'anthropic' ? 'sk-ant-test' : null,
+    );
+
+    expect(result).toBe('Check calendar');
+  });
+
+  it('strips trailing punctuation from the title', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        content: [{ type: 'text', text: 'Check calendar.' }],
+      }),
+    } as Response);
+
+    const result = await generateTaskSummary('What is on my calendar?', (p) =>
+      p === 'anthropic' ? 'sk-ant-test' : null,
+    );
+
+    expect(result).toBe('Check calendar');
+  });
+
+  it('falls back to the next provider when the first fails', async () => {
+    vi.mocked(fetch)
+      .mockRejectedValueOnce(new Error('Network error'))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content: 'Search flights' } }],
+        }),
+      } as Response);
+
+    const result = await generateTaskSummary('Book a flight', (p) => {
+      if (p === 'anthropic') return 'sk-ant-test';
+      if (p === 'openai') return 'sk-openai-test';
+      return null;
+    });
+
+    expect(result).toBe('Search flights');
+  });
+
+  it('falls back to truncated prompt when all providers fail', async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error('All failed'));
+
+    const result = await generateTaskSummary(
+      'Book a flight to Paris for the entire team next week',
+      (p) => (p === 'anthropic' ? 'sk-ant-test' : null),
+    );
+
+    expect(result).toBe('Book a flight to Paris for ...');
+  });
+
+  it('uses truncated prompt when no API keys are configured', async () => {
+    const result = await generateTaskSummary(
+      'Schedule a meeting with the whole team for tomorrow morning',
+      () => null,
+    );
+
+    expect(result).toBe('Schedule a meeting with the...');
+  });
+
+  it('handles blank lines before the title', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        content: [{ type: 'text', text: '\n\nDownload invoice' }],
+      }),
+    } as Response);
+
+    const result = await generateTaskSummary('Download my invoice', (p) =>
+      p === 'anthropic' ? 'sk-ant-test' : null,
+    );
+
+    expect(result).toBe('Download invoice');
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug:** When an LLM returned multiple lines (e.g. several title suggestions), `cleanSummary` passed all of them through because it only stripped outer quotes/punctuation without isolating the first line
- **Fix:** `cleanSummary` now splits on newlines, finds the first non-empty line, and processes only that — ensuring a single clean title is always returned
- **Prompt hardening:** Added `"Output ONLY the title on a single line, nothing else."` to reduce the chance of multi-line responses at the source
- **Tests:** 7 new unit tests covering the multi-title regression, quote stripping, punctuation stripping, provider fallback, and truncation fallback

## Files changed

- [packages/agent-core/src/services/summarizer.ts](packages/agent-core/src/services/summarizer.ts) — fix + prompt hardening
- [packages/agent-core/tests/unit/services/summarizer.test.ts](packages/agent-core/tests/unit/services/summarizer.test.ts) — new test file

## Test plan

- [x] `pnpm -F @accomplish_ai/agent-core test` — all 566 tests pass (7 new)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint:eslint` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm build` — clean

Closes ENG-843

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved summary extraction from multi-line responses to reliably extract clean single-line titles
  * Enhanced post-processing to properly remove formatting artifacts, quotes, and trailing punctuation
  * Strengthened provider fallback behavior when initial extraction fails

* **Tests**
  * Added comprehensive test coverage for summary generation and processing across various scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->