### PR TITLE
chore: update download URLs 0.4.8 → 1.1.10-test [release-all]

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -11,12 +11,12 @@
   <a href="https://github.com/accomplish-ai/accomplish/stargazers"><img src="https://img.shields.io/github/stars/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="نجوم GitHub" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/issues"><img src="https://img.shields.io/github/issues/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="مشكلات GitHub" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/commits"><img src="https://img.shields.io/github/last-commit/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="آخر تحديث" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="تحميل لـ macOS (Apple Silicon)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="تحميل لـ macOS (Intel)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="تحميل لـ Windows 11" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(ARM64)-0ea5e9?style=flat-square" alt="تحميل لـ Linux (ARM64)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(x64)-0ea5e9?style=flat-square" alt="تحميل لـ Linux (x64)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb"><img src="https://img.shields.io/badge/Download-Linux_(.deb_x64)-0ea5e9?style=flat-square" alt="تحميل لـ Linux (.deb x64)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="تحميل لـ macOS (Apple Silicon)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="تحميل لـ macOS (Intel)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="تحميل لـ Windows 11" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(ARM64)-0ea5e9?style=flat-square" alt="تحميل لـ Linux (ARM64)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(x64)-0ea5e9?style=flat-square" alt="تحميل لـ Linux (x64)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb"><img src="https://img.shields.io/badge/Download-Linux_(.deb_x64)-0ea5e9?style=flat-square" alt="تحميل لـ Linux (.deb x64)" /></a>
   <a href="https://discord.gg/YH86b2P8"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
@@ -29,17 +29,17 @@ Accomplish هو وكيل سطح مكتب ذكاء اصطناعي مفتوح ال
 </p>
 
 <p align="center">
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg"><strong>تحميل لـ Mac (Apple Silicon)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg"><strong>تحميل لـ Mac (Apple Silicon)</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg"><strong>تحميل لـ Mac (Intel)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg"><strong>تحميل لـ Mac (Intel)</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe"><strong>تحميل لـ Windows 11</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe"><strong>تحميل لـ Windows 11</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage"><strong>تحميل لـ Linux (ARM64)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage"><strong>تحميل لـ Linux (ARM64)</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage"><strong>تحميل لـ Linux (x64)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage"><strong>تحميل لـ Linux (x64)</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb"><strong>تحميل لـ Linux (.deb x64)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb"><strong>تحميل لـ Linux (.deb x64)</strong></a>
   ·
   <a href="https://www.accomplish.ai/">موقع Accomplish</a>
   ·
@@ -201,7 +201,7 @@ Accomplish هو وكيل سطح مكتب ذكاء اصطناعي مفتوح ال
 
 <div align="center">
 
-[**تحميل لـ Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg) · [**تحميل لـ Mac (Intel)**](https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg) · [**تحميل لـ Windows 11**](https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe) · [**تحميل لـ Linux (ARM64)**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage) · [**تحميل لـ Linux (x64)**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage) · [**تحميل لـ Linux (.deb x64)**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb)
+[**تحميل لـ Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg) · [**تحميل لـ Mac (Intel)**](https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg) · [**تحميل لـ Windows 11**](https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe) · [**تحميل لـ Linux (ARM64)**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage) · [**تحميل لـ Linux (x64)**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage) · [**تحميل لـ Linux (.deb x64)**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb)
 
 </div>
 

--- a/README.es.md
+++ b/README.es.md
@@ -11,12 +11,12 @@
   <a href="https://github.com/accomplish-ai/accomplish/stargazers"><img src="https://img.shields.io/github/stars/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Stars" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/issues"><img src="https://img.shields.io/github/issues/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Issues" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/commits"><img src="https://img.shields.io/github/last-commit/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="Último Commit" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="Descargar para macOS (Apple Silicon)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="Descargar para macOS (Intel)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Descargar para Windows 11" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(ARM64)-0ea5e9?style=flat-square" alt="Descargar para Linux (ARM64)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(x64)-0ea5e9?style=flat-square" alt="Descargar para Linux (x64)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb"><img src="https://img.shields.io/badge/Download-Linux_(.deb_x64)-0ea5e9?style=flat-square" alt="Descargar para Linux (.deb x64)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="Descargar para macOS (Apple Silicon)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="Descargar para macOS (Intel)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Descargar para Windows 11" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(ARM64)-0ea5e9?style=flat-square" alt="Descargar para Linux (ARM64)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(x64)-0ea5e9?style=flat-square" alt="Descargar para Linux (x64)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb"><img src="https://img.shields.io/badge/Download-Linux_(.deb_x64)-0ea5e9?style=flat-square" alt="Descargar para Linux (.deb x64)" /></a>
   <a href="https://discord.gg/YH86b2P8"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
@@ -29,17 +29,17 @@ Accomplish es un agente de escritorio de IA de código abierto que automatiza la
 </p>
 
 <p align="center">
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg"><strong>Descargar para Mac (Apple Silicon)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg"><strong>Descargar para Mac (Apple Silicon)</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg"><strong>Descargar para Mac (Intel)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg"><strong>Descargar para Mac (Intel)</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe"><strong>Descargar para Windows 11</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe"><strong>Descargar para Windows 11</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage"><strong>Descargar para Linux (ARM64)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage"><strong>Descargar para Linux (ARM64)</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage"><strong>Descargar para Linux (x64)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage"><strong>Descargar para Linux (x64)</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb"><strong>Descargar para Linux (.deb x64)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb"><strong>Descargar para Linux (.deb x64)</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Sitio web de Accomplish</a>
   ·
@@ -201,7 +201,7 @@ Accomplish se ejecuta localmente en tu máquina. Tus archivos permanecen en tu d
 
 <div align="center">
 
-[**Descargar para Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg) · [**Descargar para Mac (Intel)**](https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg) · [**Descargar para Windows 11**](https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe) · [**Descargar para Linux (ARM64)**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage) · [**Descargar para Linux (x64)**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage) · [**Descargar para Linux (.deb x64)**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb)
+[**Descargar para Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg) · [**Descargar para Mac (Intel)**](https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg) · [**Descargar para Windows 11**](https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe) · [**Descargar para Linux (ARM64)**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage) · [**Descargar para Linux (x64)**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage) · [**Descargar para Linux (.deb x64)**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb)
 
 </div>
 

--- a/README.hi.md
+++ b/README.hi.md
@@ -11,12 +11,12 @@
   <a href="https://github.com/accomplish-ai/accomplish/stargazers"><img src="https://img.shields.io/github/stars/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Stars" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/issues"><img src="https://img.shields.io/github/issues/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Issues" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/commits"><img src="https://img.shields.io/github/last-commit/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="लास्ट कमिट" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="macOS (Apple Silicon) के लिए डाउनलोड करें" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="macOS (Intel) के लिए डाउनलोड करें" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Windows 11 के लिए डाउनलोड करें" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(ARM64)-0ea5e9?style=flat-square" alt="Linux (ARM64) के लिए डाउनलोड करें" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(x64)-0ea5e9?style=flat-square" alt="Linux (x64) के लिए डाउनलोड करें" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb"><img src="https://img.shields.io/badge/Download-Linux_(.deb_x64)-0ea5e9?style=flat-square" alt="Linux (.deb x64) के लिए डाउनलोड करें" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="macOS (Apple Silicon) के लिए डाउनलोड करें" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="macOS (Intel) के लिए डाउनलोड करें" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Windows 11 के लिए डाउनलोड करें" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(ARM64)-0ea5e9?style=flat-square" alt="Linux (ARM64) के लिए डाउनलोड करें" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(x64)-0ea5e9?style=flat-square" alt="Linux (x64) के लिए डाउनलोड करें" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb"><img src="https://img.shields.io/badge/Download-Linux_(.deb_x64)-0ea5e9?style=flat-square" alt="Linux (.deb x64) के लिए डाउनलोड करें" /></a>
   <a href="https://discord.gg/MepaTT55"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
@@ -29,17 +29,17 @@ Accomplish एक ओपन सोर्स AI डेस्कटॉप एज�
 </p>
 
 <p align="center">
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg"><strong>Mac (Apple Silicon) के लिए डाउनलोड करें</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg"><strong>Mac (Apple Silicon) के लिए डाउनलोड करें</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg"><strong>Mac (Intel) के लिए डाउनलोड करें</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg"><strong>Mac (Intel) के लिए डाउनलोड करें</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe"><strong>Windows 11 के लिए डाउनलोड करें</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe"><strong>Windows 11 के लिए डाउनलोड करें</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage"><strong>Linux (ARM64) के लिए डाउनलोड करें</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage"><strong>Linux (ARM64) के लिए डाउनलोड करें</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage"><strong>Linux (x64) के लिए डाउनलोड करें</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage"><strong>Linux (x64) के लिए डाउनलोड करें</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb"><strong>Linux (.deb x64) के लिए डाउनलोड करें</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb"><strong>Linux (.deb x64) के लिए डाउनलोड करें</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Accomplish वेबसाइट</a>
   ·
@@ -201,7 +201,7 @@ Accomplish आपकी मशीन पर स्थानीय रूप स�
 
 <div align="center">
 
-[**Mac (Apple Silicon) के लिए डाउनलोड करें**](https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg) · [**Mac (Intel) के लिए डाउनलोड करें**](https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg) · [**Windows 11 के लिए डाउनलोड करें**](https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe) · [**Linux (ARM64) के लिए डाउनलोड करें**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage) · [**Linux (x64) के लिए डाउनलोड करें**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage) · [**Linux (.deb x64) के लिए डाउनलोड करें**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb)
+[**Mac (Apple Silicon) के लिए डाउनलोड करें**](https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg) · [**Mac (Intel) के लिए डाउनलोड करें**](https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg) · [**Windows 11 के लिए डाउनलोड करें**](https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe) · [**Linux (ARM64) के लिए डाउनलोड करें**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage) · [**Linux (x64) के लिए डाउनलोड करें**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage) · [**Linux (.deb x64) के लिए डाउनलोड करें**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb)
 
 </div>
 

--- a/README.id.md
+++ b/README.id.md
@@ -11,12 +11,12 @@
   <a href="https://github.com/accomplish-ai/accomplish/stargazers"><img src="https://img.shields.io/github/stars/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Stars" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/issues"><img src="https://img.shields.io/github/issues/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Issues" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/commits"><img src="https://img.shields.io/github/last-commit/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="Commit Terakhir" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="Unduh untuk macOS (Apple Silicon)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="Unduh untuk macOS (Intel)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Unduh untuk Windows 11" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(ARM64)-0ea5e9?style=flat-square" alt="Unduh untuk Linux (ARM64)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(x64)-0ea5e9?style=flat-square" alt="Unduh untuk Linux (x64)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb"><img src="https://img.shields.io/badge/Download-Linux_(.deb_x64)-0ea5e9?style=flat-square" alt="Unduh untuk Linux (.deb x64)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="Unduh untuk macOS (Apple Silicon)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="Unduh untuk macOS (Intel)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Unduh untuk Windows 11" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(ARM64)-0ea5e9?style=flat-square" alt="Unduh untuk Linux (ARM64)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(x64)-0ea5e9?style=flat-square" alt="Unduh untuk Linux (x64)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb"><img src="https://img.shields.io/badge/Download-Linux_(.deb_x64)-0ea5e9?style=flat-square" alt="Unduh untuk Linux (.deb x64)" /></a>
   <a href="https://discord.gg/YH86b2P8"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
@@ -29,17 +29,17 @@ Accomplish adalah agen desktop AI open source yang mengotomatisasi manajemen fil
 </p>
 
 <p align="center">
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg"><strong>Unduh untuk Mac (Apple Silicon)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg"><strong>Unduh untuk Mac (Apple Silicon)</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg"><strong>Unduh untuk Mac (Intel)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg"><strong>Unduh untuk Mac (Intel)</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe"><strong>Unduh untuk Windows 11</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe"><strong>Unduh untuk Windows 11</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage"><strong>Unduh untuk Linux (ARM64)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage"><strong>Unduh untuk Linux (ARM64)</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage"><strong>Unduh untuk Linux (x64)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage"><strong>Unduh untuk Linux (x64)</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb"><strong>Unduh untuk Linux (.deb x64)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb"><strong>Unduh untuk Linux (.deb x64)</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Website Accomplish</a>
   ·
@@ -201,7 +201,7 @@ Accomplish berjalan secara lokal di mesin Anda. File Anda tetap di perangkat And
 
 <div align="center">
 
-[**Unduh untuk Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg) · [**Unduh untuk Mac (Intel)**](https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg) · [**Unduh untuk Windows 11**](https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe) · [**Unduh untuk Linux (ARM64)**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage) · [**Unduh untuk Linux (x64)**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage) · [**Unduh untuk Linux (.deb x64)**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb)
+[**Unduh untuk Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg) · [**Unduh untuk Mac (Intel)**](https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg) · [**Unduh untuk Windows 11**](https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe) · [**Unduh untuk Linux (ARM64)**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage) · [**Unduh untuk Linux (x64)**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage) · [**Unduh untuk Linux (.deb x64)**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb)
 
 </div>
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -11,12 +11,12 @@
   <a href="https://github.com/accomplish-ai/accomplish/stargazers"><img src="https://img.shields.io/github/stars/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Stars" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/issues"><img src="https://img.shields.io/github/issues/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Issues" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/commits"><img src="https://img.shields.io/github/last-commit/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="最終コミット" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="macOS用ダウンロード (Apple Silicon)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="macOS用ダウンロード (Intel)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Windows 11用ダウンロード" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(ARM64)-0ea5e9?style=flat-square" alt="Linux用ダウンロード（ARM64）" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(x64)-0ea5e9?style=flat-square" alt="Linux用ダウンロード（x64）" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb"><img src="https://img.shields.io/badge/Download-Linux_(.deb_x64)-0ea5e9?style=flat-square" alt="Linux用ダウンロード (.deb x64)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="macOS用ダウンロード (Apple Silicon)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="macOS用ダウンロード (Intel)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Windows 11用ダウンロード" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(ARM64)-0ea5e9?style=flat-square" alt="Linux用ダウンロード（ARM64）" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(x64)-0ea5e9?style=flat-square" alt="Linux用ダウンロード（x64）" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb"><img src="https://img.shields.io/badge/Download-Linux_(.deb_x64)-0ea5e9?style=flat-square" alt="Linux用ダウンロード (.deb x64)" /></a>
   <a href="https://discord.gg/YH86b2P8"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
@@ -29,17 +29,17 @@ Accomplishは、お使いのマシン上でローカルにファイル管理、�
 </p>
 
 <p align="center">
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg"><strong>Mac用ダウンロード（Apple Silicon）</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg"><strong>Mac用ダウンロード（Apple Silicon）</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg"><strong>Mac用ダウンロード（Intel）</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg"><strong>Mac用ダウンロード（Intel）</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe"><strong>Windows 11用ダウンロード</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe"><strong>Windows 11用ダウンロード</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage"><strong>Linux用ダウンロード（ARM64）</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage"><strong>Linux用ダウンロード（ARM64）</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage"><strong>Linux用ダウンロード（x64）</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage"><strong>Linux用ダウンロード（x64）</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb"><strong>Linux用ダウンロード（.deb x64）</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb"><strong>Linux用ダウンロード（.deb x64）</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Accomplishウェブサイト</a>
   ·
@@ -201,7 +201,7 @@ Accomplishはお使いのマシン上でローカルに実行されます。フ�
 
 <div align="center">
 
-[**Mac用ダウンロード（Apple Silicon）**](https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg) · [**Mac用ダウンロード（Intel）**](https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg) · [**Windows 11用ダウンロード**](https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe) · [**Linux用ダウンロード（ARM64）**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage) · [**Linux用ダウンロード（x64）**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage) · [**Linux用ダウンロード（.deb x64）**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb)
+[**Mac用ダウンロード（Apple Silicon）**](https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg) · [**Mac用ダウンロード（Intel）**](https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg) · [**Windows 11用ダウンロード**](https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe) · [**Linux用ダウンロード（ARM64）**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage) · [**Linux用ダウンロード（x64）**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage) · [**Linux用ダウンロード（.deb x64）**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb)
 
 </div>
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -11,12 +11,12 @@
   <a href="https://github.com/accomplish-ai/accomplish/stargazers"><img src="https://img.shields.io/github/stars/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Stars" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/issues"><img src="https://img.shields.io/github/issues/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Issues" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/commits"><img src="https://img.shields.io/github/last-commit/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="최근 커밋" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="macOS 다운로드 (Apple Silicon)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="macOS 다운로드 (Intel)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Windows 11 다운로드" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(ARM64)-0ea5e9?style=flat-square" alt="Linux (ARM64) 다운로드" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(x64)-0ea5e9?style=flat-square" alt="Linux (x64) 다운로드" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb"><img src="https://img.shields.io/badge/Download-Linux_(.deb_x64)-0ea5e9?style=flat-square" alt="Linux (.deb x64) 다운로드" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="macOS 다운로드 (Apple Silicon)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="macOS 다운로드 (Intel)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Windows 11 다운로드" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(ARM64)-0ea5e9?style=flat-square" alt="Linux (ARM64) 다운로드" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(x64)-0ea5e9?style=flat-square" alt="Linux (x64) 다운로드" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb"><img src="https://img.shields.io/badge/Download-Linux_(.deb_x64)-0ea5e9?style=flat-square" alt="Linux (.deb x64) 다운로드" /></a>
   <a href="https://discord.gg/YH86b2P8"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
@@ -29,17 +29,17 @@ Accomplish는 로컬 머신에서 파일 관리, 문서 작성, 브라우저 작
 </p>
 
 <p align="center">
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg"><strong>Mac용 다운로드 (Apple Silicon)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg"><strong>Mac용 다운로드 (Apple Silicon)</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg"><strong>Mac용 다운로드 (Intel)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg"><strong>Mac용 다운로드 (Intel)</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe"><strong>Windows 11용 다운로드</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe"><strong>Windows 11용 다운로드</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage"><strong>Linux (ARM64) 다운로드</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage"><strong>Linux (ARM64) 다운로드</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage"><strong>Linux (x64) 다운로드</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage"><strong>Linux (x64) 다운로드</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb"><strong>Linux (.deb x64) 다운로드</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb"><strong>Linux (.deb x64) 다운로드</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Accomplish 웹사이트</a>
   ·
@@ -201,7 +201,7 @@ Accomplish는 로컬 머신에서 실행됩니다. 파일은 기기에 저장되
 
 <div align="center">
 
-[**Mac용 다운로드 (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg) · [**Mac용 다운로드 (Intel)**](https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg) · [**Windows 11용 다운로드**](https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe) · [**Linux (ARM64) 다운로드**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage) · [**Linux (x64) 다운로드**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage) · [**Linux (.deb x64) 다운로드**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb)
+[**Mac용 다운로드 (Apple Silicon)**](https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg) · [**Mac용 다운로드 (Intel)**](https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg) · [**Windows 11용 다운로드**](https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe) · [**Linux (ARM64) 다운로드**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage) · [**Linux (x64) 다운로드**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage) · [**Linux (.deb x64) 다운로드**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@
   <a href="https://github.com/accomplish-ai/accomplish/stargazers"><img src="https://img.shields.io/github/stars/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Stars" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/issues"><img src="https://img.shields.io/github/issues/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Issues" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/commits"><img src="https://img.shields.io/github/last-commit/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="Last Commit" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="Download for macOS (Apple Silicon)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="Download for macOS (Intel)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Download for Windows 11" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(ARM64)-0ea5e9?style=flat-square" alt="Download for Linux (ARM64)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(x64)-0ea5e9?style=flat-square" alt="Download for Linux (x64)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb"><img src="https://img.shields.io/badge/Download-Linux_(.deb_x64)-0ea5e9?style=flat-square" alt="Download for Linux (.deb x64)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="Download for macOS (Apple Silicon)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="Download for macOS (Intel)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Download for Windows 11" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(ARM64)-0ea5e9?style=flat-square" alt="Download for Linux (ARM64)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(x64)-0ea5e9?style=flat-square" alt="Download for Linux (x64)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb"><img src="https://img.shields.io/badge/Download-Linux_(.deb_x64)-0ea5e9?style=flat-square" alt="Download for Linux (.deb x64)" /></a>
   <a href="https://discord.gg/YH86b2P8"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
@@ -29,17 +29,17 @@ Accomplish is an open source AI desktop agent that automates file management, do
 </p>
 
 <p align="center">
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg"><strong>Download for Mac (Apple Silicon)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg"><strong>Download for Mac (Apple Silicon)</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg"><strong>Download for Mac (Intel)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg"><strong>Download for Mac (Intel)</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe"><strong>Download for Windows 11</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe"><strong>Download for Windows 11</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage"><strong>Download for Linux (ARM64)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage"><strong>Download for Linux (ARM64)</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage"><strong>Download for Linux (x64)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage"><strong>Download for Linux (x64)</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb"><strong>Download for Linux (.deb x64)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb"><strong>Download for Linux (.deb x64)</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Accomplish website</a>
   ·
@@ -202,7 +202,7 @@ Accomplish runs locally on your machine. Your files stay on your device, and you
 
 <div align="center">
 
-[**Download for Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg) · [**Download for Mac (Intel)**](https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg) · [**Download for Windows 11**](https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe) · [**Download for Linux (ARM64)**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage) · [**Download for Linux (x64)**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage) · [**Download for Linux (.deb x64)**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb)
+[**Download for Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg) · [**Download for Mac (Intel)**](https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg) · [**Download for Windows 11**](https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe) · [**Download for Linux (ARM64)**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage) · [**Download for Linux (x64)**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage) · [**Download for Linux (.deb x64)**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb)
 
 </div>
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -11,12 +11,12 @@
   <a href="https://github.com/accomplish-ai/accomplish/stargazers"><img src="https://img.shields.io/github/stars/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Stars" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/issues"><img src="https://img.shields.io/github/issues/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Issues" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/commits"><img src="https://img.shields.io/github/last-commit/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="Последний коммит" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="Скачать для macOS (Apple Silicon)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="Скачать для macOS (Intel)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Скачать для Windows 11" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(ARM64)-0ea5e9?style=flat-square" alt="Скачать для Linux (ARM64)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(x64)-0ea5e9?style=flat-square" alt="Скачать для Linux (x64)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb"><img src="https://img.shields.io/badge/Download-Linux_(.deb_x64)-0ea5e9?style=flat-square" alt="Скачать для Linux (.deb x64)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="Скачать для macOS (Apple Silicon)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="Скачать для macOS (Intel)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Скачать для Windows 11" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(ARM64)-0ea5e9?style=flat-square" alt="Скачать для Linux (ARM64)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(x64)-0ea5e9?style=flat-square" alt="Скачать для Linux (x64)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb"><img src="https://img.shields.io/badge/Download-Linux_(.deb_x64)-0ea5e9?style=flat-square" alt="Скачать для Linux (.deb x64)" /></a>
   <a href="https://discord.gg/YH86b2P8"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
@@ -29,17 +29,17 @@ Accomplish — это открытый ИИ-агент для рабочего �
 </p>
 
 <p align="center">
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg"><strong>Скачать для Mac (Apple Silicon)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg"><strong>Скачать для Mac (Apple Silicon)</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg"><strong>Скачать для Mac (Intel)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg"><strong>Скачать для Mac (Intel)</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe"><strong>Скачать для Windows 11</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe"><strong>Скачать для Windows 11</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage"><strong>Скачать для Linux (ARM64)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage"><strong>Скачать для Linux (ARM64)</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage"><strong>Скачать для Linux (x64)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage"><strong>Скачать для Linux (x64)</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb"><strong>Скачать для Linux (.deb x64)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb"><strong>Скачать для Linux (.deb x64)</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Сайт Accomplish</a>
   ·
@@ -201,7 +201,7 @@ Accomplish работает локально на вашем компьютер�
 
 <div align="center">
 
-[**Скачать для Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg) · [**Скачать для Mac (Intel)**](https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg) · [**Скачать для Windows 11**](https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe) · [**Скачать для Linux (ARM64)**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage) · [**Скачать для Linux (x64)**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage) · [**Скачать для Linux (.deb x64)**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb)
+[**Скачать для Mac (Apple Silicon)**](https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg) · [**Скачать для Mac (Intel)**](https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg) · [**Скачать для Windows 11**](https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe) · [**Скачать для Linux (ARM64)**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage) · [**Скачать для Linux (x64)**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage) · [**Скачать для Linux (.deb x64)**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb)
 
 </div>
 

--- a/README.ta.md
+++ b/README.ta.md
@@ -11,12 +11,12 @@
   <a href="https://github.com/accomplish-ai/accomplish/stargazers"><img src="https://img.shields.io/github/stars/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Stars" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/issues"><img src="https://img.shields.io/github/issues/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Issues" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/commits"><img src="https://img.shields.io/github/last-commit/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="கடைசி கமிட்" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="macOS (Apple Silicon) க்கான பதிவிறக்கம்" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="macOS (Intel) க்கான பதிவிறக்கம்" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Windows 11 க்கான பதிவிறக்கம்" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(ARM64)-0ea5e9?style=flat-square" alt="Linux (ARM64) க்கான பதிவிறக்கம்" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(x64)-0ea5e9?style=flat-square" alt="Linux (x64) க்கான பதிவிறக்கம்" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb"><img src="https://img.shields.io/badge/Download-Linux_(.deb_x64)-0ea5e9?style=flat-square" alt="Linux (.deb x64) க்கான பதிவிறக்கம்" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="macOS (Apple Silicon) க்கான பதிவிறக்கம்" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="macOS (Intel) க்கான பதிவிறக்கம்" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Windows 11 க்கான பதிவிறக்கம்" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(ARM64)-0ea5e9?style=flat-square" alt="Linux (ARM64) க்கான பதிவிறக்கம்" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(x64)-0ea5e9?style=flat-square" alt="Linux (x64) க்கான பதிவிறக்கம்" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb"><img src="https://img.shields.io/badge/Download-Linux_(.deb_x64)-0ea5e9?style=flat-square" alt="Linux (.deb x64) க்கான பதிவிறக்கம்" /></a>
   <a href="https://discord.gg/MepaTT55"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
@@ -29,17 +29,17 @@ Accomplish என்பது உங்கள் கணினியிலேய�
 </p>
 
 <p align="center">
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg"><strong>Mac (Apple Silicon) க்கான பதிவிறக்கம்</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg"><strong>Mac (Apple Silicon) க்கான பதிவிறக்கம்</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg"><strong>Mac (Intel) க்கான பதிவிறக்கம்</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg"><strong>Mac (Intel) க்கான பதிவிறக்கம்</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe"><strong>Windows 11 க்கான பதிவிறக்கம்</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe"><strong>Windows 11 க்கான பதிவிறக்கம்</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage"><strong>Linux (ARM64) க்கான பதிவிறக்கம்</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage"><strong>Linux (ARM64) க்கான பதிவிறக்கம்</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage"><strong>Linux (x64) க்கான பதிவிறக்கம்</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage"><strong>Linux (x64) க்கான பதிவிறக்கம்</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb"><strong>Linux (.deb x64) க்கான பதிவிறக்கம்</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb"><strong>Linux (.deb x64) க்கான பதிவிறக்கம்</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Accomplish வலைத்தளம்</a>
   ·
@@ -201,7 +201,7 @@ Accomplish உங்கள் கணினியிலேயே இயங்க�
 
 <div align="center">
 
-[**Mac (Apple Silicon) க்கான பதிவிறக்கம்**](https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg) · [**Mac (Intel) க்கான பதிவிறக்கம்**](https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg) · [**Windows 11 க்கான பதிவிறக்கம்**](https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe) · [**Linux (ARM64) க்கான பதிவிறக்கம்**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage) · [**Linux (x64) க்கான பதிவிறக்கம்**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage) · [**Linux (.deb x64) க்கான பதிவிறக்கம்**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb)
+[**Mac (Apple Silicon) க்கான பதிவிறக்கம்**](https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg) · [**Mac (Intel) க்கான பதிவிறக்கம்**](https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg) · [**Windows 11 க்கான பதிவிறக்கம்**](https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe) · [**Linux (ARM64) க்கான பதிவிறக்கம்**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage) · [**Linux (x64) க்கான பதிவிறக்கம்**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage) · [**Linux (.deb x64) க்கான பதிவிறக்கம்**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb)
 
 </div>
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -11,12 +11,12 @@
   <a href="https://github.com/accomplish-ai/accomplish/stargazers"><img src="https://img.shields.io/github/stars/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Stars" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/issues"><img src="https://img.shields.io/github/issues/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Issues" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/commits"><img src="https://img.shields.io/github/last-commit/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="Son Commit" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="macOS için İndir (Apple Silicon)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="macOS için İndir (Intel)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Windows 11 için İndir" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(ARM64)-0ea5e9?style=flat-square" alt="Linux için İndirin (ARM64)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(x64)-0ea5e9?style=flat-square" alt="Linux için İndirin (x64)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb"><img src="https://img.shields.io/badge/Download-Linux_(.deb_x64)-0ea5e9?style=flat-square" alt="Linux için İndirin (.deb x64)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="macOS için İndir (Apple Silicon)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="macOS için İndir (Intel)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="Windows 11 için İndir" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(ARM64)-0ea5e9?style=flat-square" alt="Linux için İndirin (ARM64)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(x64)-0ea5e9?style=flat-square" alt="Linux için İndirin (x64)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb"><img src="https://img.shields.io/badge/Download-Linux_(.deb_x64)-0ea5e9?style=flat-square" alt="Linux için İndirin (.deb x64)" /></a>
   <a href="https://discord.gg/YH86b2P8"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
@@ -29,17 +29,17 @@ Accomplish, bilgisayarınızda yerel olarak dosya yönetimi, belge oluşturma ve
 </p>
 
 <p align="center">
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg"><strong>Mac için İndirin (Apple Silicon)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg"><strong>Mac için İndirin (Apple Silicon)</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg"><strong>Mac için İndirin (Intel)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg"><strong>Mac için İndirin (Intel)</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe"><strong>Windows 11 için İndirin</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe"><strong>Windows 11 için İndirin</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage"><strong>Linux için İndirin (ARM64)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage"><strong>Linux için İndirin (ARM64)</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage"><strong>Linux için İndirin (x64)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage"><strong>Linux için İndirin (x64)</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb"><strong>Linux için İndirin (.deb x64)</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb"><strong>Linux için İndirin (.deb x64)</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Accomplish web sitesi</a>
   ·
@@ -201,7 +201,7 @@ Accomplish bilgisayarınızda yerel olarak çalışır. Dosyalarınız cihazın�
 
 <div align="center">
 
-[**Mac için İndirin (Apple Silicon)**](https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg) · [**Mac için İndirin (Intel)**](https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg) · [**Windows 11 için İndirin**](https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe) · [**Linux için İndirin (ARM64)**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage) · [**Linux için İndirin (x64)**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage) · [**Linux için İndirin (.deb x64)**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb)
+[**Mac için İndirin (Apple Silicon)**](https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg) · [**Mac için İndirin (Intel)**](https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg) · [**Windows 11 için İndirin**](https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe) · [**Linux için İndirin (ARM64)**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage) · [**Linux için İndirin (x64)**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage) · [**Linux için İndirin (.deb x64)**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb)
 
 </div>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,12 +11,12 @@
   <a href="https://github.com/accomplish-ai/accomplish/stargazers"><img src="https://img.shields.io/github/stars/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Stars" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/issues"><img src="https://img.shields.io/github/issues/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="GitHub Issues" /></a>
   <a href="https://github.com/accomplish-ai/accomplish/commits"><img src="https://img.shields.io/github/last-commit/accomplish-ai/accomplish?style=flat-square&color=22c55e" alt="最近提交" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="下载 macOS 版 (Apple Silicon)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="下载 macOS 版 (Intel)" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="下载 Windows 11 版" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(ARM64)-0ea5e9?style=flat-square" alt="下载 Linux 版（ARM64）" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(x64)-0ea5e9?style=flat-square" alt="下载 Linux 版（x64）" /></a>
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb"><img src="https://img.shields.io/badge/Download-Linux_(.deb_x64)-0ea5e9?style=flat-square" alt="下载 Linux 版 (.deb x64)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-0ea5e9?style=flat-square" alt="下载 macOS 版 (Apple Silicon)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg"><img src="https://img.shields.io/badge/Download-macOS_(Intel)-0ea5e9?style=flat-square" alt="下载 macOS 版 (Intel)" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe"><img src="https://img.shields.io/badge/Download-Windows_11-0ea5e9?style=flat-square" alt="下载 Windows 11 版" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(ARM64)-0ea5e9?style=flat-square" alt="下载 Linux 版（ARM64）" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Download-Linux_(x64)-0ea5e9?style=flat-square" alt="下载 Linux 版（x64）" /></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb"><img src="https://img.shields.io/badge/Download-Linux_(.deb_x64)-0ea5e9?style=flat-square" alt="下载 Linux 版 (.deb x64)" /></a>
   <a href="https://discord.gg/YH86b2P8"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
@@ -29,17 +29,17 @@ Accomplish 是一款开源 AI 桌面代理，可在您的本地机器上自动�
 </p>
 
 <p align="center">
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg"><strong>下载 Mac 版（Apple Silicon）</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg"><strong>下载 Mac 版（Apple Silicon）</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg"><strong>下载 Mac 版（Intel）</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg"><strong>下载 Mac 版（Intel）</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe"><strong>下载 Windows 11 版</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe"><strong>下载 Windows 11 版</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage"><strong>下载 Linux 版（ARM64）</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage"><strong>下载 Linux 版（ARM64）</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage"><strong>下载 Linux 版（x64）</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage"><strong>下载 Linux 版（x64）</strong></a>
   ·
-  <a href="https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb"><strong>下载 Linux 版（.deb x64）</strong></a>
+  <a href="https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb"><strong>下载 Linux 版（.deb x64）</strong></a>
   ·
   <a href="https://www.accomplish.ai/">Accomplish 官网</a>
   ·
@@ -201,7 +201,7 @@ Accomplish 在您的机器上本地运行。您的文件保留在您的设备上
 
 <div align="center">
 
-[**下载 Mac 版（Apple Silicon）**](https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-arm64.dmg) · [**下载 Mac 版（Intel）**](https://downloads.accomplish.ai/downloads/0.4.8/macos/Accomplish-0.4.8-mac-x64.dmg) · [**下载 Windows 11 版**](https://downloads.accomplish.ai/downloads/0.4.8/windows/Accomplish-0.4.8-win-x64.exe) · [**下载 Linux 版（ARM64）**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-arm64.AppImage) · [**下载 Linux 版（x64）**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-x86_64.AppImage) · [**下载 Linux 版（.deb x64）**](https://downloads.accomplish.ai/downloads/0.4.8/linux/Accomplish-0.4.8-linux-amd64.deb)
+[**下载 Mac 版（Apple Silicon）**](https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-arm64.dmg) · [**下载 Mac 版（Intel）**](https://downloads.accomplish.ai/downloads/1.1.10-test/macos/Accomplish-1.1.10-test-mac-x64.dmg) · [**下载 Windows 11 版**](https://downloads.accomplish.ai/downloads/1.1.10-test/windows/Accomplish-1.1.10-test-win-x64.exe) · [**下载 Linux 版（ARM64）**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-arm64.AppImage) · [**下载 Linux 版（x64）**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-x86_64.AppImage) · [**下载 Linux 版（.deb x64）**](https://downloads.accomplish.ai/downloads/1.1.10-test/linux/Accomplish-1.1.10-test-linux-amd64.deb)
 
 </div>
 


### PR DESCRIPTION
Automated Accomplish README update from release-all promote.

Updates Mac + Windows + Linux download URLs in Accomplish README files from 0.4.8 to 1.1.10-test.

**Please review and merge.**
