### PR TITLE
fix: clear stale task state after task removal

### DIFF
--- a/apps/web/__tests__/integration/renderer/taskStore.integration.test.ts
+++ b/apps/web/__tests__/integration/renderer/taskStore.integration.test.ts
@@ -43,6 +43,17 @@ function createMockMessage(
   };
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
 // Mock accomplish API
 const mockAccomplish = {
   startTask: vi.fn(),
@@ -117,6 +128,7 @@ describe('taskStore Integration', () => {
     try {
       const { useTaskStore } = await import('@/stores/taskStore');
       useTaskStore.setState({
+        _taskStateToken: 0,
         currentTask: null,
         isLoading: false,
         error: null,
@@ -307,6 +319,28 @@ describe('taskStore Integration', () => {
       expect(state.tasks).toHaveLength(1);
       expect(state.tasks[0].prompt).toBe('New prompt');
     });
+
+    it('should ignore late startTask completion after history is cleared', async () => {
+      // Arrange
+      const { useTaskStore } = await import('@/stores/taskStore');
+      const deferred = createDeferred<Task>();
+      mockAccomplish.startTask.mockReturnValueOnce(deferred.promise);
+      mockAccomplish.clearTaskHistory.mockResolvedValueOnce(undefined);
+
+      // Act
+      const startTaskPromise = useTaskStore.getState().startTask({ prompt: 'Test prompt' });
+      await useTaskStore.getState().clearHistory();
+      deferred.resolve(createMockTask('task-123', 'Test prompt', 'running'));
+      const result = await startTaskPromise;
+      const state = useTaskStore.getState();
+
+      // Assert
+      expect(result).toBeNull();
+      expect(state.currentTask).toBeNull();
+      expect(state.tasks).toEqual([]);
+      expect(state.error).toBeNull();
+      expect(state.isLoading).toBe(false);
+    });
   });
 
   describe('sendFollowUp', () => {
@@ -465,6 +499,33 @@ describe('taskStore Integration', () => {
       // Assert
       expect(state.error).toBe('Resume failed');
       expect(state.currentTask?.status).toBe('failed');
+      expect(state.isLoading).toBe(false);
+    });
+
+    it('should ignore late follow-up completion after history is cleared', async () => {
+      // Arrange
+      const { useTaskStore } = await import('@/stores/taskStore');
+      const deferred = createDeferred<Task>();
+      const taskWithSession: Task = {
+        ...createMockTask('task-123', 'Test', 'completed'),
+        sessionId: 'session-abc',
+      };
+      useTaskStore.setState({ currentTask: taskWithSession, tasks: [taskWithSession] });
+      mockAccomplish.resumeSession.mockReturnValueOnce(deferred.promise);
+      mockAccomplish.clearTaskHistory.mockResolvedValueOnce(undefined);
+
+      // Act
+      const followUpPromise = useTaskStore.getState().sendFollowUp('Continue');
+      await useTaskStore.getState().clearHistory();
+      deferred.resolve(createMockTask('task-123', 'Test', 'running'));
+      const result = await followUpPromise;
+      const state = useTaskStore.getState();
+
+      // Assert
+      expect(result).toBe(false);
+      expect(state.currentTask).toBeNull();
+      expect(state.tasks).toEqual([]);
+      expect(state.error).toBeNull();
       expect(state.isLoading).toBe(false);
     });
   });
@@ -726,6 +787,28 @@ describe('taskStore Integration', () => {
       // Assert
       expect(state.currentTask).toBeNull();
       expect(state.error).toBe('Task not found');
+    });
+
+    it('should ignore late loadTaskById completion after the task is deleted', async () => {
+      // Arrange
+      const { useTaskStore } = await import('@/stores/taskStore');
+      const deferred = createDeferred<Task | null>();
+      const trackedTask = createMockTask('task-123', 'Tracked task');
+      useTaskStore.setState({ tasks: [trackedTask] });
+      mockAccomplish.getTask.mockReturnValueOnce(deferred.promise);
+      mockAccomplish.deleteTask.mockResolvedValueOnce(undefined);
+
+      // Act
+      const loadTaskPromise = useTaskStore.getState().loadTaskById('task-123');
+      await useTaskStore.getState().deleteTask('task-123');
+      deferred.resolve(trackedTask);
+      await loadTaskPromise;
+      const state = useTaskStore.getState();
+
+      // Assert
+      expect(state.currentTask).toBeNull();
+      expect(state.tasks).toEqual([]);
+      expect(state.error).toBeNull();
     });
   });
 

--- a/apps/web/src/client/stores/taskStore.ts
+++ b/apps/web/src/client/stores/taskStore.ts
@@ -42,6 +42,7 @@ interface StartupStageInfo {
 
 interface TaskState {
   // Current task
+  _taskStateToken: number;
   currentTask: Task | null;
   isLoading: boolean;
   error: string | null;
@@ -114,9 +115,17 @@ function hasTrackedTask(
   return state.currentTask?.id === taskId || state.tasks.some((task) => task.id === taskId);
 }
 
+function hasTaskStateToken(
+  state: Pick<TaskState, '_taskStateToken'>,
+  taskStateToken: number,
+): boolean {
+  return state._taskStateToken === taskStateToken;
+}
+
 function clearScopedTaskState(
   state: Pick<
     TaskState,
+    | '_taskStateToken'
     | 'currentTask'
     | 'isLoading'
     | 'permissionRequests'
@@ -127,11 +136,13 @@ function clearScopedTaskState(
   taskId: string,
 ): Partial<TaskState> {
   const nextState: Partial<TaskState> = {};
+  let shouldBumpTaskStateToken = false;
 
   if (state.currentTask?.id === taskId) {
     nextState.currentTask = null;
     nextState.isLoading = false;
     nextState.error = null;
+    shouldBumpTaskStateToken = true;
   }
 
   if (taskId in state.permissionRequests) {
@@ -143,23 +154,31 @@ function clearScopedTaskState(
     nextState.setupProgress = null;
     nextState.setupProgressTaskId = null;
     nextState.setupDownloadStep = 1;
+    shouldBumpTaskStateToken = true;
   }
 
   if (state.startupStageTaskId === taskId) {
     nextState.startupStage = null;
     nextState.startupStageTaskId = null;
+    shouldBumpTaskStateToken = true;
   }
 
   if (state.todosTaskId === taskId) {
     nextState.todos = [];
     nextState.todosTaskId = null;
+    shouldBumpTaskStateToken = true;
+  }
+
+  if (shouldBumpTaskStateToken) {
+    nextState._taskStateToken = state._taskStateToken + 1;
   }
 
   return nextState;
 }
 
-function clearAllTaskScopedState(): Partial<TaskState> {
+function clearAllTaskScopedState(state: Pick<TaskState, '_taskStateToken'>): Partial<TaskState> {
   return {
+    _taskStateToken: state._taskStateToken + 1,
     currentTask: null,
     isLoading: false,
     error: null,
@@ -175,6 +194,7 @@ function clearAllTaskScopedState(): Partial<TaskState> {
 }
 
 export const useTaskStore = create<TaskState>((set, get) => ({
+  _taskStateToken: 0,
   currentTask: null,
   isLoading: false,
   error: null,
@@ -251,6 +271,7 @@ export const useTaskStore = create<TaskState>((set, get) => ({
 
   startTask: async (config: TaskConfig) => {
     const accomplish = getAccomplish();
+    const taskStateToken = get()._taskStateToken;
     set({ isLoading: true, error: null });
     try {
       void accomplish.logEvent({
@@ -263,7 +284,12 @@ export const useTaskStore = create<TaskState>((set, get) => ({
         },
       });
       const task = await accomplish.startTask(config);
-      const currentTasks = get().tasks;
+      const currentState = get();
+      if (!hasTaskStateToken(currentState, taskStateToken)) {
+        return null;
+      }
+
+      const currentTasks = currentState.tasks;
       set({
         currentTask: task,
         tasks: [task, ...currentTasks.filter((t) => t.id !== task.id)],
@@ -276,6 +302,10 @@ export const useTaskStore = create<TaskState>((set, get) => ({
       });
       return task;
     } catch (err) {
+      if (!hasTaskStateToken(get(), taskStateToken)) {
+        return null;
+      }
+
       set({
         error: err instanceof Error ? err.message : 'Failed to start task',
         isLoading: false,
@@ -295,6 +325,7 @@ export const useTaskStore = create<TaskState>((set, get) => ({
   ): Promise<boolean> => {
     const accomplish = getAccomplish();
     const { currentTask, startTask } = get();
+    const taskStateToken = get()._taskStateToken;
     if (!currentTask) {
       set({ error: 'No active task to continue' });
       void accomplish.logEvent({
@@ -363,6 +394,10 @@ export const useTaskStore = create<TaskState>((set, get) => ({
 
       const task = await accomplish.resumeSession(sessionId, message, currentTask.id, attachments);
 
+      if (!hasTaskStateToken(get(), taskStateToken)) {
+        return false;
+      }
+
       set((state) => ({
         currentTask: state.currentTask ? { ...state.currentTask, status: task.status } : null,
         isLoading: task.status === 'queued',
@@ -370,6 +405,10 @@ export const useTaskStore = create<TaskState>((set, get) => ({
       }));
       return true;
     } catch (err) {
+      if (!hasTaskStateToken(get(), taskStateToken)) {
+        return false;
+      }
+
       set((state) => ({
         error: err instanceof Error ? err.message : 'Failed to send message',
         isLoading: false,
@@ -394,12 +433,18 @@ export const useTaskStore = create<TaskState>((set, get) => ({
     const accomplish = getAccomplish();
     const { currentTask } = get();
     if (currentTask) {
+      const taskStateToken = get()._taskStateToken;
       void accomplish.logEvent({
         level: 'info',
         message: 'UI cancel task',
         context: { taskId: currentTask.id },
       });
       await accomplish.cancelTask(currentTask.id);
+
+      if (!hasTaskStateToken(get(), taskStateToken)) {
+        return;
+      }
+
       set((state) => ({
         currentTask: state.currentTask ? { ...state.currentTask, status: 'cancelled' } : null,
         tasks: state.tasks.map((t) =>
@@ -597,13 +642,29 @@ export const useTaskStore = create<TaskState>((set, get) => ({
 
   loadTasks: async () => {
     const accomplish = getAccomplish();
+    const taskStateToken = get()._taskStateToken;
     const tasks = await accomplish.listTasks();
+    if (!hasTaskStateToken(get(), taskStateToken)) {
+      return;
+    }
     set({ tasks });
   },
 
   loadTaskById: async (taskId: string) => {
     const accomplish = getAccomplish();
+    const currentState = get();
+    const taskStateToken = currentState._taskStateToken;
+    const requestTrackedTask = hasTrackedTask(currentState, taskId);
     const task = await accomplish.getTask(taskId);
+    const latestState = get();
+    if (!hasTaskStateToken(latestState, taskStateToken)) {
+      return;
+    }
+
+    if (requestTrackedTask && !hasTrackedTask(latestState, taskId)) {
+      return;
+    }
+
     set({ currentTask: task, error: task ? null : 'Task not found' });
   },
 
@@ -619,10 +680,10 @@ export const useTaskStore = create<TaskState>((set, get) => ({
   clearHistory: async () => {
     const accomplish = getAccomplish();
     await accomplish.clearTaskHistory();
-    set({
+    set((state) => ({
       tasks: [],
-      ...clearAllTaskScopedState(),
-    });
+      ...clearAllTaskScopedState(state),
+    }));
   },
 
   loadFavorites: async () => {
@@ -695,7 +756,8 @@ export const useTaskStore = create<TaskState>((set, get) => ({
   },
 
   reset: () => {
-    set({
+    set((state) => ({
+      _taskStateToken: state._taskStateToken + 1,
       currentTask: null,
       isLoading: false,
       error: null,
@@ -709,7 +771,7 @@ export const useTaskStore = create<TaskState>((set, get) => ({
       todosTaskId: null,
       authError: null,
       isLauncherOpen: false,
-    });
+    }));
   },
 
   setTodos: (taskId: string, todos: TodoItem[]) => {


### PR DESCRIPTION
## Summary
- clear task-scoped UI state when deleting the currently open task
- clear current task and related derived state when task history is wiped
- add integration coverage for both the deleted-current-task case and the unrelated-task case

## Testing
- `corepack pnpm --filter @accomplish/web exec vitest run __tests__/integration/renderer/taskStore.integration.test.ts --config vitest.integration.config.ts`
- `corepack pnpm --filter @accomplish/web typecheck`

## Notes
- `corepack pnpm --filter @accomplish/web test:integration -- taskStore.integration.test.ts` still booted unrelated suites and hit existing Windows asset-path failures outside this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a task reliably clears all task-scoped metadata and leaves other tasks intact.
  * Clearing history fully resets current task, task lists, permission requests, and scoped defaults.
  * Progress or completions from stale/untracked tasks are ignored to prevent incorrect state updates.

* **Tests**
  * Added integration tests covering ignored late completions, scoped-state clearing on delete/clear, and preservation of active task state when deleting other tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->