### PR TITLE
fix(web): prevent Node.js-only agent-core modules from entering browser bundle

### DIFF
--- a/apps/web/src/client/components/settings/providers/CopilotProviderForm.tsx
+++ b/apps/web/src/client/components/settings/providers/CopilotProviderForm.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { AnimatePresence, motion } from 'framer-motion';
 import { settingsVariants, settingsTransitions } from '@/lib/animations';
 import type { ConnectedProvider } from '@accomplish_ai/agent-core';
-import { COPILOT_MODELS } from '@accomplish_ai/agent-core';
+import { COPILOT_MODELS } from '@accomplish_ai/agent-core/common';
 import { ModelSelector, ConnectedControls, ProviderFormHeader, FormError } from '../shared';
 import { PROVIDER_LOGOS } from '@/lib/provider-logos';
 import { useCopilotConnection } from './useCopilotConnection';

--- a/apps/web/src/client/components/settings/providers/useCopilotConnection.ts
+++ b/apps/web/src/client/components/settings/providers/useCopilotConnection.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { getAccomplish } from '@/lib/accomplish';
 import type { ConnectedProvider, CopilotOAuthCredentials } from '@accomplish_ai/agent-core';
-import { COPILOT_MODELS } from '@accomplish_ai/agent-core';
+import { COPILOT_MODELS } from '@accomplish_ai/agent-core/common';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('useCopilotConnection');

--- a/packages/agent-core/src/common.ts
+++ b/packages/agent-core/src/common.ts
@@ -54,6 +54,7 @@ export {
   ALLOWED_API_KEY_PROVIDERS,
   STANDARD_VALIDATION_PROVIDERS,
   ZAI_ENDPOINTS,
+  COPILOT_MODELS,
 } from './common/types/provider.js';
 
 // Provider settings types

--- a/packages/agent-core/src/opencode/proxies/azure-foundry-proxy.ts
+++ b/packages/agent-core/src/opencode/proxies/azure-foundry-proxy.ts
@@ -1,6 +1,5 @@
 import http from 'http';
 import https from 'https';
-import { URL } from 'url';
 import { createConsoleLogger } from '../../utils/logging.js';
 
 const log = createConsoleLogger({ prefix: 'AzureFoundryProxy' });

--- a/packages/agent-core/src/opencode/proxies/moonshot-proxy.ts
+++ b/packages/agent-core/src/opencode/proxies/moonshot-proxy.ts
@@ -1,6 +1,5 @@
 import http from 'http';
 import https from 'https';
-import { URL } from 'url';
 import { createConsoleLogger } from '../../utils/logging.js';
 
 const log = createConsoleLogger({ prefix: 'MoonshotProxy' });


### PR DESCRIPTION
## Summary

- `COPILOT_MODELS` was imported as a runtime value from `@accomplish_ai/agent-core` (the full entry) in `CopilotProviderForm.tsx` and `useCopilotConnection.ts`, causing Vite to process the entire agent-core module graph for the browser bundle — pulling in `better-sqlite3`, `node-pty`, `EventEmitter`, AWS SDK, and other Node.js-only modules
- Fixed by importing `COPILOT_MODELS` from `@accomplish_ai/agent-core/common` (the browser-safe entry), which is where it was already defined
- Added `COPILOT_MODELS` to `common.ts` exports so it's reachable from the common entry
- Removed redundant `import { URL } from 'url'` in both proxy files — `URL` is a global in Node 18+ and all modern browsers

## Root cause

PR #815 (Copilot provider) introduced the two runtime imports from the full entry. The Vite alias resolves `@accomplish_ai/agent-core` directly to source, so any runtime import drags the entire module graph into the browser bundle.

## Test plan

- [x] `pnpm typecheck` — all workspaces pass
- [x] `pnpm lint:eslint` — no errors
- [x] `pnpm format:check` — clean
- [x] `pnpm build` — all workspaces build successfully
- [x] Web unit tests — 285/285 pass
- [x] Agent-core tests — 598/599 pass (1 skipped)
- [x] Desktop unit tests — 410/410 pass
- [x] Dev server no longer throws `Module "util" has been externalized`, `process is not defined`, or similar Node.js-in-browser errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated internal module organization to improve how Copilot model configuration constants are accessed across the application through the core public interface.

* **Chores**
  * Cleaned up unused imports in utility modules for code optimization and reduced unnecessary dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->