### PR TITLE
fix: resolve web app crash caused by node-pty in browser bundle

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -57,7 +57,11 @@ export default defineConfig({
         __dirname,
         '../../packages/agent-core/src/common',
       ),
-      '@accomplish_ai/agent-core': path.resolve(__dirname, '../../packages/agent-core/src'),
+      // IMPORTANT: In the web (browser) build, resolve the root entrypoint to
+      // the browser-safe common.ts surface. The full index.ts pulls in Node-only
+      // modules (node-pty, events) via OpenCodeAdapter that crash in the browser.
+      // Web code should only use types from agent-core — all re-exported from common.ts.
+      '@accomplish_ai/agent-core': path.resolve(__dirname, '../../packages/agent-core/src/common'),
       '@locales': path.resolve(__dirname, 'locales'),
     },
   },


### PR DESCRIPTION
## Summary

The web app crashes on load with `Uncaught ReferenceError: process is not defined` from `node-pty`.

**Root cause:** The refactor split PRs (#826, #834, #836, #849) extracted code into new files that import from `@accomplish_ai/agent-core` (root) instead of `@accomplish_ai/agent-core/common` (browser-safe). The web vite config resolves that root path to the full source tree, which includes `OpenCodeAdapter.ts` → `import * as pty from 'node-pty'` → crash.

**Fix:** Resolve the root `@accomplish_ai/agent-core` alias to `common.ts` in the web vite config. The web app only uses types from agent-core — all are available on the common surface.

## Test plan

- [x] `pnpm dev` — web app loads without console errors
- [x] Settings page opens, providers visible
- [x] No `process is not defined` or `Module events externalized` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated module resolution configuration for the web build to ensure browser-safe module compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->