### PR TITLE
feat: daemon version guard — prevent stale daemon on app upgrade

### DIFF
--- a/apps/desktop/src/main/app-startup.ts
+++ b/apps/desktop/src/main/app-startup.ts
@@ -205,7 +205,9 @@ export async function startApp(
           type: 'warning',
           title: 'Background Service Update',
           message:
-            'The background service from a previous version could not be stopped. Please restart the application.',
+            'The background service from a previous version could not be stopped. ' +
+            'Please fully quit the application (check the system tray), wait a few seconds, ' +
+            'and reopen it. If the issue persists, restart your computer.',
         });
       } else {
         logMain('WARN', '[Main] Daemon bootstrap failed — GUI will open without daemon', {

--- a/apps/desktop/src/main/app-startup.ts
+++ b/apps/desktop/src/main/app-startup.ts
@@ -26,7 +26,7 @@ import {
 } from './daemon-bootstrap';
 import { registerIPCHandlers } from './ipc/handlers';
 import { drainProtocolUrlQueue } from './protocol-handlers';
-import { getBuildConfig, isAnalyticsEnabled } from './config/build-config';
+import { getBuildConfig, getBuildId, isAnalyticsEnabled } from './config/build-config';
 import { initAnalytics, initDeviceFingerprint } from './analytics/analytics-service';
 import { initMixpanel } from './analytics/mixpanel-service';
 import { trackAppLaunched } from './analytics/events';
@@ -51,6 +51,10 @@ export async function startApp(
   isQuittingRef: { value: boolean },
 ): Promise<void> {
   logMain('INFO', `[Main] Electron app ready, version: ${app.getVersion()}`);
+
+  // Set build identity for daemon version-guard (used by in-process DaemonServer
+  // and compared against standalone daemon's ping response)
+  process.env.ACCOMPLISH_BUILD_ID = getBuildId();
 
   if (process.env.CLEAN_START !== '1') {
     try {
@@ -191,9 +195,23 @@ export async function startApp(
       await bootstrapDaemon();
       logMain('INFO', '[Main] Daemon connected');
     } catch (err) {
-      logMain('WARN', '[Main] Daemon bootstrap failed — GUI will open without daemon', {
-        error: String(err),
-      });
+      const { DaemonRestartError } = await import('./daemon/daemon-connector');
+      if (err instanceof DaemonRestartError) {
+        logMain('ERROR', '[Main] Failed to restart daemon after upgrade', {
+          error: String(err),
+        });
+        const { dialog } = await import('electron');
+        dialog.showMessageBox({
+          type: 'warning',
+          title: 'Background Service Update',
+          message:
+            'The background service from a previous version could not be stopped. Please restart the application.',
+        });
+      } else {
+        logMain('WARN', '[Main] Daemon bootstrap failed — GUI will open without daemon', {
+          error: String(err),
+        });
+      }
     }
   } else {
     logMain('INFO', '[Main] E2E mock mode — skipping daemon bootstrap');

--- a/apps/desktop/src/main/config/build-config.ts
+++ b/apps/desktop/src/main/config/build-config.ts
@@ -9,6 +9,7 @@
  */
 
 import { parse as dotenvParse } from 'dotenv';
+import { execSync } from 'child_process';
 import { z } from 'zod';
 import { app } from 'electron';
 import path from 'path';
@@ -21,6 +22,7 @@ const buildConfigSchema = z.object({
   gaMeasurementId: z.string().default(''),
   sentryDsn: z.string().default(''),
   accomplishGatewayUrl: z.string().default(''),
+  buildId: z.string().default(''),
 });
 
 export type BuildConfig = z.infer<typeof buildConfigSchema>;
@@ -60,6 +62,7 @@ export function loadBuildConfig(): BuildConfig {
     gaMeasurementId: raw.GA_MEASUREMENT_ID,
     sentryDsn: raw.SENTRY_DSN,
     accomplishGatewayUrl: raw.ACCOMPLISH_GATEWAY_URL,
+    buildId: raw.ACCOMPLISH_BUILD_ID,
   });
 
   if (!parsed.success) {
@@ -106,4 +109,43 @@ export function isAnalyticsEnabled(): boolean {
  *  the commercial repo's Free tier (which also used 'lite'). */
 export function getAppTier(): 'lite' | 'oss' {
   return getBuildConfig().buildEnvVersion ? 'lite' : 'oss';
+}
+
+/**
+ * Get the build identity for daemon version-guard.
+ *
+ * Used to detect stale daemons after app upgrades. The identity changes
+ * with every different build, ensuring the new app restarts the daemon.
+ *
+ * Priority:
+ * 1. Packaged builds: ACCOMPLISH_BUILD_ID from build.env (injected by release pipeline)
+ * 2. Dev builds: git commit SHA (changes with every committed change)
+ * 3. Fallback: app version (weakest, but covers basic version upgrades)
+ */
+let cachedBuildId: string | null = null;
+
+export function getBuildId(): string {
+  if (cachedBuildId) return cachedBuildId;
+
+  // 1. From build.env (packaged Free builds)
+  const fromBuildEnv = getBuildConfig().buildId;
+  if (fromBuildEnv) {
+    cachedBuildId = fromBuildEnv;
+    return cachedBuildId;
+  }
+
+  // 2. Git commit SHA (dev builds)
+  try {
+    cachedBuildId = execSync('git rev-parse --short HEAD', {
+      encoding: 'utf8',
+      stdio: 'pipe',
+    }).trim();
+    return cachedBuildId;
+  } catch {
+    // Not in a git repo or git not available
+  }
+
+  // 3. Fallback: app version
+  cachedBuildId = app.getVersion();
+  return cachedBuildId;
 }

--- a/apps/desktop/src/main/config/build-config.ts
+++ b/apps/desktop/src/main/config/build-config.ts
@@ -119,7 +119,9 @@ export function getAppTier(): 'lite' | 'oss' {
  *
  * Priority:
  * 1. Packaged builds: ACCOMPLISH_BUILD_ID from build.env (injected by release pipeline)
- * 2. Dev builds: git commit SHA (changes with every committed change)
+ * 2. Dev builds: git commit SHA (changes with every committed change / git pull).
+ *    NOTE: does not detect uncommitted edits or stale daemon artifacts from
+ *    bundled-input changes — developers must rebuild the daemon explicitly.
  * 3. Fallback: app version (weakest, but covers basic version upgrades)
  */
 let cachedBuildId: string | null = null;

--- a/apps/desktop/src/main/daemon/daemon-connector.ts
+++ b/apps/desktop/src/main/daemon/daemon-connector.ts
@@ -211,19 +211,16 @@ export function spawnDaemon(dataDir: string): void {
     daemonEnv.ACCOMPLISH_RESOURCES_PATH = path.join(app.getAppPath(), 'resources');
   }
 
-  // In dev mode, redirect daemon output to a log file so it can be tailed
-  // by any Electron process (including restarts). In production, use 'ignore'.
+  // Always redirect daemon stdout/stderr to daemon.log — essential for
+  // debugging in both dev and production. Without this, packaged daemon
+  // crashes are invisible (stdio: 'ignore' sends output nowhere).
+  const logPath = getDaemonLogPath(dataDir);
+  const logFd = fs.openSync(logPath, 'a');
   const spawnOptions: Parameters<typeof spawn>[2] = {
     detached: true,
-    stdio: 'ignore',
+    stdio: ['ignore', logFd, logFd],
     env: daemonEnv,
   };
-
-  if (!app.isPackaged) {
-    const logPath = getDaemonLogPath(dataDir);
-    const logFd = fs.openSync(logPath, 'a');
-    spawnOptions.stdio = ['ignore', logFd, logFd];
-  }
 
   const child = spawn(nodeBin, [entryPath, '--data-dir', dataDir], spawnOptions);
 

--- a/apps/desktop/src/main/daemon/daemon-connector.ts
+++ b/apps/desktop/src/main/daemon/daemon-connector.ts
@@ -130,9 +130,11 @@ async function tryConnectBuildChecked(dataDir: string): Promise<DaemonClient | n
     await waitForDaemonExit(dataDir, 30_000);
 
     return null; // Caller will spawn a new daemon
-  } catch {
-    // Ping failed or shutdown failed — close and let caller handle
+  } catch (err) {
     client.close();
+    // Let DaemonRestartError propagate — it surfaces the user-facing dialog
+    if (err instanceof DaemonRestartError) throw err;
+    // Other errors (ping failed, shutdown failed) — treat as "no daemon"
     return null;
   }
 }

--- a/apps/desktop/src/main/daemon/daemon-connector.ts
+++ b/apps/desktop/src/main/daemon/daemon-connector.ts
@@ -449,7 +449,18 @@ async function reconnectWithBackoff(): Promise<void> {
     }
 
     const dataDir = getDataDir();
-    const client = await tryConnectBuildChecked(dataDir);
+    let client: DaemonClient | null = null;
+    try {
+      client = await tryConnectBuildChecked(dataDir);
+    } catch (err) {
+      if (err instanceof DaemonRestartError) {
+        // Stale daemon couldn't be stopped — broadcast failure and stop retrying
+        log('ERROR', `[DaemonConnector] ${String(err)}`);
+        broadcastToRenderer('daemon:reconnect-failed');
+        return;
+      }
+      // Other errors — continue retry loop
+    }
 
     if (client) {
       log('INFO', '[DaemonConnector] Reconnected to daemon');

--- a/apps/desktop/src/main/daemon/daemon-connector.ts
+++ b/apps/desktop/src/main/daemon/daemon-connector.ts
@@ -16,7 +16,8 @@ import { app, BrowserWindow } from 'electron';
 import { DaemonClient, createSocketTransport, getSocketPath } from '@accomplish_ai/agent-core';
 import { getNodePath } from '../utils/bundled-node';
 import { getLogCollector } from '../logging';
-import { getBuildConfig } from '../config/build-config';
+import { getBuildConfig, getBuildId } from '../config/build-config';
+import { getPidFilePath } from '@accomplish_ai/agent-core';
 
 /** How long to wait for the daemon to become ready after spawning. */
 const SPAWN_READY_TIMEOUT_MS = 10_000;
@@ -85,6 +86,92 @@ async function tryConnect(dataDir: string): Promise<DaemonClient | null> {
 }
 
 /**
+ * Error thrown when a stale daemon could not be stopped during version-guard restart.
+ */
+export class DaemonRestartError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DaemonRestartError';
+  }
+}
+
+/**
+ * Try to connect to a daemon with matching build identity.
+ *
+ * If the daemon is reachable but has a different buildId (or no buildId — older version),
+ * sends a shutdown request and waits for the old daemon to exit so the caller can spawn a new one.
+ *
+ * Used by both ensureDaemonRunning() and reconnectWithBackoff() — centralized guard.
+ */
+async function tryConnectBuildChecked(dataDir: string): Promise<DaemonClient | null> {
+  const client = await tryConnect(dataDir);
+  if (!client) return null;
+
+  try {
+    const pingResult = await client.ping();
+    const expectedBuildId = getBuildId();
+
+    if (pingResult.buildId === expectedBuildId) {
+      // Same build — reuse this daemon
+      return client;
+    }
+
+    // Build mismatch (or old daemon without buildId) — restart
+    log(
+      'INFO',
+      `[DaemonConnector] Build mismatch: daemon=${pingResult.buildId ?? 'none'}, app=${expectedBuildId}. Restarting daemon...`,
+    );
+
+    // Await the shutdown RPC ack before closing (daemon defers exit until after reply)
+    await client.call('daemon.shutdown').catch(() => {});
+    client.close();
+
+    // Wait for old daemon to exit (up to 30s — matches daemon's DRAIN_TIMEOUT_MS)
+    await waitForDaemonExit(dataDir, 30_000);
+
+    return null; // Caller will spawn a new daemon
+  } catch {
+    // Ping failed or shutdown failed — close and let caller handle
+    client.close();
+    return null;
+  }
+}
+
+/**
+ * Wait for the daemon process to exit by polling the PID file.
+ * Throws DaemonRestartError if the daemon doesn't exit within timeoutMs.
+ * Does NOT clean up socket/PID files — the old daemon still owns them if alive.
+ */
+async function waitForDaemonExit(dataDir: string, timeoutMs: number = 30_000): Promise<void> {
+  const pidPath = getPidFilePath(dataDir);
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    // Check if PID file exists
+    if (!fs.existsSync(pidPath)) {
+      return; // Daemon exited and cleaned up
+    }
+
+    // Check if the process is still alive
+    try {
+      const content = fs.readFileSync(pidPath, 'utf8');
+      const { pid } = JSON.parse(content);
+      process.kill(pid, 0); // Signal 0 = check if alive, no actual signal sent
+      // Still alive — wait and retry
+      await sleep(200);
+    } catch {
+      // Process dead or PID file unreadable — daemon is gone
+      return;
+    }
+  }
+
+  // Timeout — daemon didn't exit. Don't clean up its state.
+  throw new DaemonRestartError(
+    'Old daemon did not exit within 30s after shutdown request. Please restart the application.',
+  );
+}
+
+/**
  * Spawn the daemon as a fully detached process.
  * The daemon process survives Electron exit (detached + unref).
  */
@@ -101,6 +188,8 @@ export function spawnDaemon(dataDir: string): void {
     ...process.env,
     // In dev mode, tell Electron to act as plain Node.js
     ELECTRON_RUN_AS_NODE: app.isPackaged ? undefined : '1',
+    // Build identity for version-guard — daemon returns this in ping response
+    ACCOMPLISH_BUILD_ID: getBuildId(),
   };
 
   // Inject gateway URL so the daemon can start the Accomplish AI proxy.
@@ -239,7 +328,7 @@ export async function ensureDaemonRunning(): Promise<DaemonClient> {
   const dataDir = getDataDir();
 
   log('INFO', '[DaemonConnector] Attempting connection to existing daemon...');
-  const existing = await tryConnect(dataDir);
+  const existing = await tryConnectBuildChecked(dataDir);
   if (existing) {
     log('INFO', '[DaemonConnector] Connected to existing daemon');
     return existing;
@@ -247,7 +336,7 @@ export async function ensureDaemonRunning(): Promise<DaemonClient> {
 
   log('INFO', '[DaemonConnector] No daemon found, retrying after short delay...');
   await sleep(LOGIN_ITEM_RETRY_DELAY_MS);
-  const retried = await tryConnect(dataDir);
+  const retried = await tryConnectBuildChecked(dataDir);
   if (retried) {
     log('INFO', '[DaemonConnector] Connected to daemon (login item)');
     return retried;
@@ -358,7 +447,7 @@ async function reconnectWithBackoff(): Promise<void> {
     }
 
     const dataDir = getDataDir();
-    const client = await tryConnect(dataDir);
+    const client = await tryConnectBuildChecked(dataDir);
 
     if (client) {
       log('INFO', '[DaemonConnector] Reconnected to daemon');

--- a/apps/desktop/src/main/daemon/daemon-connector.ts
+++ b/apps/desktop/src/main/daemon/daemon-connector.ts
@@ -229,10 +229,32 @@ export function spawnDaemon(dataDir: string): void {
 }
 
 /**
- * Get the path to the daemon log file.
+ * Get the path to today's daemon log file (date-rotated, matches app log pattern).
+ * Also cleans up old daemon logs (keeps last 7 days).
  */
 function getDaemonLogPath(dataDir: string): string {
-  return path.join(dataDir, 'daemon.log');
+  const logsDir = path.join(dataDir, 'logs');
+  fs.mkdirSync(logsDir, { recursive: true });
+
+  const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+  const logPath = path.join(logsDir, `daemon-${today}.log`);
+
+  // Clean up old daemon logs (keep last 7 days)
+  try {
+    const files = fs
+      .readdirSync(logsDir)
+      .filter((f) => f.startsWith('daemon-') && f.endsWith('.log'));
+    if (files.length > 7) {
+      files.sort();
+      for (const old of files.slice(0, files.length - 7)) {
+        fs.unlinkSync(path.join(logsDir, old));
+      }
+    }
+  } catch {
+    // Best-effort cleanup
+  }
+
+  return logPath;
 }
 
 /** Active log tail watcher — only one at a time */

--- a/apps/desktop/src/main/daemon/daemon-connector.ts
+++ b/apps/desktop/src/main/daemon/daemon-connector.ts
@@ -216,16 +216,19 @@ export function spawnDaemon(dataDir: string): void {
   // crashes are invisible (stdio: 'ignore' sends output nowhere).
   const logPath = getDaemonLogPath(dataDir);
   const logFd = fs.openSync(logPath, 'a');
-  const spawnOptions: Parameters<typeof spawn>[2] = {
-    detached: true,
-    stdio: ['ignore', logFd, logFd],
-    env: daemonEnv,
-  };
-
-  const child = spawn(nodeBin, [entryPath, '--data-dir', dataDir], spawnOptions);
-
-  child.unref();
-  log('INFO', `[DaemonConnector] Daemon spawned (detached, pid=${child.pid})`);
+  try {
+    const child = spawn(nodeBin, [entryPath, '--data-dir', dataDir], {
+      detached: true,
+      stdio: ['ignore', logFd, logFd],
+      env: daemonEnv,
+    });
+    child.unref();
+    log('INFO', `[DaemonConnector] Daemon spawned (detached, pid=${child.pid})`);
+  } finally {
+    // Close the parent's copy of the log fd — child inherited it.
+    // try/finally ensures cleanup even if spawn() throws.
+    fs.closeSync(logFd);
+  }
 }
 
 /**

--- a/apps/desktop/src/main/daemon/service-manager.ts
+++ b/apps/desktop/src/main/daemon/service-manager.ts
@@ -209,9 +209,9 @@ function getLaunchAgentContent(): string {
 
   lines.push(
     '  <key>StandardOutPath</key>',
-    `  <string>${path.join(dataDir, 'logs', `daemon-${new Date().toISOString().slice(0, 10)}.log`)}</string>`,
+    `  <string>${path.join(dataDir, 'logs', 'daemon-service.log')}</string>`,
     '  <key>StandardErrorPath</key>',
-    `  <string>${path.join(dataDir, 'logs', `daemon-${new Date().toISOString().slice(0, 10)}.log`)}</string>`,
+    `  <string>${path.join(dataDir, 'logs', 'daemon-service.log')}</string>`,
     '</dict>',
     '</plist>',
     '',

--- a/apps/desktop/src/main/daemon/service-manager.ts
+++ b/apps/desktop/src/main/daemon/service-manager.ts
@@ -209,9 +209,9 @@ function getLaunchAgentContent(): string {
 
   lines.push(
     '  <key>StandardOutPath</key>',
-    `  <string>${path.join(dataDir, 'daemon-stdout.log')}</string>`,
+    `  <string>${path.join(dataDir, 'logs', `daemon-${new Date().toISOString().slice(0, 10)}.log`)}</string>`,
     '  <key>StandardErrorPath</key>',
-    `  <string>${path.join(dataDir, 'daemon-stderr.log')}</string>`,
+    `  <string>${path.join(dataDir, 'logs', `daemon-${new Date().toISOString().slice(0, 10)}.log`)}</string>`,
     '</dict>',
     '</plist>',
     '',

--- a/packages/agent-core/src/common/types/daemon.ts
+++ b/packages/agent-core/src/common/types/daemon.ts
@@ -250,7 +250,7 @@ export interface DaemonMethodMap {
   'whatsapp.setEnabled': { params: { enabled: boolean }; result: void };
 
   // Health & lifecycle
-  'daemon.ping': { params: undefined; result: { status: 'ok'; uptime: number } };
+  'daemon.ping': { params: undefined; result: { status: 'ok'; uptime: number; buildId?: string } };
   'daemon.shutdown': { params: undefined; result: void };
   'health.check': { params: undefined; result: HealthCheckResult };
 

--- a/packages/agent-core/src/daemon/client.ts
+++ b/packages/agent-core/src/daemon/client.ts
@@ -109,7 +109,7 @@ export class DaemonClient {
   /**
    * Health check — ping the daemon.
    */
-  async ping(): Promise<{ status: 'ok'; uptime: number }> {
+  async ping(): Promise<{ status: 'ok'; uptime: number; buildId?: string }> {
     return this.call('daemon.ping');
   }
 

--- a/packages/agent-core/src/daemon/rpc-server.ts
+++ b/packages/agent-core/src/daemon/rpc-server.ts
@@ -45,10 +45,11 @@ export class DaemonRpcServer {
     this.onConnection = options.onConnection;
     this.onDisconnection = options.onDisconnection;
 
-    // Register built-in health check
+    // Register built-in health check (buildId used for version-guard on app upgrade)
     this.registerMethod('daemon.ping', () => ({
       status: 'ok' as const,
       uptime: Date.now() - this.startTime,
+      buildId: process.env.ACCOMPLISH_BUILD_ID,
     }));
   }
 

--- a/packages/agent-core/src/daemon/server.ts
+++ b/packages/agent-core/src/daemon/server.ts
@@ -36,10 +36,11 @@ export class DaemonServer {
   constructor(options: DaemonServerOptions) {
     this.transport = options.transport;
 
-    // Register built-in health check
+    // Register built-in health check (buildId used for version-guard on app upgrade)
     this.registerMethod('daemon.ping', () => ({
       status: 'ok' as const,
       uptime: Date.now() - this.startTime,
+      buildId: process.env.ACCOMPLISH_BUILD_ID,
     }));
 
     this.transport.onMessage((msg) => {


### PR DESCRIPTION
## Summary

Prevents a newly upgraded app from reusing a stale daemon process from a previous version. When the app connects to an existing daemon, it checks the build identity. If mismatched, it gracefully shuts down the old daemon and spawns a new one.

### Build Identity

- **Packaged builds**: `ACCOMPLISH_BUILD_ID` injected into `build.env` by the release pipeline (commit SHA + build timestamp). Unique per build.
- **Dev builds**: `git rev-parse --short HEAD`. Changes with every commit.
- **Fallback**: `app.getVersion()`. Weakest but covers basic version upgrades.

### How It Works

1. `daemon.ping` now returns optional `buildId` field
2. New `tryConnectBuildChecked()` helper centralizes the guard — used by both `ensureDaemonRunning()` and `reconnectWithBackoff()`
3. On mismatch: sends `daemon.shutdown` RPC (awaited), then polls PID file for up to 30s
4. On timeout: surfaces user-facing dialog — no force-kill (PID reuse makes SIGKILL unsafe)
5. Old daemons without `buildId` are treated as mismatched (backward compat)

### Files Changed

- `packages/agent-core/src/common/types/daemon.ts` — `buildId?: string` in ping result
- `packages/agent-core/src/daemon/client.ts` — Updated `ping()` return type
- `packages/agent-core/src/daemon/rpc-server.ts` — Returns `ACCOMPLISH_BUILD_ID` env var in ping
- `packages/agent-core/src/daemon/server.ts` — Same for in-process server
- `apps/desktop/src/main/config/build-config.ts` — `buildId` in schema + `getBuildId()` helper
- `apps/desktop/src/main/daemon/daemon-connector.ts` — `tryConnectBuildChecked()`, `waitForDaemonExit()`, `DaemonRestartError`
- `apps/desktop/src/main/app-startup.ts` — Sets `ACCOMPLISH_BUILD_ID` env + restart error dialog

## Test plan

- [ ] Same build: `pnpm dev`, quit, restart → daemon reused
- [ ] New commit: `pnpm dev`, quit, make commit, restart → daemon restarted
- [ ] Old daemon without buildId → treated as mismatch → restarted
- [ ] Timeout: freeze daemon with `kill -STOP` → 30s → error dialog
- [ ] Packaged upgrade: install v1, quit, install v2 → daemon restarted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App enforces matching background-service build identity and restarts the service when mismatched.
  * Health check now reports service build identity for clearer diagnostics.
  * Installer/startup captures and exposes build identity early to improve upgrade behavior.

* **Bug Fixes**
  * More reliable restart and reuse logic for stale or mismatched background services to reduce partial startups.
  * Blocking "Background Service Update" dialog and clearer error logs surface when a service cannot be restarted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->