### PR TITLE
fix: avoid bundling source Node.js runtimes in desktop packages

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -171,13 +171,6 @@
         "to": "daemon"
       },
       {
-        "from": "resources/nodejs",
-        "to": "nodejs",
-        "filter": [
-          "**/*"
-        ]
-      },
-      {
         "from": "build.env",
         "to": "build.env"
       }


### PR DESCRIPTION
Summary
- stop shipping the source apps/desktop/resources/nodejs tree as an extra packaged resource
- rely on the existing afterPack hook to copy only the target-specific bundled Node.js runtime into the final app
- reduce desktop package size and remove duplicated Node.js payload from Windows NSIS builds

Why
The Windows packaging failure was happening during the electron-builder NSIS 7za step. The desktop package config was bundling the full source resources/nodejs cache for all downloaded runtimes, and then afterPack copied the target runtime into the packaged app again. That duplicated the Node.js payload in the installer and significantly inflated the Windows artifact.

Validation
- pnpm typecheck
- pnpm lint:eslint (passes with existing unrelated warnings)
- pnpm format:check
- pre-push verification passed, including desktop unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused resource entry from the desktop application build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->