### PR TITLE
fix(browser): resolve CDP localhost IPv6 failure and auto-minimize on macOS

### DIFF
--- a/packages/agent-core/mcp-tools/dev-browser-mcp/src/connection.ts
+++ b/packages/agent-core/mcp-tools/dev-browser-mcp/src/connection.ts
@@ -253,7 +253,18 @@ async function connectBrowser(config: ConnectionConfig): Promise<Browser> {
         throw new Error(`dev-browser health check failed: ${res.status}`);
       }
       const info = (await res.json()) as { wsEndpoint: string };
-      return chromium.connectOverCDP(info.wsEndpoint);
+      if (!info.wsEndpoint) {
+        // Chrome not yet launched — treat as a recoverable error so the retry loop
+        // waits and tries again (the POST /pages call will trigger launch on first use).
+        throw new Error('fetch failed: dev-browser wsEndpoint is empty (browser not ready)');
+      }
+      // Normalize to 127.0.0.1: Chrome may report "localhost" which resolves to ::1 (IPv6)
+      // on macOS Sequoia/Tahoe, causing connectOverCDP to fail with ECONNREFUSED.
+      const normalizedEndpoint = info.wsEndpoint.replace(
+        /^(wss?:\/\/)localhost(:\d+)/,
+        '$1127.0.0.1$2',
+      );
+      return chromium.connectOverCDP(normalizedEndpoint);
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(String(error));
       if (attempt < BROWSER_CONNECT_MAX_ATTEMPTS - 1 && isRecoverableConnectionError(lastError)) {

--- a/packages/agent-core/mcp-tools/dev-browser/src/browser-window-controller.ts
+++ b/packages/agent-core/mcp-tools/dev-browser/src/browser-window-controller.ts
@@ -26,7 +26,26 @@ export class BrowserWindowController {
     if (this.options.headless) {
       return;
     }
-    await this.setWindowStateForPage(page, 'minimized', undefined, browserContext);
+    // Retry a few times with backoff: Browser.getWindowForTarget is not always ready
+    // immediately after Chrome launches, especially on macOS with system Chrome.
+    const MAX_ATTEMPTS = 3;
+    const RETRY_DELAY_MS = 500;
+    let lastError: unknown;
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      try {
+        await this.setWindowStateForPage(page, 'minimized', undefined, browserContext);
+        return;
+      } catch (error) {
+        lastError = error;
+        if (isClosedPageError(error)) {
+          throw error;
+        }
+        if (attempt < MAX_ATTEMPTS - 1) {
+          await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS * (attempt + 1)));
+        }
+      }
+    }
+    throw lastError;
   }
 
   async setNormalWindowState(

--- a/packages/agent-core/mcp-tools/dev-browser/src/index.ts
+++ b/packages/agent-core/mcp-tools/dev-browser/src/index.ts
@@ -55,6 +55,7 @@ export async function serve(options: ServeOptions = {}): Promise<DevBrowserServe
             ignoreDefaultArgs: ['--enable-automation'],
             args: [
               `--remote-debugging-port=${cdpPort}`,
+              '--remote-debugging-address=127.0.0.1',
               '--disable-blink-features=AutomationControlled',
             ],
           });
@@ -73,6 +74,7 @@ export async function serve(options: ServeOptions = {}): Promise<DevBrowserServe
           ignoreDefaultArgs: ['--enable-automation'],
           args: [
             `--remote-debugging-port=${cdpPort}`,
+            '--remote-debugging-address=127.0.0.1',
             '--disable-blink-features=AutomationControlled',
           ],
         });
@@ -80,7 +82,12 @@ export async function serve(options: ServeOptions = {}): Promise<DevBrowserServe
 
       const cdpResponse = await fetchWithRetry(`http://127.0.0.1:${cdpPort}/json/version`);
       const cdpInfo = (await cdpResponse.json()) as { webSocketDebuggerUrl: string };
-      _wsEndpoint = cdpInfo.webSocketDebuggerUrl;
+      // Normalize to 127.0.0.1 — Chrome may report "localhost" which resolves to ::1 (IPv6)
+      // on macOS Sequoia/Tahoe, breaking connectOverCDP and the browser preview.
+      _wsEndpoint = cdpInfo.webSocketDebuggerUrl.replace(
+        /^(wss?:\/\/)localhost(:\d+)/,
+        '$1127.0.0.1$2',
+      );
       console.log(`CDP WebSocket endpoint: ${_wsEndpoint}`);
 
       _browserContext = browserContext!;


### PR DESCRIPTION
## Summary

- **Fix fetch failed / ECONNREFUSED**: Chrome's CDP `webSocketDebuggerUrl` reports `localhost` as hostname, which resolves to `::1` (IPv6) on macOS Tahoe/Sequoia (Darwin 25.x) — but Chrome only binds its debug port to `127.0.0.1` (IPv4). Added `--remote-debugging-address=127.0.0.1` to Chrome launch args and normalize `localhost` → `127.0.0.1` in both the dev-browser server (`_wsEndpoint`) and the MCP client (`connectBrowser`)
- **Fix empty wsEndpoint race**: When `connectBrowser` polls `GET /` before Chrome has fully launched, `wsEndpoint` is an empty string. Added an explicit check that throws a recoverable `"fetch failed"` error, so the existing retry loop handles it correctly instead of passing `""` to `connectOverCDP`
- **Fix auto-minimize**: `Browser.getWindowForTarget` CDP command is not immediately available after Chrome launch. `backgroundPage()` now retries up to 3× with 500ms/1000ms backoff instead of failing silently

## Root Cause

On macOS Darwin 25.x (Tahoe/Sequoia), `localhost` DNS resolves to `::1` (IPv6) rather than `127.0.0.1` (IPv4). Chrome's remote debugging port binds to IPv4 only unless `--remote-debugging-address=127.0.0.1` is passed explicitly. This caused every `connectOverCDP` call to fail with ECONNREFUSED, retrying 3× (15s total) before throwing "fetch failed".

## Files Changed

- `packages/agent-core/mcp-tools/dev-browser/src/index.ts` — added `--remote-debugging-address=127.0.0.1` flag + normalize wsEndpoint
- `packages/agent-core/mcp-tools/dev-browser-mcp/src/connection.ts` — empty wsEndpoint guard + normalize before `connectOverCDP`
- `packages/agent-core/mcp-tools/dev-browser/src/browser-window-controller.ts` — retry loop for `backgroundPage()`

## Test plan

- [ ] Launch release build on macOS Tahoe/Sequoia (Darwin 25.x)
- [ ] Run a browser task — browser tools should connect immediately without "fetch failed" errors
- [ ] Verify Chrome window minimizes automatically after opening
- [ ] Verify browser preview in the app still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed IPv6-related connection failures on certain macOS configurations by enforcing IPv4 loopback binding.
  * Improved browser connection validation and error recovery in builtin mode.
  * Enhanced reliability of window state operations with automatic retry logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->