### PR TITLE
fix(ui): crash opening conversation with malformed browser_script actions + error boundaries

### DIFF
--- a/apps/web/locales/en/errors.json
+++ b/apps/web/locales/en/errors.json
@@ -120,5 +120,13 @@
     "reconnectFailed": "Reconnection Failed",
     "reconnectFailedMessage": "Could not reconnect to the daemon. Tasks may be interrupted.",
     "openSettings": "Open Settings"
+  },
+  "boundary": {
+    "title": "Something went wrong",
+    "unexpectedError": "An unexpected error occurred.",
+    "compactMessage": "Something went wrong rendering this content.",
+    "errorPrefix": "Error:",
+    "tryAgain": "Try again",
+    "sidebarLoading": "Loading navigation…"
   }
 }

--- a/apps/web/locales/fr/errors.json
+++ b/apps/web/locales/fr/errors.json
@@ -120,5 +120,13 @@
     "reconnectFailed": "Reconnection Failed",
     "reconnectFailedMessage": "Could not reconnect to the daemon. Tasks may be interrupted.",
     "openSettings": "Open Settings"
+  },
+  "boundary": {
+    "title": "Quelque chose s'est mal passé",
+    "unexpectedError": "Une erreur inattendue s'est produite.",
+    "compactMessage": "Une erreur s'est produite lors du rendu de ce contenu.",
+    "errorPrefix": "Erreur :",
+    "tryAgain": "Réessayer",
+    "sidebarLoading": "Chargement de la navigation…"
   }
 }

--- a/apps/web/locales/ru/errors.json
+++ b/apps/web/locales/ru/errors.json
@@ -120,5 +120,13 @@
     "reconnectFailed": "Reconnection Failed",
     "reconnectFailedMessage": "Could not reconnect to the daemon. Tasks may be interrupted.",
     "openSettings": "Open Settings"
+  },
+  "boundary": {
+    "title": "Что-то пошло не так",
+    "unexpectedError": "Произошла непредвиденная ошибка.",
+    "compactMessage": "Ошибка при отображении содержимого.",
+    "errorPrefix": "Ошибка:",
+    "tryAgain": "Попробовать снова",
+    "sidebarLoading": "Загрузка навигации…"
   }
 }

--- a/apps/web/locales/zh-CN/errors.json
+++ b/apps/web/locales/zh-CN/errors.json
@@ -120,5 +120,13 @@
     "reconnectFailed": "Reconnection Failed",
     "reconnectFailedMessage": "Could not reconnect to the daemon. Tasks may be interrupted.",
     "openSettings": "Open Settings"
+  },
+  "boundary": {
+    "title": "出现了一些问题",
+    "unexpectedError": "发生了意外错误。",
+    "compactMessage": "渲染此内容时出现问题。",
+    "errorPrefix": "错误：",
+    "tryAgain": "再试一次",
+    "sidebarLoading": "正在加载导航…"
   }
 }

--- a/apps/web/src/client/App.tsx
+++ b/apps/web/src/client/App.tsx
@@ -17,6 +17,7 @@ import { CloseConfirmDialog } from './components/CloseConfirmDialog';
 import SettingsDialog from './components/layout/SettingsDialog';
 import { useTaskStore } from './stores/taskStore';
 import { SpinnerGap, Warning } from '@phosphor-icons/react';
+import { ErrorBoundary } from './components/ui/ErrorBoundary';
 
 type AppStatus = 'loading' | 'ready' | 'error';
 
@@ -172,7 +173,9 @@ export function App() {
     <div className="flex h-screen overflow-hidden bg-background">
       {/* Invisible drag region for window dragging (macOS hiddenInset titlebar) */}
       <div className="drag-region fixed top-0 left-0 right-0 h-10 z-50 pointer-events-none" />
-      <Sidebar />
+      <ErrorBoundary>
+        <Sidebar />
+      </ErrorBoundary>
       <main className="flex-1 overflow-hidden">
         <AnimatedOutletWrapper />
       </main>

--- a/apps/web/src/client/App.tsx
+++ b/apps/web/src/client/App.tsx
@@ -10,6 +10,7 @@ import { OAuthProviderId } from '@accomplish_ai/agent-core/common';
 
 // Components
 import Sidebar from './components/layout/Sidebar';
+import { SidebarFallback } from './components/layout/SidebarFallback';
 import { TaskLauncher } from './components/TaskLauncher';
 import { AuthErrorToast } from './components/AuthErrorToast';
 import { DaemonConnectionToast } from './components/DaemonConnectionToast';
@@ -173,7 +174,7 @@ export function App() {
     <div className="flex h-screen overflow-hidden bg-background">
       {/* Invisible drag region for window dragging (macOS hiddenInset titlebar) */}
       <div className="drag-region fixed top-0 left-0 right-0 h-10 z-50 pointer-events-none" />
-      <ErrorBoundary>
+      <ErrorBoundary fallback={(_error, _reset) => <SidebarFallback />}>
         <Sidebar />
       </ErrorBoundary>
       <main className="flex-1 overflow-hidden">

--- a/apps/web/src/client/components/execution/MessageList.tsx
+++ b/apps/web/src/client/components/execution/MessageList.tsx
@@ -78,7 +78,7 @@ export const MessageBubble = memo(
       >
         {isTool &&
         toolName?.endsWith('browser_script') &&
-        (message.toolInput as { actions?: unknown[] })?.actions ? (
+        Array.isArray((message.toolInput as { actions?: unknown })?.actions) ? (
           <BrowserScriptCard
             actions={
               (

--- a/apps/web/src/client/components/layout/SidebarFallback.tsx
+++ b/apps/web/src/client/components/layout/SidebarFallback.tsx
@@ -1,10 +1,12 @@
+import { useTranslation } from 'react-i18next';
 import { SpinnerGap } from '@phosphor-icons/react';
 
 export function SidebarFallback() {
+  const { t } = useTranslation('errors');
   return (
     <div className="flex flex-col items-center justify-center h-full p-4 text-muted-foreground">
       <SpinnerGap className="animate-spin mb-2" />
-      <div>Loading navigation…</div>
+      <div>{t('boundary.sidebarLoading')}</div>
     </div>
   );
 }

--- a/apps/web/src/client/components/layout/SidebarFallback.tsx
+++ b/apps/web/src/client/components/layout/SidebarFallback.tsx
@@ -1,0 +1,10 @@
+import { SpinnerGap } from '@phosphor-icons/react';
+
+export function SidebarFallback() {
+  return (
+    <div className="flex flex-col items-center justify-center h-full p-4 text-muted-foreground">
+      <SpinnerGap className="animate-spin mb-2" />
+      <div>Loading navigation…</div>
+    </div>
+  );
+}

--- a/apps/web/src/client/components/ui/ErrorBoundary.tsx
+++ b/apps/web/src/client/components/ui/ErrorBoundary.tsx
@@ -1,0 +1,88 @@
+import { Component, type ReactNode, type ErrorInfo } from 'react';
+import { WarningCircle, ArrowCounterClockwise } from '@phosphor-icons/react';
+
+interface Props {
+  children: ReactNode;
+  /** Custom fallback. Receives `reset` callback to retry. */
+  fallback?: (reset: () => void) => ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // Log for debugging — uses console.error intentionally (boundary context, not production logic)
+    console.error('[ErrorBoundary] caught:', error, info.componentStack);
+  }
+
+  reset = () => this.setState({ error: null });
+
+  render() {
+    if (this.state.error) {
+      if (this.props.fallback) {
+        return this.props.fallback(this.reset);
+      }
+      return <DefaultFallback error={this.state.error} reset={this.reset} />;
+    }
+    return this.props.children;
+  }
+}
+
+interface FallbackProps {
+  error: Error;
+  reset: () => void;
+  /** Make it compact for inline use (e.g. inside a conversation) */
+  compact?: boolean;
+}
+
+export function DefaultFallback({ error, reset, compact = false }: FallbackProps) {
+  if (compact) {
+    return (
+      <div className="flex items-center gap-3 rounded-xl border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+        <WarningCircle className="h-4 w-4 shrink-0" />
+        <span className="flex-1 truncate">
+          Something went wrong rendering this content.{' '}
+          <span className="opacity-60 font-mono text-xs">{error.message}</span>
+        </span>
+        <button
+          type="button"
+          onClick={reset}
+          className="shrink-0 flex items-center gap-1 text-xs text-destructive/80 hover:text-destructive transition-colors"
+        >
+          <ArrowCounterClockwise className="h-3.5 w-3.5" />
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full items-center justify-center p-8">
+      <div className="max-w-md w-full text-center">
+        <div className="mb-4 flex justify-center">
+          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-destructive/10">
+            <WarningCircle className="h-7 w-7 text-destructive" />
+          </div>
+        </div>
+        <h2 className="mb-1 text-base font-semibold text-foreground">Something went wrong</h2>
+        <p className="mb-4 text-sm text-muted-foreground font-mono break-all">{error.message}</p>
+        <button
+          type="button"
+          onClick={reset}
+          className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+        >
+          <ArrowCounterClockwise className="h-4 w-4" />
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/client/components/ui/ErrorBoundary.tsx
+++ b/apps/web/src/client/components/ui/ErrorBoundary.tsx
@@ -48,7 +48,7 @@ interface FallbackProps {
 export function DefaultFallback({ error, reset, compact = false }: FallbackProps) {
   const { t } = useTranslation('errors');
   const { t: tCommon } = useTranslation('common');
-  const isDev = process.env.NODE_ENV === 'development';
+  const isDev: boolean = import.meta.env.DEV;
   let rawMessage = error?.message ?? String(error);
   if (!rawMessage || typeof rawMessage !== 'string' || rawMessage.trim() === '') {
     rawMessage = t('boundary.unexpectedError');

--- a/apps/web/src/client/components/ui/ErrorBoundary.tsx
+++ b/apps/web/src/client/components/ui/ErrorBoundary.tsx
@@ -1,10 +1,11 @@
 import { Component, type ReactNode, type ErrorInfo } from 'react';
 import { WarningCircle, ArrowCounterClockwise } from '@phosphor-icons/react';
+import { Button } from './button';
 
 interface Props {
   children: ReactNode;
-  /** Custom fallback. Receives `reset` callback to retry. */
-  fallback?: (reset: () => void) => ReactNode;
+  /** Custom fallback. Receives the caught Error and a reset callback. */
+  fallback?: (error: Error, reset: () => void) => ReactNode;
 }
 
 interface State {
@@ -28,7 +29,7 @@ export class ErrorBoundary extends Component<Props, State> {
   render() {
     if (this.state.error) {
       if (this.props.fallback) {
-        return this.props.fallback(this.reset);
+        return this.props.fallback(this.state.error, this.reset);
       }
       return <DefaultFallback error={this.state.error} reset={this.reset} />;
     }
@@ -44,22 +45,30 @@ interface FallbackProps {
 }
 
 export function DefaultFallback({ error, reset, compact = false }: FallbackProps) {
+  const isDev = process.env.NODE_ENV === 'development';
+  let safeMessage = 'An unexpected error occurred.';
+  if (isDev) {
+    safeMessage = error.message?.length > 500 ? error.message.slice(0, 500) + '…' : error.message;
+  }
+
   if (compact) {
     return (
       <div className="flex items-center gap-3 rounded-xl border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
         <WarningCircle className="h-4 w-4 shrink-0" />
         <span className="flex-1 truncate">
           Something went wrong rendering this content.{' '}
-          <span className="opacity-60 font-mono text-xs">{error.message}</span>
+          <span className="opacity-60 font-mono text-xs">{safeMessage}</span>
         </span>
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          size="sm"
           onClick={reset}
-          className="shrink-0 flex items-center gap-1 text-xs text-destructive/80 hover:text-destructive transition-colors"
+          className="shrink-0 gap-1 text-xs text-destructive/80 hover:text-destructive hover:bg-transparent px-1"
         >
           <ArrowCounterClockwise className="h-3.5 w-3.5" />
           Retry
-        </button>
+        </Button>
       </div>
     );
   }
@@ -73,15 +82,11 @@ export function DefaultFallback({ error, reset, compact = false }: FallbackProps
           </div>
         </div>
         <h2 className="mb-1 text-base font-semibold text-foreground">Something went wrong</h2>
-        <p className="mb-4 text-sm text-muted-foreground font-mono break-all">{error.message}</p>
-        <button
-          type="button"
-          onClick={reset}
-          className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
-        >
-          <ArrowCounterClockwise className="h-4 w-4" />
+        <p className="mb-4 text-sm text-muted-foreground font-mono break-all">{safeMessage}</p>
+        <Button type="button" onClick={reset}>
+          <ArrowCounterClockwise />
           Try again
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/apps/web/src/client/components/ui/ErrorBoundary.tsx
+++ b/apps/web/src/client/components/ui/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type ReactNode, type ErrorInfo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { WarningCircle, ArrowCounterClockwise } from '@phosphor-icons/react';
 import { Button } from './button';
 
@@ -45,19 +46,32 @@ interface FallbackProps {
 }
 
 export function DefaultFallback({ error, reset, compact = false }: FallbackProps) {
+  const { t } = useTranslation('errors');
+  const { t: tCommon } = useTranslation('common');
   const isDev = process.env.NODE_ENV === 'development';
-  let safeMessage = 'An unexpected error occurred.';
-  if (isDev) {
-    safeMessage = error.message?.length > 500 ? error.message.slice(0, 500) + '…' : error.message;
-  }
+  const safeMessage = isDev
+    ? error.message?.length > 500
+      ? error.message.slice(0, 500) + '…'
+      : error.message
+    : t('boundary.unexpectedError');
 
   if (compact) {
     return (
-      <div className="flex items-center gap-3 rounded-xl border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
-        <WarningCircle className="h-4 w-4 shrink-0" />
+      <div
+        className="flex items-center gap-3 rounded-xl border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive"
+        role="alert"
+        aria-live="assertive"
+        aria-atomic="true"
+      >
+        <WarningCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
         <span className="flex-1 truncate">
-          Something went wrong rendering this content.{' '}
-          <span className="opacity-60 font-mono text-xs">{safeMessage}</span>
+          {t('boundary.compactMessage')}{' '}
+          <span className="opacity-60 font-mono text-xs" aria-atomic="true">
+            {safeMessage}
+            <span className="sr-only">
+              {t('boundary.errorPrefix')} {safeMessage}
+            </span>
+          </span>
         </span>
         <Button
           type="button"
@@ -67,7 +81,7 @@ export function DefaultFallback({ error, reset, compact = false }: FallbackProps
           className="shrink-0 gap-1 text-xs text-destructive/80 hover:text-destructive hover:bg-transparent px-1"
         >
           <ArrowCounterClockwise className="h-3.5 w-3.5" />
-          Retry
+          {tCommon('buttons.retry')}
         </Button>
       </div>
     );
@@ -81,11 +95,11 @@ export function DefaultFallback({ error, reset, compact = false }: FallbackProps
             <WarningCircle className="h-7 w-7 text-destructive" />
           </div>
         </div>
-        <h2 className="mb-1 text-base font-semibold text-foreground">Something went wrong</h2>
+        <h2 className="mb-1 text-base font-semibold text-foreground">{t('boundary.title')}</h2>
         <p className="mb-4 text-sm text-muted-foreground font-mono break-all">{safeMessage}</p>
         <Button type="button" onClick={reset}>
           <ArrowCounterClockwise />
-          Try again
+          {t('boundary.tryAgain')}
         </Button>
       </div>
     </div>

--- a/apps/web/src/client/components/ui/ErrorBoundary.tsx
+++ b/apps/web/src/client/components/ui/ErrorBoundary.tsx
@@ -49,11 +49,17 @@ export function DefaultFallback({ error, reset, compact = false }: FallbackProps
   const { t } = useTranslation('errors');
   const { t: tCommon } = useTranslation('common');
   const isDev = process.env.NODE_ENV === 'development';
-  const safeMessage = isDev
-    ? error.message?.length > 500
-      ? error.message.slice(0, 500) + '…'
-      : error.message
-    : t('boundary.unexpectedError');
+  let rawMessage = error?.message ?? String(error);
+  if (!rawMessage || typeof rawMessage !== 'string' || rawMessage.trim() === '') {
+    rawMessage = t('boundary.unexpectedError');
+  }
+
+  let safeMessage: string;
+  if (isDev) {
+    safeMessage = rawMessage.length > 500 ? rawMessage.slice(0, 500) + '...' : rawMessage;
+  } else {
+    safeMessage = t('boundary.unexpectedError');
+  }
 
   if (compact) {
     return (
@@ -66,12 +72,7 @@ export function DefaultFallback({ error, reset, compact = false }: FallbackProps
         <WarningCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
         <span className="flex-1 truncate">
           {t('boundary.compactMessage')}{' '}
-          <span className="opacity-60 font-mono text-xs" aria-atomic="true">
-            {safeMessage}
-            <span className="sr-only">
-              {t('boundary.errorPrefix')} {safeMessage}
-            </span>
-          </span>
+          <span className="opacity-60 font-mono text-xs">{safeMessage}</span>
         </span>
         <Button
           type="button"

--- a/apps/web/src/client/components/ui/RouteErrorFallback.tsx
+++ b/apps/web/src/client/components/ui/RouteErrorFallback.tsx
@@ -1,0 +1,33 @@
+import { useRouteError, isRouteErrorResponse, Link } from 'react-router';
+import { WarningCircle } from '@phosphor-icons/react';
+
+export function RouteErrorFallback() {
+  const error = useRouteError();
+
+  let message = 'An unexpected error occurred.';
+  if (isRouteErrorResponse(error)) {
+    message = `${error.status} — ${error.statusText}`;
+  } else if (error instanceof Error) {
+    message = error.message;
+  }
+
+  return (
+    <div className="flex h-full min-h-screen items-center justify-center bg-background p-8">
+      <div className="max-w-md w-full text-center">
+        <div className="mb-4 flex justify-center">
+          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-destructive/10">
+            <WarningCircle className="h-7 w-7 text-destructive" />
+          </div>
+        </div>
+        <h1 className="mb-1 text-lg font-semibold text-foreground">Something went wrong</h1>
+        <p className="mb-6 text-sm text-muted-foreground font-mono break-all">{message}</p>
+        <Link
+          to="/"
+          className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+        >
+          Go home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/client/components/ui/RouteErrorFallback.tsx
+++ b/apps/web/src/client/components/ui/RouteErrorFallback.tsx
@@ -1,14 +1,22 @@
 import { useRouteError, isRouteErrorResponse, Link } from 'react-router';
 import { WarningCircle } from '@phosphor-icons/react';
+import { Button } from './button';
 
 export function RouteErrorFallback() {
   const error = useRouteError();
+  const isDev = process.env.NODE_ENV === 'development';
 
   let message = 'An unexpected error occurred.';
   if (isRouteErrorResponse(error)) {
     message = `${error.status} — ${error.statusText}`;
+    if (isDev) console.error('[RouteErrorFallback] RouteErrorResponse:', error);
   } else if (error instanceof Error) {
-    message = error.message;
+    if (isDev) {
+      console.error('[RouteErrorFallback] Error:', error);
+      message = error.message?.length > 500 ? error.message.slice(0, 500) + '…' : error.message;
+    }
+  } else if (isDev) {
+    console.error('[RouteErrorFallback] Unknown error:', error);
   }
 
   return (
@@ -21,12 +29,9 @@ export function RouteErrorFallback() {
         </div>
         <h1 className="mb-1 text-lg font-semibold text-foreground">Something went wrong</h1>
         <p className="mb-6 text-sm text-muted-foreground font-mono break-all">{message}</p>
-        <Link
-          to="/"
-          className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
-        >
-          Go home
-        </Link>
+        <Button asChild>
+          <Link to="/">Go home</Link>
+        </Button>
       </div>
     </div>
   );

--- a/apps/web/src/client/components/ui/RouteErrorFallback.tsx
+++ b/apps/web/src/client/components/ui/RouteErrorFallback.tsx
@@ -1,12 +1,15 @@
 import { useRouteError, isRouteErrorResponse, Link } from 'react-router';
+import { useTranslation } from 'react-i18next';
 import { WarningCircle } from '@phosphor-icons/react';
 import { Button } from './button';
 
 export function RouteErrorFallback() {
   const error = useRouteError();
+  const { t } = useTranslation('errors');
+  const { t: tCommon } = useTranslation('common');
   const isDev = process.env.NODE_ENV === 'development';
 
-  let message = 'An unexpected error occurred.';
+  let message = t('boundary.unexpectedError');
   if (isRouteErrorResponse(error)) {
     message = `${error.status} — ${error.statusText}`;
     if (isDev) console.error('[RouteErrorFallback] RouteErrorResponse:', error);
@@ -27,10 +30,10 @@ export function RouteErrorFallback() {
             <WarningCircle className="h-7 w-7 text-destructive" />
           </div>
         </div>
-        <h1 className="mb-1 text-lg font-semibold text-foreground">Something went wrong</h1>
+        <h1 className="mb-1 text-lg font-semibold text-foreground">{t('boundary.title')}</h1>
         <p className="mb-6 text-sm text-muted-foreground font-mono break-all">{message}</p>
         <Button asChild>
-          <Link to="/">Go home</Link>
+          <Link to="/">{tCommon('buttons.goHome')}</Link>
         </Button>
       </div>
     </div>

--- a/apps/web/src/client/components/ui/RouteErrorFallback.tsx
+++ b/apps/web/src/client/components/ui/RouteErrorFallback.tsx
@@ -7,7 +7,7 @@ export function RouteErrorFallback() {
   const error = useRouteError();
   const { t } = useTranslation('errors');
   const { t: tCommon } = useTranslation('common');
-  const isDev = process.env.NODE_ENV === 'development';
+  const isDev: boolean = import.meta.env.DEV;
 
   let message = t('boundary.unexpectedError');
   if (isRouteErrorResponse(error)) {

--- a/apps/web/src/client/i18n/index.ts
+++ b/apps/web/src/client/i18n/index.ts
@@ -178,7 +178,7 @@ export async function initI18n(): Promise<void> {
           lookupLocalStorage: LANGUAGE_STORAGE_KEY,
         },
 
-        debug: process.env.NODE_ENV === 'development',
+        debug: import.meta.env.DEV,
 
         returnEmptyString: false,
 

--- a/apps/web/src/client/pages/Execution.tsx
+++ b/apps/web/src/client/pages/Execution.tsx
@@ -17,6 +17,7 @@ import { FollowUpInput } from './execution/FollowUpInput';
 import { useExecutionPage } from './execution/useExecutionPage';
 import { CreditExhaustedChatBanner } from '../components/execution/CreditExhaustedChatBanner';
 import { useCreditsState } from '../hooks/useCreditsState';
+import { ErrorBoundary, DefaultFallback } from '../components/ui/ErrorBoundary';
 
 /** Detects Accomplish AI free-tier credit exhaustion errors specifically. */
 function isAccomplishCreditExhaustedError(message?: string): boolean {
@@ -126,32 +127,44 @@ export default function ExecutionPage() {
 
         {/* Running messages */}
         {s.currentTask.status !== 'queued' && (
-          <ConversationView
-            currentTask={s.currentTask}
-            taskId={s.id}
-            scrollContainerRef={scrollContainerRef}
-            messagesEndRef={messagesEndRef}
-            onScroll={s.handleScroll}
-            isAtBottom={s.isAtBottom}
-            scrollToBottom={s.scrollToBottom}
-            hasSession={s.hasSession}
-            isConnectorAuthPause={s.isConnectorAuthPause}
-            taskActionLabel={s.taskActionLabel}
-            taskActionPendingLabel={s.taskActionPendingLabel}
-            onTaskAction={s.handleTaskAction}
-            isTaskActionRunning={s.isTaskActionRunning}
-            taskActionError={s.taskActionError}
-            isLoading={s.isLoading}
-            permissionRequest={s.permissionRequest}
-            onPermissionResponse={s.handlePermissionResponse}
-            currentTool={s.currentTool}
-            currentToolInput={s.currentToolInput}
-            startupStage={s.startupStage}
-            startupStageTaskId={s.startupStageTaskId}
-            elapsedTime={s.elapsedTime}
-            todos={s.todos}
-            todosTaskId={s.todosTaskId}
-          />
+          <ErrorBoundary
+            fallback={(reset) => (
+              <div className="flex-1 flex items-center justify-center p-6">
+                <DefaultFallback
+                  error={new Error('Failed to render conversation')}
+                  reset={reset}
+                  compact={false}
+                />
+              </div>
+            )}
+          >
+            <ConversationView
+              currentTask={s.currentTask}
+              taskId={s.id}
+              scrollContainerRef={scrollContainerRef}
+              messagesEndRef={messagesEndRef}
+              onScroll={s.handleScroll}
+              isAtBottom={s.isAtBottom}
+              scrollToBottom={s.scrollToBottom}
+              hasSession={s.hasSession}
+              isConnectorAuthPause={s.isConnectorAuthPause}
+              taskActionLabel={s.taskActionLabel}
+              taskActionPendingLabel={s.taskActionPendingLabel}
+              onTaskAction={s.handleTaskAction}
+              isTaskActionRunning={s.isTaskActionRunning}
+              taskActionError={s.taskActionError}
+              isLoading={s.isLoading}
+              permissionRequest={s.permissionRequest}
+              onPermissionResponse={s.handlePermissionResponse}
+              currentTool={s.currentTool}
+              currentToolInput={s.currentToolInput}
+              startupStage={s.startupStage}
+              startupStageTaskId={s.startupStageTaskId}
+              elapsedTime={s.elapsedTime}
+              todos={s.todos}
+              todosTaskId={s.todosTaskId}
+            />
+          </ErrorBoundary>
         )}
 
         {/* Running — stop button */}

--- a/apps/web/src/client/pages/Execution.tsx
+++ b/apps/web/src/client/pages/Execution.tsx
@@ -128,13 +128,9 @@ export default function ExecutionPage() {
         {/* Running messages */}
         {s.currentTask.status !== 'queued' && (
           <ErrorBoundary
-            fallback={(reset) => (
+            fallback={(error, reset) => (
               <div className="flex-1 flex items-center justify-center p-6">
-                <DefaultFallback
-                  error={new Error('Failed to render conversation')}
-                  reset={reset}
-                  compact={false}
-                />
+                <DefaultFallback error={error} reset={reset} compact={false} />
               </div>
             )}
           >

--- a/apps/web/src/client/router.tsx
+++ b/apps/web/src/client/router.tsx
@@ -2,14 +2,16 @@ import { createHashRouter, Navigate } from 'react-router';
 import { App } from './App';
 import { HomePage } from './pages/Home';
 import ExecutionPage from './pages/Execution';
+import { RouteErrorFallback } from './components/ui/RouteErrorFallback';
 
 export const router = createHashRouter([
   {
     path: '/',
     Component: App,
+    errorElement: <RouteErrorFallback />,
     children: [
-      { index: true, Component: HomePage },
-      { path: 'execution/:id', Component: ExecutionPage },
+      { index: true, Component: HomePage, errorElement: <RouteErrorFallback /> },
+      { path: 'execution/:id', Component: ExecutionPage, errorElement: <RouteErrorFallback /> },
       { path: '*', element: <Navigate to="/" replace /> },
     ],
   },

--- a/packages/agent-core/src/storage/repositories/providerSettings.ts
+++ b/packages/agent-core/src/storage/repositories/providerSettings.ts
@@ -42,9 +42,12 @@ function rowToProvider(row: ProviderRow): ConnectedProvider {
     selectedModelId: row.selected_model_id,
     credentials,
     lastConnectedAt: row.last_connected_at || new Date().toISOString(),
-    availableModels:
-      safeParseJsonWithFallback<Array<{ id: string; name: string }>>(row.available_models) ??
-      undefined,
+    availableModels: (() => {
+      const parsed = safeParseJsonWithFallback<Array<{ id: string; name: string }>>(
+        row.available_models,
+      );
+      return Array.isArray(parsed) ? parsed : undefined;
+    })(),
     customBaseUrl: row.custom_base_url || undefined,
   };
 }

--- a/packages/agent-core/src/storage/repositories/providerSettings.ts
+++ b/packages/agent-core/src/storage/repositories/providerSettings.ts
@@ -46,7 +46,17 @@ function rowToProvider(row: ProviderRow): ConnectedProvider {
       const parsed = safeParseJsonWithFallback<Array<{ id: string; name: string }>>(
         row.available_models,
       );
-      return Array.isArray(parsed) ? parsed : undefined;
+      if (!Array.isArray(parsed)) {
+        return undefined;
+      }
+      const valid = parsed.filter(
+        (m) =>
+          m !== null &&
+          typeof m === 'object' &&
+          typeof m.id === 'string' &&
+          typeof m.name === 'string',
+      );
+      return valid.length > 0 ? valid : undefined;
     })(),
     customBaseUrl: row.custom_base_url || undefined,
   };

--- a/packages/agent-core/src/storage/repositories/providerSettings.ts
+++ b/packages/agent-core/src/storage/repositories/providerSettings.ts
@@ -56,7 +56,7 @@ function rowToProvider(row: ProviderRow): ConnectedProvider {
           typeof m.id === 'string' &&
           typeof m.name === 'string',
       );
-      return valid.length > 0 ? valid : undefined;
+      return valid;
     })(),
     customBaseUrl: row.custom_base_url || undefined,
   };


### PR DESCRIPTION
## Summary

- **Bug fix**: Opening a specific conversation crashed the app with `o.map is not a function`. The agent had stored `actions` as a JSON string instead of an array in one tool message. The `BrowserScriptCard` guard used a truthy check (`?.actions ?`) which passed for a non-empty string, then `actions.slice(0,3)` returned 3 characters, and `.map()` on a string threw.
- **Fix**: Changed the guard in `MessageList.tsx` to `Array.isArray(...)` so only real arrays reach `BrowserScriptCard`.
- **Defensive fix**: `providerSettings.ts` now validates `availableModels` is actually an array after JSON parsing, preventing a similar crash in `ModelIndicator` if the DB row contains non-array JSON.
- **Error boundaries**: Added `ErrorBoundary` class component + `RouteErrorFallback` and wired them throughout the app so a single bad message can never white-screen the whole UI.

## Error boundaries added

| Location | Coverage |
|---|---|
| `router.tsx` — all 3 routes | Route-level render crashes → full-page error with "Go home" |
| `Execution.tsx` → `ConversationView` | Bad message data (like this crash) → inline error card with "Try again" |
| `App.tsx` → `Sidebar` | Sidebar crash → nav disappears gracefully, main content stays usable |

## Test plan

- [ ] Open the previously-crashing conversation (`task_1776226955077_s23i3mm`) — should now render without crashing, showing the malformed browser_script message as a plain text bubble
- [ ] Verify other conversations with normal `browser_script` messages still render `BrowserScriptCard` correctly
- [ ] Confirm all routes still render normally (home, execution)
- [ ] Verify typecheck, lint, build, and unit tests pass (all green in pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Error boundary protection for sidebar and conversation views with retry UI
  * Global route error page with user-friendly messaging and "Go home" action
  * Localized fallback UI and sidebar loading placeholder in English, French, Russian, and Chinese

* **Bug Fixes**
  * Stricter validation for tool message actions and provider model data parsing
  * Prevented app-wide crashes by isolating rendering errors to fallbacks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->