### PR TITLE
fix(tests): cli-path integration test imports from cli-resolver

### DIFF
--- a/apps/desktop/__tests__/integration/main/opencode/cli-path.integration.test.ts
+++ b/apps/desktop/__tests__/integration/main/opencode/cli-path.integration.test.ts
@@ -73,7 +73,7 @@ describe('OpenCode CLI Path Module', () => {
       mockApp.getAppPath.mockReturnValue(appPath);
       mockFs.existsSync.mockImplementation((p: string) => p === localCliPath);
 
-      const { getOpenCodeCliPath } = await import('@main/opencode/electron-options');
+      const { getOpenCodeCliPath } = await import('@main/opencode/cli-resolver');
       const result = getOpenCodeCliPath();
 
       expect(result.command).toBe(localCliPath);
@@ -91,7 +91,7 @@ describe('OpenCode CLI Path Module', () => {
       mockApp.getAppPath.mockReturnValue(appPath);
       mockFs.existsSync.mockImplementation((p: string) => p === localCliPath);
 
-      const { getOpenCodeCliPath } = await import('@main/opencode/electron-options');
+      const { getOpenCodeCliPath } = await import('@main/opencode/cli-resolver');
       const result = getOpenCodeCliPath();
 
       expect(result.command).toBe(localCliPath);
@@ -100,7 +100,7 @@ describe('OpenCode CLI Path Module', () => {
 
     it('throws when local CLI is missing in development mode', async () => {
       mockFs.existsSync.mockReturnValue(false);
-      const { getOpenCodeCliPath } = await import('@main/opencode/electron-options');
+      const { getOpenCodeCliPath } = await import('@main/opencode/cli-resolver');
 
       expect(() => getOpenCodeCliPath()).toThrow('OpenCode CLI executable not found');
     });
@@ -129,7 +129,7 @@ describe('OpenCode CLI Path Module', () => {
 
       mockFs.existsSync.mockImplementation((p: string) => p === bundledCliPath);
 
-      const { getOpenCodeCliPath } = await import('@main/opencode/electron-options');
+      const { getOpenCodeCliPath } = await import('@main/opencode/cli-resolver');
       const result = getOpenCodeCliPath();
 
       expect(result.command).toBe(bundledCliPath);
@@ -147,14 +147,14 @@ describe('OpenCode CLI Path Module', () => {
       mockApp.getAppPath.mockReturnValue(appPath);
       mockFs.existsSync.mockImplementation((p: string) => p === localCliPath);
 
-      const { isOpenCodeBundled } = await import('@main/opencode/electron-options');
+      const { isOpenCodeBundled } = await import('@main/opencode/cli-resolver');
       expect(isOpenCodeBundled()).toBe(true);
     });
 
     it('returns false when no local workspace CLI is available', async () => {
       mockFs.existsSync.mockReturnValue(false);
 
-      const { isOpenCodeBundled } = await import('@main/opencode/electron-options');
+      const { isOpenCodeBundled } = await import('@main/opencode/cli-resolver');
       expect(isOpenCodeBundled()).toBe(false);
     });
   });


### PR DESCRIPTION
## Summary

Fixes the CI integration-test failure introduced by PR #938 (OpenCode SDK cutover port).

PR #938's Phase 4b deleted \`apps/desktop/src/main/opencode/electron-options.ts\` but missed updating \`apps/desktop/__tests__/integration/main/opencode/cli-path.integration.test.ts\`, which still dynamically-imported \`getOpenCodeCliPath\` and \`isOpenCodeBundled\` from the deleted module.

The CI run for the merge commit ([24472884075](https://github.com/accomplish-ai/accomplish/actions/runs/24472884075/job/71517535657)) failed with all 6 cli-path tests reporting:

\`\`\`
Cannot find package '@main/opencode/electron-options' imported from
  apps/desktop/__tests__/integration/main/opencode/cli-path.integration.test.ts
\`\`\`

Both functions live in \`apps/desktop/src/main/opencode/cli-resolver.ts\` with identical signatures. One-line sed swap of the 6 import paths:

\`\`\`
-import('@main/opencode/electron-options')
+import('@main/opencode/cli-resolver')
\`\`\`

## Why this slipped through #938

The local pre-push hook only runs \`test:unit\` per workspace. The full \`pnpm -F @accomplish/desktop test\` (unit + integration) only runs in CI. Folding the integration command into the local pre-push gate would catch this class of regression earlier — left as a follow-up tooling improvement.

## Test plan

- [x] \`pnpm -F @accomplish/desktop test:integration\` → **126 pass** (was 120 / 6 failing)
- [x] \`pnpm -F @accomplish/desktop test\` (unit + integration) → **438 pass**
- [x] \`pnpm typecheck\` (4 workspaces) → clean
- [x] \`pnpm format:check\` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized internal test imports for improved code structure.

---

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->