### PR TITLE
fix(daemon): route task config through resolveTaskConfig (restore 6 dropped features)

### DIFF
--- a/apps/daemon/__tests__/unit/storage-service.unit.test.ts
+++ b/apps/daemon/__tests__/unit/storage-service.unit.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Regression tests for `StorageService` bootstrap.
+ *
+ * The primary concern pinned here is subtle and was caught only by running
+ * the daemon end-to-end: `resolveTaskConfig` (routed through by PR #946)
+ * calls `getKnowledgeNotesForPrompt`, which in turn calls `getMetaDatabase()`.
+ * That meta database is a SIBLING SQLite file from the main `accomplish.db`;
+ * before this test existed, only the desktop main process called
+ * `initializeMetaDatabase`. The daemon never did.
+ *
+ * Consequence pre-fix: every daemon-run task silently dropped workspace
+ * knowledge notes — the repo threw `"Workspace meta database not
+ * initialized"`, `resolveTaskConfig`'s try/catch swallowed it into a log
+ * warning, and the generated `opencode-<taskId>.json` was missing the
+ * knowledge text users had configured.
+ *
+ * This test asserts the bootstrap order that makes the real flow work:
+ *   1. `StorageService.initialize(dataDir)` calls `initializeMetaDatabase`
+ *      with a path derived from the same dataDir (so desktop + daemon
+ *      share the on-disk meta file).
+ *   2. `StorageService.close()` tears the meta DB down too.
+ *
+ * Better-sqlite3's native binding can't be loaded in the daemon vitest
+ * environment (NODE_MODULE_VERSION mismatch against Electron's bundled
+ * Node), so we can't run a live DB here. Instead we intercept the three
+ * agent-core meta-DB entry points and assert the call shapes — which is
+ * exactly enough to detect a future revert.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { rmSync } from 'node:fs';
+
+let initCalls: string[] = [];
+let closeCalls = 0;
+let metaInitialized = false;
+
+vi.mock('@accomplish_ai/agent-core', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    createStorage: vi.fn(() => ({
+      initialize: vi.fn(),
+      close: vi.fn(),
+    })),
+    initializeMetaDatabase: vi.fn((path: string) => {
+      initCalls.push(path);
+      metaInitialized = true;
+    }),
+    closeMetaDatabase: vi.fn(() => {
+      closeCalls += 1;
+      metaInitialized = false;
+    }),
+    isMetaDatabaseInitialized: vi.fn(() => metaInitialized),
+  };
+});
+
+const { StorageService } = await import('../../src/storage-service.js');
+
+describe('StorageService bootstrap — workspace-meta DB', () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    initCalls = [];
+    closeCalls = 0;
+    metaInitialized = false;
+    delete process.env.ACCOMPLISH_IS_PACKAGED;
+    dataDir = join(tmpdir(), `storage-svc-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  });
+
+  afterEach(() => {
+    delete process.env.ACCOMPLISH_IS_PACKAGED;
+    try {
+      rmSync(dataDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  it('initialises the workspace-meta DB next to the main DB in dev mode', () => {
+    const svc = new StorageService();
+    svc.initialize(dataDir);
+
+    expect(initCalls).toEqual([join(dataDir, 'workspace-meta-dev.db')]);
+  });
+
+  it('uses the packaged file name when ACCOMPLISH_IS_PACKAGED=1', () => {
+    process.env.ACCOMPLISH_IS_PACKAGED = '1';
+    const svc = new StorageService();
+    svc.initialize(dataDir);
+
+    expect(initCalls).toEqual([join(dataDir, 'workspace-meta.db')]);
+  });
+
+  it('closes the workspace-meta DB when close() is called', () => {
+    const svc = new StorageService();
+    svc.initialize(dataDir);
+    expect(closeCalls).toBe(0);
+
+    svc.close();
+    expect(closeCalls).toBe(1);
+  });
+
+  it('close() is a no-op for the meta DB when it was never initialised', () => {
+    // Caller accidentally invokes close() without initialize() — e.g. a
+    // crashed bootstrap path. `closeMetaDatabase` must not fire for a
+    // never-opened singleton.
+    const svc = new StorageService();
+    svc.close();
+    expect(closeCalls).toBe(0);
+  });
+});

--- a/apps/daemon/__tests__/unit/task-config-builder.unit.test.ts
+++ b/apps/daemon/__tests__/unit/task-config-builder.unit.test.ts
@@ -1,0 +1,379 @@
+/**
+ * Integration-ish tests for the daemon's `onBeforeStart` hook.
+ *
+ * These tests run the REAL `resolveTaskConfig` + `generateConfig` (not
+ * mocked), so they prove that the live daemon config path writes all of:
+ *   - workspace knowledge notes into the system prompt
+ *   - enabled MCP connectors into `mcpServers`
+ *   - GWS accounts (gws-mcp / gmail-mcp / calendar-mcp) + manifest env
+ *   - OpenAI `store: false` provider option
+ *   - language preference
+ * into the actual opencode-<taskId>.json file on disk.
+ *
+ * The only mocks we inject sit at the edges `resolveTaskConfig` can't
+ * reach without better-sqlite3 native bindings:
+ *   - `getDatabase()` returns an in-memory stub that answers the two SQL
+ *     shapes `prepareGwsManifest` issues
+ *   - knowledge-note repo + provider-settings repo return fixed values
+ *
+ * Everything else — connector-token shape, cloud browser config,
+ * language, `store: false` injection, filename construction — flows
+ * through the real code.
+ *
+ * Tests also pin the three regressions Codex flagged:
+ *   - validateTaskConfig preserves workspaceId (so resolveTaskConfig
+ *     actually sees it)
+ *   - configFileName sanitisation against malicious taskIds
+ *   - resumeSession workspaceId fallback to the stored task (in a
+ *     sibling test file that mocks StorageAPI only)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+// Tunable via each test.
+let knowledgeNotesText: string | undefined = undefined;
+let activeProviderModel: { provider: string; model: string } | null = null;
+let gwsRows: Record<string, unknown>[] = [];
+
+// `generateConfig` does `fs.existsSync(nodeExe)` before writing the config;
+// create a real placeholder file each test can point at. This is test
+// plumbing, not what onBeforeStart produces on a real machine — the real
+// daemon resolves this from packaged / dev paths.
+let fakeNodeBinDir: string;
+let fakeMcpToolsPath: string;
+
+// Live DB stub — only answers what `prepareGwsManifest` queries.
+const dbStub = {
+  prepare: vi.fn((sql: string) => {
+    if (sql.includes('SELECT') && sql.includes('google_accounts')) {
+      return { all: vi.fn(() => gwsRows), run: vi.fn(), get: vi.fn() };
+    }
+    // UPDATE last_refreshed_at — no-op in tests (we never near-expiry here)
+    return { all: vi.fn(() => []), run: vi.fn(), get: vi.fn() };
+  }),
+};
+
+vi.mock('@accomplish_ai/agent-core/storage/database', () => ({
+  getDatabase: vi.fn(() => dbStub),
+}));
+
+// resolveTaskConfig imports getKnowledgeNotesForPrompt directly from the
+// repository module (NOT via the barrel), so the mock must target that
+// module path exactly.
+vi.mock('@accomplish_ai/agent-core/storage/repositories/knowledgeNotes', () => ({
+  getKnowledgeNotesForPrompt: vi.fn(() => knowledgeNotesText),
+}));
+
+vi.mock('@accomplish_ai/agent-core', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    // Mock out the auth.json sync / bundled-node resolution bits that
+    // hit the filesystem unnecessarily for this test.
+    syncApiKeysToOpenCodeAuth: vi.fn(),
+    getOpenCodeAuthJsonPath: vi.fn(() => '/tmp/fake-auth.json'),
+    // generateConfig throws without a bundled node path; point at a real
+    // file created in beforeEach. The MCP server entries the test asserts
+    // on don't actually spawn — we just need fs.existsSync to pass. The
+    // real daemon resolves this from packaged / dev paths.
+    getBundledNodePaths: vi.fn(() => ({
+      binDir: fakeNodeBinDir,
+      nodeExe: path.join(fakeNodeBinDir, process.platform === 'win32' ? 'node.exe' : 'node'),
+    })),
+    getEnabledSkills: vi.fn(() => []),
+    isCliAvailable: vi.fn(async () => true),
+  };
+});
+
+// Provider-settings / storage-repository barrel reads getDatabase() at call
+// time — the real one requires an initialised native SQLite module which is
+// absent in this test environment. Stub only the methods `buildProviderConfigs`
+// pulls in via that barrel. The vitest alias maps `@accomplish_ai/agent-core`
+// to agent-core's src/, so the relative path resolves the same way as from
+// `src/opencode/config-builder.ts`.
+vi.mock('@accomplish_ai/agent-core/storage/repositories/index', async () => {
+  return {
+    getProviderSettings: vi.fn(() => ({
+      activeProviderId: null,
+      connectedProviders: {},
+      debugMode: false,
+      onboardingComplete: true,
+      selectedModel: undefined,
+      ollamaConfig: null,
+      litellmConfig: null,
+      azureFoundryConfig: null,
+      lmstudioConfig: null,
+      huggingfaceLocalConfig: null,
+      nimConfig: null,
+      openAiBaseUrl: '',
+      llamaCppConfig: null,
+      language: undefined,
+    })),
+    getActiveProviderModel: vi.fn(() => activeProviderModel),
+    getConnectedProviderIds: vi.fn(() => []),
+    getOllamaConfig: vi.fn(() => null),
+    getLMStudioConfig: vi.fn(() => null),
+    getLiteLLMConfig: vi.fn(() => null),
+    getAzureFoundryConfig: vi.fn(() => null),
+    getHuggingFaceLocalConfig: vi.fn(() => null),
+    getNimConfig: vi.fn(() => null),
+    getOpenAiBaseUrl: vi.fn(() => ''),
+    getLlamaCppConfig: vi.fn(() => null),
+  };
+});
+
+const { onBeforeStart } = await import('../../src/task-config-builder.js');
+
+function makeStorage(overrides: Record<string, unknown> = {}) {
+  return {
+    getAllApiKeys: vi.fn(async () => ({ openai: 'sk-test-openai' })),
+    getApiKey: vi.fn((provider: string) => (provider === 'openai' ? 'sk-test-openai' : null)),
+    get: vi.fn(() => null),
+    set: vi.fn(),
+    getEnabledConnectors: vi.fn(() => []),
+    getConnectorTokens: vi.fn(() => null),
+    setConnectorStatus: vi.fn(),
+    storeConnectorTokens: vi.fn(),
+    getCloudBrowserConfig: vi.fn(() => null),
+    getLanguage: vi.fn(() => undefined),
+    ...overrides,
+  };
+}
+
+describe('daemon onBeforeStart — integration against real resolveTaskConfig + generateConfig', () => {
+  let tmpUserData: string;
+
+  beforeEach(() => {
+    knowledgeNotesText = undefined;
+    activeProviderModel = null;
+    gwsRows = [];
+    tmpUserData = path.join(
+      os.tmpdir(),
+      `daemon-onbeforestart-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    fs.mkdirSync(tmpUserData, { recursive: true });
+    fakeNodeBinDir = path.join(tmpUserData, 'fake-node-bin');
+    fs.mkdirSync(fakeNodeBinDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(fakeNodeBinDir, process.platform === 'win32' ? 'node.exe' : 'node'),
+      '',
+    );
+    // generator-mcp validates each registered MCP tool has a real
+    // `{tool}/dist/index.mjs` on disk. Create empty placeholders for each
+    // tool the real generator could conditionally register, so the test
+    // doesn't have to know which combinations each scenario enables.
+    fakeMcpToolsPath = path.join(tmpUserData, 'fake-mcp-tools');
+    for (const tool of [
+      'request-connector-auth',
+      'complete-task',
+      'start-task',
+      'desktop-control',
+      'whatsapp',
+      'dev-browser-mcp',
+      'gmail-mcp',
+      'calendar-mcp',
+      'gws-mcp',
+      'request-google-file-picker',
+    ]) {
+      const distDir = path.join(fakeMcpToolsPath, tool, 'dist');
+      fs.mkdirSync(distDir, { recursive: true });
+      fs.writeFileSync(path.join(distDir, 'index.mjs'), '');
+    }
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpUserData, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('writes opencode-<taskId>.json containing workspace knowledge notes and OpenAI store:false', async () => {
+    knowledgeNotesText = 'Remember: treat `foo` as a reserved keyword in this workspace.';
+    const storage = makeStorage();
+
+    const { configPath } = await onBeforeStart(
+      storage as never,
+      {
+        userDataPath: tmpUserData,
+        mcpToolsPath: fakeMcpToolsPath,
+        isPackaged: false,
+        resourcesPath: '',
+        appPath: '',
+      },
+      { taskId: 'tsk_abc', workspaceId: 'ws_42' },
+    );
+
+    // File should exist under the per-task name inside userDataPath/opencode/
+    expect(configPath).toBe(path.join(tmpUserData, 'opencode', 'opencode-tsk_abc.json'));
+    expect(fs.existsSync(configPath)).toBe(true);
+
+    const written = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    // System prompt has the workspace knowledge text embedded
+    const systemPrompt =
+      typeof written.instructions === 'string'
+        ? written.instructions
+        : Array.isArray(written.instructions)
+          ? written.instructions.join('\n')
+          : JSON.stringify(written);
+    expect(systemPrompt).toContain('treat `foo` as a reserved keyword');
+
+    // OpenAI provider has store:false injected
+    expect(written.provider?.openai?.options?.store).toBe(false);
+  });
+
+  it('includes enabled MCP connectors in the written config', async () => {
+    const storage = makeStorage({
+      getEnabledConnectors: vi.fn(() => [
+        {
+          id: 'conn-slack-1',
+          name: 'slack',
+          url: 'https://slack.example.com/mcp',
+          status: 'connected',
+        },
+      ]),
+      getConnectorTokens: vi.fn(() => ({
+        accessToken: 'slack-access-token',
+        refreshToken: undefined,
+        expiresAt: Date.now() + 3600_000,
+      })),
+    });
+
+    const { configPath } = await onBeforeStart(
+      storage as never,
+      {
+        userDataPath: tmpUserData,
+        mcpToolsPath: fakeMcpToolsPath,
+        isPackaged: false,
+        resourcesPath: '',
+        appPath: '',
+      },
+      { taskId: 'tsk_conn', workspaceId: undefined },
+    );
+
+    const written = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    const mcp = (written.mcp ?? written.mcpServers ?? {}) as Record<
+      string,
+      { type?: string; url?: string; headers?: Record<string, string> }
+    >;
+    // Generator-mcp encodes user connectors as `connector-<sanitized-name>-<id-prefix>`
+    // (see generator-mcp.ts:240–262). Built-in `slack` uses a bare `slack` key,
+    // so filtering on the `connector-` prefix avoids false-passing on the
+    // default remote slack MCP that's always registered.
+    const userConnectorEntries = Object.entries(mcp).filter(([key]) =>
+      key.startsWith('connector-'),
+    );
+    expect(userConnectorEntries).toHaveLength(1);
+    const [connectorKey, connectorServer] = userConnectorEntries[0];
+    expect(connectorKey).toBe('connector-slack-conn-s');
+    expect(connectorServer.type).toBe('remote');
+    expect(connectorServer.url).toBe('https://slack.example.com/mcp');
+    expect(connectorServer.headers?.Authorization).toBe('Bearer slack-access-token');
+  });
+
+  it('registers gws-mcp + gmail-mcp + calendar-mcp + GWS_ACCOUNTS_MANIFEST env when accounts are connected', async () => {
+    const now = Date.now();
+    gwsRows = [
+      {
+        google_account_id: 'gacc-1',
+        email: 'alice@example.com',
+        display_name: 'Alice',
+        picture_url: null,
+        label: 'Personal',
+        status: 'connected',
+        connected_at: new Date(now).toISOString(),
+        last_refreshed_at: null,
+      },
+    ];
+    const storage = makeStorage({
+      get: vi.fn((key: string) => {
+        if (key === 'gws:token:gacc-1') {
+          return JSON.stringify({
+            accessToken: 'ya29.live',
+            refreshToken: 'rt-live',
+            expiresAt: now + 3600_000, // 1 hour — well outside refresh margin
+            scopes: ['https://www.googleapis.com/auth/gmail.modify'],
+          });
+        }
+        return null;
+      }),
+    });
+
+    const { configPath } = await onBeforeStart(
+      storage as never,
+      {
+        userDataPath: tmpUserData,
+        mcpToolsPath: fakeMcpToolsPath,
+        isPackaged: false,
+        resourcesPath: '',
+        appPath: '',
+      },
+      { taskId: 'tsk_gws', workspaceId: undefined },
+    );
+
+    const written = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    const mcp = (written.mcp ?? written.mcpServers ?? {}) as Record<
+      string,
+      { environment?: Record<string, string>; env?: Record<string, string> }
+    >;
+    // The three GWS MCP servers should be registered
+    expect(Object.keys(mcp)).toEqual(
+      expect.arrayContaining(['gws-mcp', 'gmail-mcp', 'calendar-mcp']),
+    );
+    // Each GWS MCP server's env should include GWS_ACCOUNTS_MANIFEST pointing
+    // at the manifest file we just wrote
+    const gwsMcpEnv = mcp['gws-mcp'].environment ?? mcp['gws-mcp'].env ?? {};
+    expect(gwsMcpEnv.GWS_ACCOUNTS_MANIFEST).toContain('gws-manifests');
+    expect(gwsMcpEnv.GWS_ACCOUNTS_MANIFEST).toContain('manifest.json');
+    // Verify the manifest actually exists on disk
+    expect(fs.existsSync(gwsMcpEnv.GWS_ACCOUNTS_MANIFEST!)).toBe(true);
+    const manifest = JSON.parse(fs.readFileSync(gwsMcpEnv.GWS_ACCOUNTS_MANIFEST!, 'utf-8'));
+    expect(manifest).toHaveLength(1);
+    expect(manifest[0].email).toBe('alice@example.com');
+  });
+
+  it('sanitises malicious taskIds when building the per-task config filename', async () => {
+    const storage = makeStorage();
+    const { configPath } = await onBeforeStart(
+      storage as never,
+      {
+        userDataPath: tmpUserData,
+        mcpToolsPath: fakeMcpToolsPath,
+        isPackaged: false,
+        resourcesPath: '',
+        appPath: '',
+      },
+      { taskId: '../../../etc/passwd', workspaceId: undefined },
+    );
+
+    // No path escape — the file lands inside userDataPath/opencode/ and
+    // the filename has path separators replaced with underscores.
+    expect(configPath.startsWith(path.join(tmpUserData, 'opencode'))).toBe(true);
+    expect(configPath).not.toContain('..');
+    expect(configPath).not.toContain('/etc/passwd');
+    const filename = path.basename(configPath);
+    expect(filename).toMatch(/^opencode-[_A-Za-z0-9-]+\.json$/);
+  });
+
+  it('falls back to default opencode.json when ctx has no taskId (transient OAuth path)', async () => {
+    const storage = makeStorage();
+    const { configPath } = await onBeforeStart(
+      storage as never,
+      {
+        userDataPath: tmpUserData,
+        mcpToolsPath: fakeMcpToolsPath,
+        isPackaged: false,
+        resourcesPath: '',
+        appPath: '',
+      },
+      {},
+    );
+
+    expect(path.basename(configPath)).toBe('opencode.json');
+  });
+});

--- a/apps/daemon/__tests__/unit/task-service-parity.test.ts
+++ b/apps/daemon/__tests__/unit/task-service-parity.test.ts
@@ -177,6 +177,85 @@ describe('TaskService parity', () => {
     expect(capturedTaskConfigs[0].config.files).toEqual(attachments);
   });
 
+  // Regression: `resumeSession` used to not accept `workspaceId` at all,
+  // so every follow-up turn in a workspace conversation ran without
+  // workspace-scoped knowledge notes. This test pins the explicit forward.
+  it('resumeSession forwards caller-supplied workspaceId into the resumed TaskConfig', async () => {
+    const storage = createMockStorage();
+    const service = new TaskService(storage as never, {
+      userDataPath: '/data',
+      mcpToolsPath: '/tools',
+    });
+
+    await service.resumeSession({
+      sessionId: 'sess-ws-1',
+      prompt: 'continue please',
+      existingTaskId: 'tsk_ws_resume',
+      workspaceId: 'ws_explicit',
+    });
+
+    expect(capturedTaskConfigs).toHaveLength(1);
+    expect(capturedTaskConfigs[0].config.workspaceId).toBe('ws_explicit');
+  });
+
+  // Regression: without an explicit workspaceId, `resumeSession` should
+  // fall back to the workspace the existing task was originally saved
+  // under — otherwise users who scheduled a workspace task and later
+  // resume via a daemon-only source (WhatsApp, scheduler) would still
+  // lose workspace knowledge notes on the resumed turn.
+  it('resumeSession falls back to the stored task workspaceId when none is provided', async () => {
+    const storage = createMockStorage();
+    (storage.getTask as ReturnType<typeof vi.fn>).mockReturnValue({
+      id: 'tsk_stored_ws',
+      prompt: 'original',
+      status: 'completed',
+      messages: [],
+      createdAt: new Date().toISOString(),
+      workspaceId: 'ws_from_storage',
+    });
+    const service = new TaskService(storage as never, {
+      userDataPath: '/data',
+      mcpToolsPath: '/tools',
+    });
+
+    await service.resumeSession({
+      sessionId: 'sess-fallback',
+      prompt: 'continue',
+      existingTaskId: 'tsk_stored_ws',
+    });
+
+    expect(capturedTaskConfigs).toHaveLength(1);
+    expect(capturedTaskConfigs[0].config.workspaceId).toBe('ws_from_storage');
+  });
+
+  // Regression: when the resumed task has no workspaceId anywhere,
+  // `resumeSession` must not invent one — it stays undefined so the
+  // resolver skips the knowledge-note step cleanly.
+  it('resumeSession leaves workspaceId undefined when neither params nor stored task has one', async () => {
+    const storage = createMockStorage();
+    (storage.getTask as ReturnType<typeof vi.fn>).mockReturnValue({
+      id: 'tsk_no_ws',
+      prompt: 'original',
+      status: 'completed',
+      messages: [],
+      createdAt: new Date().toISOString(),
+      workspaceId: undefined,
+    });
+    const service = new TaskService(storage as never, {
+      userDataPath: '/data',
+      mcpToolsPath: '/tools',
+    });
+
+    await service.resumeSession({
+      sessionId: 'sess-plain',
+      prompt: 'continue',
+      existingTaskId: 'tsk_no_ws',
+    });
+
+    expect(capturedTaskConfigs).toHaveLength(1);
+    expect(capturedTaskConfigs[0].config.workspaceId).toBeUndefined();
+  });
+
   it('listTasks passes workspaceId to storage', () => {
     const storage = createMockStorage();
     const service = new TaskService(storage as never, {

--- a/apps/daemon/src/opencode/server-manager.ts
+++ b/apps/daemon/src/opencode/server-manager.ts
@@ -36,6 +36,7 @@ import {
   type StorageAPI,
   type AccomplishRuntime,
   type CliResolverConfig,
+  type OnBeforeStartContext,
 } from '@accomplish_ai/agent-core';
 import { createOpencodeClient, type OpencodeClient } from '@opencode-ai/sdk/v2';
 
@@ -333,11 +334,32 @@ class OpenCodeTaskRuntime {
   private startPromise: Promise<void> | null = null;
   private startAbortController: AbortController | null = null;
   private disposed = false;
+  /**
+   * Per-task context forwarded to `onBeforeStart`. Populated by
+   * `ensureTaskRuntime(taskId, ctx)`. Defaults to `{ taskId }` so runtimes
+   * spawned by code paths that predate the workspace-aware task path
+   * (transient OAuth client, future callers) still get a taskId at
+   * minimum — `prepareGwsManifest` etc. only need the `workspaceId` when
+   * it's actually present.
+   */
+  private ctx: OnBeforeStartContext;
 
   constructor(
     readonly taskId: string,
     private readonly deps: ServerManagerDeps,
-  ) {}
+  ) {
+    this.ctx = { taskId };
+  }
+
+  /**
+   * Update the per-task context. Called by the manager before `start()` /
+   * on follow-up `ensureTaskRuntime` calls so the latest workspace context
+   * reaches `onBeforeStart` if the runtime is still warm from a previous
+   * task step.
+   */
+  setContext(ctx: OnBeforeStartContext): void {
+    this.ctx = { taskId: this.taskId, ...ctx };
+  }
 
   isReady(): boolean {
     return this.ready;
@@ -373,7 +395,7 @@ class OpenCodeTaskRuntime {
     const startedAt = performance.now();
     try {
       throwIfStartAborted(signal);
-      const { env: runtimeEnv } = await onBeforeStart(this.deps.storage, this.deps);
+      const { env: runtimeEnv } = await onBeforeStart(this.deps.storage, this.deps, this.ctx);
       throwIfStartAborted(signal);
 
       const spawnedServer = await spawnOpenCodeServer(runtimeEnv, this.deps, signal, () => {
@@ -451,10 +473,14 @@ export class OpenCodeServerManager {
     return this.runtimes.get(taskId)?.isReady() ?? false;
   }
 
-  async ensureTaskRuntime(taskId: string): Promise<void> {
+  async ensureTaskRuntime(taskId: string, ctx?: OnBeforeStartContext): Promise<void> {
     if (!taskId || this.disposed) return;
     this.clearCleanupTimer(taskId);
-    await this.getOrCreateRuntime(taskId).start();
+    const runtime = this.getOrCreateRuntime(taskId);
+    if (ctx) {
+      runtime.setContext(ctx);
+    }
+    await runtime.start();
   }
 
   async waitForServerUrl(taskId: string): Promise<string | undefined> {
@@ -549,7 +575,10 @@ export async function createTransientOpencodeClient(
   signal?: AbortSignal,
 ): Promise<{ client: OpencodeClient; close: () => void }> {
   throwIfStartAborted(signal);
-  const { env: runtimeEnv } = await onBeforeStart(deps.storage, deps);
+  // No task context for the OAuth flow — pass an empty ctx. The daemon's
+  // onBeforeStart uses this to skip workspace/config-filename specifics and
+  // write the default `opencode.json` for OAuth.
+  const { env: runtimeEnv } = await onBeforeStart(deps.storage, deps, {});
   throwIfStartAborted(signal);
   const server = await spawnOpenCodeServer(runtimeEnv, deps, signal);
   return {

--- a/apps/daemon/src/storage-service.ts
+++ b/apps/daemon/src/storage-service.ts
@@ -1,7 +1,13 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { mkdirSync } from 'node:fs';
-import { createStorage, type StorageAPI } from '@accomplish_ai/agent-core';
+import {
+  createStorage,
+  initializeMetaDatabase,
+  closeMetaDatabase,
+  isMetaDatabaseInitialized,
+  type StorageAPI,
+} from '@accomplish_ai/agent-core';
 import { log } from './logger.js';
 
 const DEV_DEFAULT_DATA_DIR = join(homedir(), '.accomplish');
@@ -37,6 +43,26 @@ export class StorageService {
 
     this.storage.initialize();
     log.info(`[StorageService] Database initialized at ${databasePath}`);
+
+    // The workspace-meta database holds workspace metadata + knowledge-notes
+    // rows. It is a SIBLING SQLite file, not part of `accomplish.db`. Before
+    // PR #946 only the desktop main process called `initializeMetaDatabase`;
+    // the daemon never touched the module. PR #946 routes daemon task-config
+    // through `resolveTaskConfig`, which calls `getKnowledgeNotesForPrompt`
+    // on every task — and that throws "Workspace meta database not
+    // initialized" unless the meta DB handle is open. The try/catch inside
+    // `resolveTaskConfig` swallows it into a log warning, so daemon tasks
+    // silently drop workspace knowledge notes.
+    //
+    // Initialise it here alongside the main DB so both processes share the
+    // same on-disk file. We do NOT create a default workspace here — that
+    // stays a desktop-only concern (daemon-only runs against an empty meta
+    // DB just return empty knowledge notes, which is fine).
+    const metaDbName = isPackaged ? 'workspace-meta.db' : 'workspace-meta-dev.db';
+    const metaDbPath = join(dir, metaDbName);
+    initializeMetaDatabase(metaDbPath);
+    log.info(`[StorageService] Workspace meta database initialized at ${metaDbPath}`);
+
     return this.storage;
   }
 
@@ -52,6 +78,14 @@ export class StorageService {
       this.storage.close();
       this.storage = null;
       log.info('[StorageService] Database closed');
+    }
+    // Mirror the main-DB teardown for the workspace-meta handle. Calling
+    // `closeMetaDatabase` when no handle is open is a no-op in agent-core
+    // but guarding explicitly documents intent and avoids a superfluous
+    // import-for-side-effect.
+    if (isMetaDatabaseInitialized()) {
+      closeMetaDatabase();
+      log.info('[StorageService] Workspace meta database closed');
     }
   }
 }

--- a/apps/daemon/src/task-config-builder.ts
+++ b/apps/daemon/src/task-config-builder.ts
@@ -9,7 +9,7 @@ import path from 'node:path';
 import {
   isCliAvailable as coreIsCliAvailable,
   generateConfig,
-  buildProviderConfigs,
+  resolveTaskConfig,
   syncApiKeysToOpenCodeAuth,
   getOpenCodeAuthJsonPath,
   getBundledNodePaths,
@@ -17,7 +17,9 @@ import {
   type StorageAPI,
   type CliResolverConfig,
   type AccomplishRuntime,
+  type OnBeforeStartContext,
 } from '@accomplish_ai/agent-core';
+import { getDatabase } from '@accomplish_ai/agent-core/storage/database';
 
 export interface TaskConfigBuilderOptions {
   userDataPath: string;
@@ -56,32 +58,75 @@ export async function isCliAvailable(opts: TaskConfigBuilderOptions): Promise<bo
   return coreIsCliAvailable(cliConfig);
 }
 
+/**
+ * Read a port number from the given env var, returning `undefined` when the
+ * var is unset or not an integer. Used to pick up port assignments that the
+ * daemon emits from its own HTTP services (WhatsApp API) into child-process
+ * MCP tools.
+ */
+function getPort(envVar: string): number | undefined {
+  const val = process.env[envVar];
+  if (!val) {
+    return undefined;
+  }
+  const parsed = parseInt(val, 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/**
+ * Build the per-task config filename from the adapter-supplied taskId,
+ * scrubbed to a safe character set. `task.start` accepts an optional
+ * caller-provided `taskId` as an arbitrary string, and `generateConfig`
+ * joins `configFileName` straight into a filesystem path — a value
+ * containing `/`, `..`, or NUL could write outside the opencode config
+ * directory. Replace anything outside `[A-Za-z0-9_-]` with `_`.
+ *
+ * Returns `undefined` when no taskId is supplied (the transient OAuth
+ * path passes an empty `ctx`) so `generateConfig` falls back to its
+ * default `opencode.json` filename.
+ */
+function buildConfigFileName(taskId: string | undefined): string | undefined {
+  if (!taskId) {
+    return undefined;
+  }
+  const safe = taskId.replace(/[^A-Za-z0-9_-]/g, '_').slice(0, 128);
+  if (!safe) {
+    return undefined;
+  }
+  return `opencode-${safe}.json`;
+}
+
+/**
+ * Pre-task hook invoked from two places:
+ *   1. `OpenCodeAdapter.startTask` (agent-core) — writes the per-task config
+ *      file, then calls `session.create` against the running `opencode serve`.
+ *   2. `OpenCodeTaskRuntime.doStart` (server-manager) — writes the same
+ *      config file and surfaces `OPENCODE_CONFIG[_DIR]` into the env the
+ *      `opencode serve` child inherits.
+ *
+ * Both calls route through `resolveTaskConfig` — the shared "one brain"
+ * that injects skills, connectors (with token refresh), cloud browser,
+ * knowledge notes, language, GWS accounts manifest, and OpenAI store:false
+ * into a single `ConfigGeneratorOptions` payload.
+ *
+ * The `ctx` argument carries per-task context:
+ *   - `ctx.taskId` → lets us emit a per-task config filename
+ *     (`opencode-<taskId>.json`) so concurrent tasks don't race on the same
+ *     `opencode.json`.
+ *   - `ctx.workspaceId` → workspace-scoped knowledge notes.
+ *
+ * The transient OAuth flow (`createTransientOpencodeClient`) passes an empty
+ * ctx; in that case we fall back to the default `opencode.json` filename and
+ * skip the workspace context.
+ */
 export async function onBeforeStart(
   storage: StorageAPI,
   opts: TaskConfigBuilderOptions,
+  ctx: OnBeforeStartContext,
 ): Promise<{ configPath: string; env: NodeJS.ProcessEnv }> {
   const authPath = getOpenCodeAuthJsonPath();
   const apiKeys = await storage.getAllApiKeys();
   await syncApiKeysToOpenCodeAuth(authPath, apiKeys);
-
-  const { providerConfigs, enabledProviders, modelOverride } = await buildProviderConfigs({
-    getApiKey: (provider) => storage.getApiKey(provider),
-    accomplishRuntime: opts.accomplishRuntime,
-    accomplishStorageDeps: {
-      readKey: (key) => storage.get(key),
-      writeKey: (key, value) => storage.set(key, value),
-      readGaClientId: () => null, // GA client ID not available in daemon — fingerprint fallback used
-    },
-  });
-
-  const getPort = (envVar: string) => {
-    const val = process.env[envVar];
-    if (!val) {
-      return undefined;
-    }
-    const parsed = parseInt(val, 10);
-    return Number.isNaN(parsed) ? undefined : parsed;
-  };
 
   const permissionApiPort = getPort('ACCOMPLISH_PERMISSION_API_PORT');
   const questionApiPort = getPort('ACCOMPLISH_QUESTION_API_PORT');
@@ -89,41 +134,41 @@ export async function onBeforeStart(
 
   const skills = getEnabledSkills();
 
-  // KNOWN GAP — Google Workspace (GWS) feature merged from main (#921) is
-  // not wired into the daemon's task-execution path. `generator-mcp.ts`
-  // only registers `gmail-mcp`, `calendar-mcp`, `gws-mcp`, and
-  // `request-google-file-picker` when `gwsAccountsManifestPath` is set on
-  // the config-generator options below. The only producer of that manifest
-  // is `apps/desktop/src/main/opencode/config-generator.ts`'s
-  // `prepareGwsManifest`, which is no longer on the task-execution path
-  // under SDK architecture (the daemon owns runtime config generation).
-  // Result: users can connect Google accounts in Settings, but real daemon
-  // tasks won't get the GWS MCP tools.
-  //
-  // Wiring it requires the daemon to (a) read `google_accounts` from the
-  // shared SQLite, (b) materialise per-account token files, and (c) pass
-  // `gwsAccountsManifestPath`/`gwsAccountsSummary` into `generateConfig`.
-  // Step (b) is non-trivial because tokens live in Electron's SecureStorage
-  // (AES-256-GCM) which is not directly daemon-accessible — we'd need
-  // either a daemon→desktop "prepare manifest" RPC or a token-storage
-  // layer the daemon can decrypt. Tracked as a follow-up; not in scope
-  // for this merge.
-  const result = generateConfig({
+  // Resolve the database lazily. Tests or daemon callers that initialize
+  // storage differently may not have `getDatabase()` set up — treat it as
+  // optional (GWS manifest step then silently skips).
+  let database: ReturnType<typeof getDatabase> | undefined;
+  try {
+    database = getDatabase();
+  } catch {
+    database = undefined;
+  }
+
+  const { configOptions } = await resolveTaskConfig({
+    storage,
     platform: process.platform,
     mcpToolsPath: opts.mcpToolsPath,
     userDataPath: opts.userDataPath,
     isPackaged: opts.isPackaged,
     bundledNodeBinPath: getBundledNodeBinPath(opts),
-    providerConfigs,
-    enabledProviders,
+    getApiKey: (provider) => storage.getApiKey(provider),
     permissionApiPort,
     questionApiPort,
     whatsappApiPort,
     authToken: process.env.ACCOMPLISH_DAEMON_AUTH_TOKEN,
-    model: modelOverride?.model,
-    smallModel: modelOverride?.smallModel,
     skills,
+    workspaceId: ctx.workspaceId,
+    configFileName: buildConfigFileName(ctx.taskId),
+    accomplishRuntime: opts.accomplishRuntime,
+    accomplishStorageDeps: {
+      readKey: (key) => storage.get(key),
+      writeKey: (key, value) => storage.set(key, value),
+      readGaClientId: () => null, // GA client ID not available in daemon — fingerprint fallback used
+    },
+    database,
   });
+
+  const result = generateConfig(configOptions);
 
   // Prepend the bundled Node.js bin dir to the env's PATH so the
   // `apps/desktop/node_modules/.bin/opencode` shell wrapper (and the

--- a/apps/daemon/src/task-service.ts
+++ b/apps/daemon/src/task-service.ts
@@ -113,13 +113,21 @@ export class TaskService extends EventEmitter {
         // talks HTTP. `onBeforeStart` still runs to write the per-task
         // `opencode.json`, sync API keys to `auth.json`, and surface
         // `OPENCODE_CONFIG[_DIR]` so the spawned `opencode serve` picks them up.
-        onBeforeStart: async () => {
-          const result = await onBeforeStart(this.storage, this.opts);
+        //
+        // The adapter passes a per-task `ctx` with `taskId` + `workspaceId`;
+        // we forward it unchanged. `resolveTaskConfig` inside `onBeforeStart`
+        // consumes `ctx.workspaceId` for knowledge-note injection and uses
+        // `ctx.taskId` to compute a per-task config filename.
+        onBeforeStart: async (ctx) => {
+          const result = await onBeforeStart(this.storage, this.opts, ctx);
           return result.env;
         },
-        // SDK-based adapter resolves its `opencode serve` URL here.
-        getServerUrl: async (taskId) => {
-          await this.serverManager.ensureTaskRuntime(taskId);
+        // SDK-based adapter resolves its `opencode serve` URL here. The
+        // optional `ctx` carries the same per-task context into the
+        // server-manager's own `onBeforeStart` call so the spawned
+        // `opencode serve` sees the workspace-scoped config.
+        getServerUrl: async (taskId, ctx) => {
+          await this.serverManager.ensureTaskRuntime(taskId, ctx);
           return this.serverManager.waitForServerUrl(taskId);
         },
         getModelDisplayName,
@@ -182,6 +190,7 @@ export class TaskService extends EventEmitter {
       modelId: params.modelId,
       sessionId: params.sessionId,
       workingDirectory: params.workingDirectory,
+      workspaceId: params.workspaceId,
       systemPromptAppend: params.systemPromptAppend,
       files: params.attachments,
       allowedTools: params.allowedTools,
@@ -257,6 +266,13 @@ export class TaskService extends EventEmitter {
     /** Same rationale as `startTask.attachments` — follow-up turns also
      * carry user-attached files and must forward them into TaskConfig.files. */
     attachments?: FileAttachmentInfo[];
+    /**
+     * Caller-supplied workspace for the resumed turn. When the caller
+     * omits this but `existingTaskId` is present, we fall back to the
+     * workspace the original task was saved under so workspace knowledge
+     * notes keep flowing across resume turns.
+     */
+    workspaceId?: string;
   }): Promise<Task> {
     const { sessionId, prompt, existingTaskId, attachments } = params;
     const taskId = existingTaskId || createTaskId();
@@ -273,12 +289,21 @@ export class TaskService extends EventEmitter {
 
     const activeModel = this.storage.getActiveProviderModel();
     const selectedModel = activeModel || this.storage.getSelectedModel();
+    // Workspace resolution order:
+    //   1. explicit `params.workspaceId` (caller knows best)
+    //   2. the workspace the existing task was saved under (resume case)
+    //   3. undefined (fresh session with no workspace context)
+    let workspaceId = params.workspaceId;
+    if (!workspaceId && existingTaskId) {
+      workspaceId = this.storage.getTask(existingTaskId)?.workspaceId;
+    }
     const task = await this._runTask(taskId, {
       prompt,
       sessionId,
       taskId,
       modelId: selectedModel?.model,
       files: attachments,
+      workspaceId,
     });
 
     if (existingTaskId) {

--- a/packages/agent-core/src/common/types/task.ts
+++ b/packages/agent-core/src/common/types/task.ts
@@ -41,6 +41,12 @@ export interface TaskConfig {
    * daemon can apply the right permission-prompt policy. Defaults to `'ui'` when omitted.
    */
   source?: TaskSource;
+  /**
+   * Workspace this task belongs to. Threaded into the daemon's `onBeforeStart`
+   * so `resolveTaskConfig` can load per-workspace knowledge notes. Optional —
+   * scheduler/WhatsApp tasks may run without a workspace context.
+   */
+  workspaceId?: string;
 }
 
 /** Metadata for a user-attached file in a task. */

--- a/packages/agent-core/src/google-accounts/constants.ts
+++ b/packages/agent-core/src/google-accounts/constants.ts
@@ -1,0 +1,17 @@
+/**
+ * Google Workspace token constants — shared between desktop and daemon.
+ *
+ * Kept deliberately minimal: only the values `prepare-manifest.ts` needs. The
+ * desktop-side `apps/desktop/src/main/google-accounts/constants.ts` carries
+ * the richer set (OAuth endpoints, scopes, callback ports) that only the
+ * desktop OAuth-initiation flow uses.
+ */
+
+/** Refresh the token 10 minutes before actual expiry to avoid using an expired one. */
+export const TOKEN_REFRESH_MARGIN_MS = 10 * 60 * 1000;
+
+/** Google OAuth 2.0 token endpoint — used for refresh grants. */
+export const GOOGLE_TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token';
+
+/** StorageAPI key shape for a given Google account's token blob. */
+export const gwsTokenKey = (accountId: string): string => `gws:token:${accountId}`;

--- a/packages/agent-core/src/google-accounts/index.ts
+++ b/packages/agent-core/src/google-accounts/index.ts
@@ -1,0 +1,8 @@
+export { prepareGwsManifest } from './prepare-manifest.js';
+export type {
+  PrepareGwsManifestResult,
+  GwsAccountEntry,
+  GwsAccountSummary,
+  LogFn,
+} from './prepare-manifest.js';
+export { gwsTokenKey, TOKEN_REFRESH_MARGIN_MS, GOOGLE_TOKEN_ENDPOINT } from './constants.js';

--- a/packages/agent-core/src/google-accounts/prepare-manifest.ts
+++ b/packages/agent-core/src/google-accounts/prepare-manifest.ts
@@ -1,0 +1,327 @@
+/**
+ * `prepareGwsManifest` — daemon-portable GWS manifest generator.
+ *
+ * Reads connected Google accounts from the shared SQLite `google_accounts`
+ * table, pulls each account's OAuth token from SecureStorage (via StorageAPI),
+ * lazily refreshes tokens that are within `TOKEN_REFRESH_MARGIN_MS` of
+ * expiry, writes per-account token files + a manifest to userDataPath, and
+ * returns the manifest path + summary for injection into `opencode.json`.
+ *
+ * Pure function, no class, no singleton: callable from both the daemon's
+ * `resolveTaskConfig` step and any other context that has the dependencies.
+ *
+ * Why this lives here and not inside a class (per review):
+ *   - Daemon is the new caller; it only reads state and does occasional
+ *     lazy refreshes. The long-lived `TokenManager` refresh loop + the DB
+ *     CRUD patterns in `AccountManager` stay in desktop for now.
+ *   - A free function with explicit dependencies is the minimum surface
+ *     needed to fix the task-config bypass without introducing a
+ *     cross-process class-ownership question.
+ *
+ * The lazy-refresh is a best-effort belt-and-braces for the edge case where
+ * a task starts from a daemon-only source (scheduler, WhatsApp) while the
+ * desktop `TokenManager` isn't attached. On refresh failure we fall back
+ * to the previously-stored (possibly-stale) token rather than skipping
+ * the account — the stale token may still work for the duration of the
+ * task, and persistent failure is handled by the desktop `TokenManager`
+ * on its own schedule (which eventually flips the account status to
+ * `expired` in `google_accounts`).
+ *
+ * An account IS omitted from the manifest entry list (but still appears
+ * in the returned summary) only when it has no stored token at all, or
+ * when writing its per-account token file fails — i.e. when we have
+ * nothing to pass to the GWS MCP servers.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { Database } from 'better-sqlite3';
+import type { StorageAPI } from '../types/storage.js';
+import type {
+  GoogleAccount,
+  GoogleAccountStatus,
+  GoogleAccountToken,
+} from '../common/types/google-account.js';
+import { gwsTokenKey, TOKEN_REFRESH_MARGIN_MS, GOOGLE_TOKEN_ENDPOINT } from './constants.js';
+import { atomicWriteFile } from '../internal/classes/secure-storage-crypto.js';
+
+export type LogFn = (
+  level: 'INFO' | 'WARN' | 'ERROR',
+  message: string,
+  data?: Record<string, unknown>,
+) => void;
+
+export interface GwsAccountEntry {
+  googleAccountId: string;
+  label: string;
+  email: string;
+  tokenFilePath: string;
+}
+
+export interface GwsAccountSummary {
+  label: string;
+  email: string;
+  status: GoogleAccountStatus;
+}
+
+export interface PrepareGwsManifestResult {
+  manifestPath: string;
+  summary: GwsAccountSummary[];
+}
+
+interface ConnectedAccountRow {
+  google_account_id: string;
+  email: string;
+  display_name: string;
+  picture_url: string | null;
+  label: string;
+  status: GoogleAccountStatus;
+  connected_at: string;
+  last_refreshed_at: string | null;
+}
+
+/**
+ * Main entry point. Returns `undefined` when there are no connected accounts —
+ * callers should treat that as "don't register GWS MCP servers" rather than
+ * a failure. Returns a result with manifest path + summary on success; any
+ * per-account failure is logged and that account is skipped from the manifest
+ * but does not fail the whole call.
+ */
+export async function prepareGwsManifest(
+  storage: StorageAPI,
+  db: Database,
+  userDataPath: string,
+  log: LogFn,
+): Promise<PrepareGwsManifestResult | undefined> {
+  let rows: ConnectedAccountRow[];
+  try {
+    rows = db
+      .prepare(`SELECT * FROM google_accounts WHERE status = 'connected' ORDER BY connected_at ASC`)
+      .all() as ConnectedAccountRow[];
+  } catch (err) {
+    // Pre-migration DB (v028 not yet applied) or transient DB error — treat
+    // as "no accounts connected", don't fail the task.
+    log('WARN', '[prepareGwsManifest] google_accounts read failed; skipping GWS step', {
+      err: String(err),
+    });
+    return undefined;
+  }
+
+  if (rows.length === 0) {
+    return undefined;
+  }
+
+  const accounts: GoogleAccount[] = rows.map(rowToAccount);
+
+  const tokenDir = path.join(userDataPath, 'gws-tokens');
+  fs.mkdirSync(tokenDir, { recursive: true });
+  try {
+    fs.chmodSync(tokenDir, 0o700);
+  } catch {
+    // Non-critical on platforms that don't support chmod (Windows).
+  }
+
+  const entries: GwsAccountEntry[] = [];
+  const summary: GwsAccountSummary[] = [];
+
+  for (const account of accounts) {
+    const token = await readOrRefreshToken(storage, db, account.googleAccountId, log);
+    if (!token) {
+      // Refresh failed or account had no token — skip from manifest but
+      // include in summary so the agent still sees the account exists.
+      summary.push({ label: account.label, email: account.email, status: account.status });
+      continue;
+    }
+
+    const tokenFilePath = path.join(tokenDir, `${account.googleAccountId}.json`);
+    try {
+      atomicWriteFile(tokenFilePath, JSON.stringify(token));
+      try {
+        fs.chmodSync(tokenFilePath, 0o600);
+      } catch {
+        // chmod is best-effort (Windows, etc.)
+      }
+    } catch (err) {
+      log('WARN', '[prepareGwsManifest] failed to write per-account token file', {
+        googleAccountId: account.googleAccountId,
+        err: String(err),
+      });
+      summary.push({ label: account.label, email: account.email, status: account.status });
+      continue;
+    }
+
+    entries.push({
+      googleAccountId: account.googleAccountId,
+      label: account.label,
+      email: account.email,
+      tokenFilePath,
+    });
+    summary.push({ label: account.label, email: account.email, status: account.status });
+  }
+
+  if (entries.length === 0) {
+    // Every account's token read failed. No manifest makes sense, but
+    // return the summary so the agent still sees account presence.
+    return { manifestPath: '', summary };
+  }
+
+  const manifestDir = path.join(userDataPath, 'gws-manifests');
+  fs.mkdirSync(manifestDir, { recursive: true });
+  const manifestPath = path.join(manifestDir, 'manifest.json');
+  try {
+    atomicWriteFile(manifestPath, JSON.stringify(entries, null, 2));
+    try {
+      fs.chmodSync(manifestPath, 0o600);
+    } catch {
+      // non-critical
+    }
+  } catch (err) {
+    log('ERROR', '[prepareGwsManifest] failed to write manifest', { err: String(err) });
+    return { manifestPath: '', summary };
+  }
+
+  return { manifestPath, summary };
+}
+
+/**
+ * Read the stored token for an account; if it's within the refresh margin,
+ * attempt an inline refresh using the Google OAuth token endpoint. Returns
+ * the freshest available token, or `null` if no usable token exists (caller
+ * should skip that account).
+ *
+ * Writes back to StorageAPI + updates `last_refreshed_at` on successful
+ * refresh. On any failure, returns the previously-stored token (even if
+ * expired — better to try the task than fail silently).
+ */
+async function readOrRefreshToken(
+  storage: StorageAPI,
+  db: Database,
+  accountId: string,
+  log: LogFn,
+): Promise<GoogleAccountToken | null> {
+  const raw = storage.get(gwsTokenKey(accountId));
+  if (!raw || raw === '') {
+    return null;
+  }
+
+  let token: GoogleAccountToken;
+  try {
+    token = JSON.parse(raw) as GoogleAccountToken;
+  } catch (err) {
+    log('WARN', '[prepareGwsManifest] failed to parse stored token', {
+      accountId,
+      err: String(err),
+    });
+    return null;
+  }
+
+  const needsRefresh = token.expiresAt - Date.now() < TOKEN_REFRESH_MARGIN_MS;
+  if (!needsRefresh) {
+    return token;
+  }
+
+  if (!token.refreshToken) {
+    log('WARN', '[prepareGwsManifest] token near expiry but no refresh token', { accountId });
+    return token; // best-effort: return the stale token rather than null
+  }
+
+  const clientId = process.env.GOOGLE_CLIENT_ID ?? '';
+  if (!clientId) {
+    log('WARN', '[prepareGwsManifest] GOOGLE_CLIENT_ID unset; skipping inline refresh', {
+      accountId,
+    });
+    return token;
+  }
+
+  try {
+    const res = await fetch(GOOGLE_TOKEN_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        client_id: clientId,
+        refresh_token: token.refreshToken,
+        grant_type: 'refresh_token',
+      }).toString(),
+    });
+
+    if (!res.ok) {
+      log('WARN', '[prepareGwsManifest] inline refresh non-OK response', {
+        accountId,
+        status: res.status,
+      });
+      return token; // return stale; TokenManager (desktop) owns permanent-failure handling
+    }
+
+    const data = (await res.json()) as {
+      access_token?: string;
+      expires_in?: number;
+      error?: string;
+    };
+
+    if (!data.access_token || data.error) {
+      log('WARN', '[prepareGwsManifest] inline refresh returned no access_token', {
+        accountId,
+        error: data.error,
+      });
+      return token;
+    }
+
+    const newExpiresAt = Date.now() + (data.expires_in ?? 3600) * 1000;
+    const refreshed: GoogleAccountToken = {
+      accessToken: data.access_token,
+      refreshToken: token.refreshToken,
+      expiresAt: newExpiresAt,
+      scopes: token.scopes,
+    };
+
+    // Guard: abort the write if the stored token changed while the fetch was
+    // in-flight (e.g. desktop's TokenManager refreshed it first, or user
+    // reconnected). Matches desktop TokenManager's behavior.
+    const currentRaw = storage.get(gwsTokenKey(accountId));
+    if (!currentRaw || currentRaw !== raw) {
+      log('INFO', '[prepareGwsManifest] stored token changed during inline refresh; not writing', {
+        accountId,
+      });
+      // Return whatever is currently stored instead — the other writer wrote
+      // a presumably-newer token.
+      try {
+        return currentRaw ? (JSON.parse(currentRaw) as GoogleAccountToken) : refreshed;
+      } catch {
+        return refreshed;
+      }
+    }
+
+    storage.set(gwsTokenKey(accountId), JSON.stringify(refreshed));
+    try {
+      db.prepare(
+        'UPDATE google_accounts SET last_refreshed_at = ? WHERE google_account_id = ?',
+      ).run(new Date().toISOString(), accountId);
+    } catch (err) {
+      log('WARN', '[prepareGwsManifest] last_refreshed_at UPDATE failed', {
+        accountId,
+        err: String(err),
+      });
+    }
+
+    return refreshed;
+  } catch (err) {
+    log('WARN', '[prepareGwsManifest] inline refresh network error', {
+      accountId,
+      err: String(err),
+    });
+    return token; // return stale, let the task proceed; it may still work
+  }
+}
+
+function rowToAccount(row: ConnectedAccountRow): GoogleAccount {
+  return {
+    googleAccountId: row.google_account_id,
+    email: row.email,
+    displayName: row.display_name,
+    pictureUrl: row.picture_url,
+    label: row.label,
+    status: row.status,
+    connectedAt: row.connected_at,
+    lastRefreshedAt: row.last_refreshed_at,
+  };
+}

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -36,6 +36,7 @@ export type {
   TaskAdapterOptions,
   TaskCallbacks as TaskManagerCallbacks,
   TaskProgressEvent as TaskManagerProgressEvent,
+  OnBeforeStartContext,
   // Storage API
   StorageAPI,
   StorageOptions,
@@ -300,6 +301,22 @@ export { validateHttpUrl } from './utils/url.js';
 
 // Task validation functions
 export { validateTaskConfig } from './utils/task-validation.js';
+
+// Google Workspace account manifest helper (daemon-portable). The desktop
+// side keeps its own `AccountManager` / `TokenManager` singletons; agent-core
+// exports only the stateless pieces the daemon needs for per-task manifest
+// generation at `onBeforeStart` time.
+export {
+  prepareGwsManifest,
+  gwsTokenKey,
+  TOKEN_REFRESH_MARGIN_MS,
+  GOOGLE_TOKEN_ENDPOINT,
+} from './google-accounts/index.js';
+export type {
+  PrepareGwsManifestResult,
+  GwsAccountEntry,
+  GwsAccountSummary,
+} from './google-accounts/index.js';
 
 // JSON parsing functions
 export { safeParseJson } from './utils/json.js';

--- a/packages/agent-core/src/internal/classes/OpenCodeAdapter.ts
+++ b/packages/agent-core/src/internal/classes/OpenCodeAdapter.ts
@@ -60,6 +60,7 @@ import {
 } from '../../opencode/completion/index.js';
 
 import type { TaskConfig, Task, TaskResult } from '../../common/types/task.js';
+import type { OnBeforeStartContext } from '../../types/task-manager.js';
 import type { OpenCodeMessage } from '../../common/types/opencode.js';
 import type { PermissionRequest, PermissionResponse } from '../../common/types/permission.js';
 import {
@@ -132,8 +133,12 @@ export interface AdapterOptions {
    * Populated in Phase 2 by the daemon's server-manager. Required for the
    * SDK adapter; constructors that omit it will succeed, but startTask will
    * throw `OpenCodeRuntimeUnavailableError` until it is wired up.
+   *
+   * The optional `ctx` carries per-task context (workspaceId) through to the
+   * server-manager's own `onBeforeStart` call so the daemon can write the
+   * correct per-task config file when spawning `opencode serve`.
    */
-  getServerUrl?: (taskId: string) => Promise<string | undefined>;
+  getServerUrl?: (taskId: string, ctx?: OnBeforeStartContext) => Promise<string | undefined>;
   /**
    * Optional pre-task hook. Returns environment variables to merge into
    * `this.externalEnv` before opening the SDK session. The daemon's
@@ -144,8 +149,12 @@ export interface AdapterOptions {
    * `getCliCommand`, `buildEnvironment`, and `buildCliArgs` siblings — the
    * SDK flow has no equivalent of CLI args (it uses `session.prompt`) and
    * the spawn environment is owned by `apps/daemon/src/opencode/server-manager.ts`.
+   *
+   * The `ctx` argument lets the hook include per-task data (taskId for the
+   * per-task config filename, workspaceId for workspace knowledge notes).
+   * Callers that don't have a task context pass an empty object.
    */
-  onBeforeStart?: () => Promise<NodeJS.ProcessEnv | void>;
+  onBeforeStart?: (ctx: OnBeforeStartContext) => Promise<NodeJS.ProcessEnv | void>;
   getModelDisplayName?: (modelId: string) => string;
   /** Lazy sandbox factory, called once per adapter instance. */
   sandboxFactory?: () => { provider: SandboxProvider; config: SandboxConfig };
@@ -377,8 +386,19 @@ export class OpenCodeAdapter extends EventEmitter<OpenCodeAdapterEvents> {
       await this.logWatcher.start();
     }
 
+    // Per-task context lets the daemon's onBeforeStart resolve workspace-
+    // scoped knowledge notes and pick a per-task config filename so
+    // concurrent tasks don't race on the same opencode.json. Built once and
+    // forwarded both to the adapter-side `onBeforeStart` hook AND the
+    // server-manager `getServerUrl` call, since both end up invoking the
+    // daemon's `onBeforeStart` internally.
+    const onBeforeStartCtx: OnBeforeStartContext = {
+      taskId,
+      workspaceId: config.workspaceId,
+    };
+
     if (this.options.onBeforeStart) {
-      this.externalEnv = (await this.options.onBeforeStart()) ?? {};
+      this.externalEnv = (await this.options.onBeforeStart(onBeforeStartCtx)) ?? {};
     }
 
     // Resolve the running opencode-serve URL. Phase 2 populates this from the
@@ -388,7 +408,7 @@ export class OpenCodeAdapter extends EventEmitter<OpenCodeAdapterEvents> {
         'AdapterOptions.getServerUrl not configured. Daemon server-manager wiring lands in Phase 2 of the SDK cutover port.',
       );
     }
-    const serverUrl = await this.options.getServerUrl(taskId);
+    const serverUrl = await this.options.getServerUrl(taskId, onBeforeStartCtx);
     if (!serverUrl) {
       throw new OpenCodeRuntimeUnavailableError(
         `No opencode-serve URL available for task ${taskId}.`,

--- a/packages/agent-core/src/opencode/resolve-task-config.ts
+++ b/packages/agent-core/src/opencode/resolve-task-config.ts
@@ -2,20 +2,24 @@
  * Shared task config resolution — the "one brain" for config assembly.
  *
  * Resolves skills, connectors (with token refresh), cloud browser config,
- * workspace knowledge notes, and OpenAI store:false injection into a
- * ConfigGeneratorOptions object that can be passed to generateConfig().
+ * workspace knowledge notes, Google Workspace accounts, and OpenAI
+ * store:false injection into a ConfigGeneratorOptions object that can be
+ * passed to generateConfig().
  *
  * Used by both the desktop config-generator (bridge period) and the
  * standalone daemon's TaskService.
  */
 
+import type { Database } from 'better-sqlite3';
 import type { StorageAPI } from '../types/storage.js';
 import type { Skill } from '../common/types/skills.js';
 import type { ConfigGeneratorOptions, ProviderConfig } from './config-generator.js';
 import type { BrowserConfig } from './generator-mcp.js';
+import type { AccomplishRuntime, StorageDeps } from './accomplish-runtime.js';
 import { isTokenExpired, refreshAccessToken } from '../connectors/oauth-tokens.js';
 import { getKnowledgeNotesForPrompt } from '../storage/repositories/knowledgeNotes.js';
 import { buildProviderConfigs } from './config-builder.js';
+import { prepareGwsManifest, type LogFn } from '../google-accounts/index.js';
 
 export interface ResolveTaskConfigOptions {
   /** Storage API for reading connectors, cloud browser, sandbox, etc. */
@@ -57,10 +61,44 @@ export interface ResolveTaskConfigOptions {
   workspaceId?: string;
 
   /**
+   * Optional per-task config filename (e.g. `opencode-<taskId>.json`).
+   * When concurrent tasks run simultaneously, sharing the default
+   * `opencode.json` makes them race on the same file. The daemon passes
+   * a taskId-scoped filename; desktop can omit to keep legacy behavior.
+   */
+  configFileName?: string;
+
+  /**
+   * Accomplish AI runtime adapter (noop in OSS, real impl in commercial).
+   * Forwarded into `buildProviderConfigs` so the Accomplish-AI provider can
+   * register itself when the runtime is available.
+   */
+  accomplishRuntime?: AccomplishRuntime;
+
+  /**
+   * Accomplish AI identity storage deps (injected from the caller's
+   * secure storage). Forwarded into `buildProviderConfigs`.
+   */
+  accomplishStorageDeps?: StorageDeps;
+
+  /**
+   * Optional SQLite handle for GWS manifest generation. The daemon passes
+   * its shared database; desktop omits (its own config-generator calls
+   * `prepareGwsManifest` separately with its own AccountManager).
+   *
+   * When provided AND the `google_accounts` table has `status='connected'`
+   * rows, `resolveTaskConfig` writes per-account token files + a manifest
+   * and sets `gwsAccountsManifestPath` + `gwsAccountsSummary` on the
+   * returned configOptions. If the table is missing (pre-migration DB) or
+   * empty, this step silently skips.
+   */
+  database?: Database;
+
+  /**
    * Logger function for non-fatal warnings.
    * Defaults to console.warn if not provided.
    */
-  log?: (level: 'INFO' | 'WARN' | 'ERROR', message: string, data?: Record<string, unknown>) => void;
+  log?: LogFn;
 }
 
 export interface ResolvedTaskConfig {
@@ -92,14 +130,22 @@ export async function resolveTaskConfig(
     authToken,
     skills,
     workspaceId,
+    configFileName,
+    accomplishRuntime,
+    accomplishStorageDeps,
+    database,
   } = options;
 
-  const log = options.log ?? ((_level: string, msg: string) => console.warn(msg));
+  const log: LogFn = options.log ?? ((_level, msg) => console.warn(msg));
 
-  // 1. Build provider configs
+  // 1. Build provider configs. `accomplishRuntime` + `accomplishStorageDeps`
+  // forward to the Accomplish-AI provider when the optional runtime is loaded
+  // (Free build); omitted on OSS so the provider stays dormant.
   const { providerConfigs, enabledProviders, modelOverride } = await buildProviderConfigs({
     getApiKey,
     azureFoundryToken,
+    accomplishRuntime,
+    accomplishStorageDeps,
   });
 
   // 2. Inject store:false for OpenAI to prevent 403 errors with project-scoped keys
@@ -140,6 +186,29 @@ export async function resolveTaskConfig(
     // Non-critical: language column may be absent in older DBs before migration
   }
 
+  // 7. Resolve Google Workspace accounts manifest (daemon only — desktop's
+  // config-generator calls `prepareGwsManifest` separately via its own
+  // `AccountManager`). When the caller omits `database`, we skip this step.
+  let gwsAccountsManifestPath: string | undefined;
+  let gwsAccountsSummary: Array<{ label: string; email: string; status: string }> | undefined;
+  if (database) {
+    try {
+      const gwsResult = await prepareGwsManifest(storage, database, userDataPath, log);
+      if (gwsResult?.manifestPath) {
+        gwsAccountsManifestPath = gwsResult.manifestPath;
+      }
+      if (gwsResult?.summary && gwsResult.summary.length > 0) {
+        gwsAccountsSummary = gwsResult.summary.map((s) => ({
+          label: s.label,
+          email: s.email,
+          status: s.status,
+        }));
+      }
+    } catch (err) {
+      log('WARN', '[resolveTaskConfig] GWS manifest step failed', { err: String(err) });
+    }
+  }
+
   return {
     configOptions: {
       platform,
@@ -160,6 +229,9 @@ export async function resolveTaskConfig(
       browser,
       knowledgeNotes,
       language,
+      configFileName,
+      gwsAccountsManifestPath,
+      gwsAccountsSummary,
     },
   };
 }

--- a/packages/agent-core/src/types/index.ts
+++ b/packages/agent-core/src/types/index.ts
@@ -12,6 +12,7 @@ export type {
   TaskAdapterOptions,
   TaskCallbacks,
   TaskProgressEvent,
+  OnBeforeStartContext,
 } from './task-manager.js';
 
 // Storage API

--- a/packages/agent-core/src/types/storage.ts
+++ b/packages/agent-core/src/types/storage.ts
@@ -47,6 +47,13 @@ export interface StoredTask {
   createdAt: string;
   startedAt?: string;
   completedAt?: string;
+  /**
+   * Workspace this task is filed under, if any. Already populated from the
+   * `tasks.workspace_id` column by the storage row mapper — previously the
+   * type surface omitted it, so `TaskService.resumeSession` couldn't fall
+   * back to the original task's workspace on resume turns.
+   */
+  workspaceId?: string;
 }
 
 /** A favorited (starred) completed task, stored for quick reuse on the home page */

--- a/packages/agent-core/src/types/task-manager.ts
+++ b/packages/agent-core/src/types/task-manager.ts
@@ -20,6 +20,19 @@ export interface TaskProgressEvent {
   modelName?: string;
 }
 
+/**
+ * Per-task context passed to the adapter's `onBeforeStart` hook.
+ *
+ * The daemon uses this to:
+ *   - write per-task config filenames (`opencode-<taskId>.json`) so concurrent
+ *     tasks don't race on the same file
+ *   - thread `workspaceId` into `resolveTaskConfig` for knowledge-note injection
+ */
+export interface OnBeforeStartContext {
+  taskId?: string;
+  workspaceId?: string;
+}
+
 /** Callbacks for task lifecycle events */
 export interface TaskCallbacks {
   /**
@@ -101,8 +114,14 @@ export interface TaskAdapterOptions {
    * adapter's externalEnv before opening the SDK session — the daemon uses
    * this to surface `OPENCODE_CONFIG[_DIR]` after writing the per-task
    * config file.
+   *
+   * The `ctx` argument gives the hook access to the current task's identity
+   * and workspace so the per-task config filename can include the taskId
+   * and `resolveTaskConfig` can inject workspace-scoped knowledge notes.
+   * Both fields are optional — callers that don't have a task context yet
+   * (legacy PTY paths, transient OAuth clients) pass an empty object.
    */
-  onBeforeStart?: () => Promise<NodeJS.ProcessEnv | void>;
+  onBeforeStart?: (ctx: OnBeforeStartContext) => Promise<NodeJS.ProcessEnv | void>;
   /** Function to get display name for a model ID */
   getModelDisplayName?: (modelId: string) => string;
   /**
@@ -113,10 +132,13 @@ export interface TaskAdapterOptions {
    * Optional during Phase 1a — the legacy PTY adapter ignores it; the SDK adapter requires it.
    *
    * @param taskId - ID of the task whose runtime server URL is needed
+   * @param ctx - optional per-task context; the daemon threads `workspaceId`
+   *              into its `server-manager` → `onBeforeStart` call so the
+   *              opencode-serve process sees the right per-task config.
    * @returns Base URL of the opencode-serve instance hosting this task, or `undefined`
    *          if no runtime exists for that task.
    */
-  getServerUrl?: (taskId: string) => Promise<string | undefined>;
+  getServerUrl?: (taskId: string, ctx?: OnBeforeStartContext) => Promise<string | undefined>;
   /**
    * Optional proxy tagger (Phase 2 of the SDK cutover port). Called by the
    * adapter on task start (with `taskId`) and teardown (with `undefined`).

--- a/packages/agent-core/src/utils/task-validation.ts
+++ b/packages/agent-core/src/utils/task-validation.ts
@@ -36,6 +36,15 @@ export function validateTaskConfig(config: TaskConfig): TaskConfig {
   if (config.modelId) {
     validated.modelId = sanitizeString(config.modelId, 'modelId', 128);
   }
+  // Copy workspaceId through so `resolveTaskConfig` can inject the
+  // workspace's knowledge notes into the system prompt. Without this
+  // copy, `task-service.startTask` writes `config.workspaceId` but
+  // `validateTaskConfig` silently strips it, the adapter builds
+  // `{ workspaceId: undefined }`, and `resolveTaskConfig`'s step 5
+  // skips the notes. Tight length limit (128) matches other IDs here.
+  if (config.workspaceId) {
+    validated.workspaceId = sanitizeString(config.workspaceId, 'workspaceId', 128);
+  }
   // Pass through file attachments — they are validated at the IPC/RPC boundary,
   // not here. Stripping them silently breaks the daemon task path.
   if (Array.isArray(config.files) && config.files.length > 0) {

--- a/packages/agent-core/tests/unit/google-accounts/prepare-manifest.test.ts
+++ b/packages/agent-core/tests/unit/google-accounts/prepare-manifest.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests for `prepareGwsManifest` — the pure helper that reads connected
+ * Google accounts from SQLite + SecureStorage, lazy-refreshes tokens that
+ * are near expiry, and writes per-account token files + manifest to disk.
+ *
+ * These tests exercise the daemon's happy paths and failure modes:
+ *   - zero connected accounts → undefined (caller skips GWS step)
+ *   - one connected account with fresh token → manifest written + summary populated
+ *   - near-expiry token triggers inline refresh via fetch
+ *   - refresh failure returns the stale token (best-effort) but still succeeds
+ *   - pre-migration DB (no `google_accounts` table) → undefined, no throw
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { StorageAPI } from '../../../src/types/storage.js';
+import { prepareGwsManifest } from '../../../src/google-accounts/prepare-manifest.js';
+import { gwsTokenKey } from '../../../src/google-accounts/constants.js';
+
+interface StmtMock {
+  all: ReturnType<typeof vi.fn>;
+  run: ReturnType<typeof vi.fn>;
+  get: ReturnType<typeof vi.fn>;
+}
+
+function makeStorage(): StorageAPI {
+  const store = new Map<string, string>();
+  return {
+    get: vi.fn((key: string) => store.get(key) ?? null),
+    set: vi.fn((key: string, value: string) => {
+      store.set(key, value);
+    }),
+  } as unknown as StorageAPI;
+}
+
+function makeDb(accountRows: Record<string, unknown>[]): { prepare: ReturnType<typeof vi.fn> } {
+  // Simple in-memory SQL stub: the prepared-statement SELECT returns the
+  // provided rows; UPDATE statements no-op. Good enough for prepareGwsManifest
+  // which only issues two shapes of queries.
+  const selectStmt: StmtMock = {
+    all: vi.fn(() => accountRows),
+    run: vi.fn(),
+    get: vi.fn(() => undefined),
+  };
+  const updateStmt: StmtMock = {
+    all: vi.fn(() => []),
+    run: vi.fn(),
+    get: vi.fn(() => undefined),
+  };
+  return {
+    prepare: vi.fn((sql: string) => (sql.startsWith('SELECT') ? selectStmt : updateStmt)),
+  };
+}
+
+function connectedRow(
+  id: string,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    google_account_id: id,
+    email: `${id}@gmail.com`,
+    display_name: `User ${id}`,
+    picture_url: null,
+    label: id,
+    status: 'connected',
+    connected_at: new Date().toISOString(),
+    last_refreshed_at: null,
+    ...overrides,
+  };
+}
+
+function makeTokenJson(
+  overrides: Partial<{
+    accessToken: string;
+    refreshToken: string;
+    expiresAt: number;
+    scopes: string[];
+  }> = {},
+): string {
+  return JSON.stringify({
+    accessToken: 'old-access',
+    refreshToken: 'my-refresh-token',
+    expiresAt: Date.now() + 3600_000,
+    scopes: ['https://www.googleapis.com/auth/gmail.modify'],
+    ...overrides,
+  });
+}
+
+describe('prepareGwsManifest', () => {
+  let tmpDir: string;
+  const log = vi.fn();
+
+  beforeEach(() => {
+    tmpDir = path.join(
+      os.tmpdir(),
+      `prep-gws-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    fs.mkdirSync(tmpDir, { recursive: true });
+    log.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort cleanup */
+    }
+  });
+
+  it('returns undefined when no connected accounts exist', async () => {
+    const storage = makeStorage();
+    const db = makeDb([]);
+    const result = await prepareGwsManifest(storage, db as never, tmpDir, log);
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when the google_accounts table is missing (pre-migration DB)', async () => {
+    const storage = makeStorage();
+    // DB.prepare throws — simulates "no such table" on a pre-v028 install
+    const db = {
+      prepare: vi.fn(() => {
+        throw new Error('no such table: google_accounts');
+      }),
+    };
+    const result = await prepareGwsManifest(storage, db as never, tmpDir, log);
+    expect(result).toBeUndefined();
+    expect(log).toHaveBeenCalledWith(
+      'WARN',
+      expect.stringContaining('google_accounts read failed'),
+      expect.any(Object),
+    );
+  });
+
+  it('writes the manifest + per-account token file for a connected account with a fresh token', async () => {
+    const storage = makeStorage();
+    vi.mocked(storage.get).mockImplementation((key: string) =>
+      key === gwsTokenKey('uid-1') ? makeTokenJson() : null,
+    );
+    const db = makeDb([connectedRow('uid-1', { email: 'alice@gmail.com', label: 'Personal' })]);
+
+    const result = await prepareGwsManifest(storage, db as never, tmpDir, log);
+
+    expect(result).toBeDefined();
+    expect(result!.manifestPath).toContain('gws-manifests');
+    expect(result!.manifestPath).toContain('manifest.json');
+    expect(fs.existsSync(result!.manifestPath)).toBe(true);
+    const manifest = JSON.parse(fs.readFileSync(result!.manifestPath, 'utf-8'));
+    expect(manifest).toHaveLength(1);
+    expect(manifest[0].googleAccountId).toBe('uid-1');
+    expect(manifest[0].email).toBe('alice@gmail.com');
+    expect(manifest[0].tokenFilePath).toContain('gws-tokens');
+    expect(manifest[0].tokenFilePath).toContain('uid-1.json');
+    expect(fs.existsSync(manifest[0].tokenFilePath)).toBe(true);
+
+    expect(result!.summary).toEqual([
+      { label: 'Personal', email: 'alice@gmail.com', status: 'connected' },
+    ]);
+  });
+
+  it('triggers an inline refresh when the token is within the refresh margin', async () => {
+    // Token expires in 5 minutes — below the 10-minute refresh margin.
+    const storage = makeStorage();
+    const originalRaw = makeTokenJson({ expiresAt: Date.now() + 5 * 60 * 1000 });
+    vi.mocked(storage.get).mockImplementation((key: string) =>
+      key === gwsTokenKey('uid-1') ? originalRaw : null,
+    );
+    const db = makeDb([connectedRow('uid-1')]);
+
+    process.env.GOOGLE_CLIENT_ID = 'test-client-id';
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ access_token: 'freshly-refreshed', expires_in: 3600 }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await prepareGwsManifest(storage, db as never, tmpDir, log);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://oauth2.googleapis.com/token',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    // The new token should have been written back via storage.set
+    expect(vi.mocked(storage.set)).toHaveBeenCalledWith(
+      gwsTokenKey('uid-1'),
+      expect.stringContaining('freshly-refreshed'),
+    );
+    // Manifest still produced using the refreshed token
+    expect(result!.manifestPath).toBeTruthy();
+    const tokenFile = JSON.parse(
+      fs.readFileSync(
+        JSON.parse(fs.readFileSync(result!.manifestPath, 'utf-8'))[0].tokenFilePath,
+        'utf-8',
+      ),
+    );
+    expect(tokenFile.accessToken).toBe('freshly-refreshed');
+  });
+
+  it('falls back to the stale token when the inline refresh fails', async () => {
+    // Token near expiry → would trigger refresh. The fetch rejects.
+    const storage = makeStorage();
+    const staleRaw = makeTokenJson({
+      accessToken: 'stale-but-still-valid',
+      expiresAt: Date.now() + 5 * 60 * 1000,
+    });
+    vi.mocked(storage.get).mockImplementation((key: string) =>
+      key === gwsTokenKey('uid-1') ? staleRaw : null,
+    );
+    const db = makeDb([connectedRow('uid-1')]);
+
+    process.env.GOOGLE_CLIENT_ID = 'test-client-id';
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+
+    const result = await prepareGwsManifest(storage, db as never, tmpDir, log);
+
+    // The manifest is still produced — best-effort means we try the stale
+    // token rather than skip the account entirely.
+    expect(result!.manifestPath).toBeTruthy();
+    const tokenFile = JSON.parse(
+      fs.readFileSync(
+        JSON.parse(fs.readFileSync(result!.manifestPath, 'utf-8'))[0].tokenFilePath,
+        'utf-8',
+      ),
+    );
+    expect(tokenFile.accessToken).toBe('stale-but-still-valid');
+    expect(log).toHaveBeenCalledWith(
+      'WARN',
+      expect.stringContaining('inline refresh network error'),
+      expect.any(Object),
+    );
+  });
+
+  it('skips an account whose stored token is missing or empty', async () => {
+    const storage = makeStorage();
+    // storage.get returns null for uid-1 (no stored token)
+    const db = makeDb([
+      connectedRow('uid-1', { email: 'missing@gmail.com', label: 'MissingToken' }),
+      connectedRow('uid-2', { email: 'alice@gmail.com', label: 'Present' }),
+    ]);
+    vi.mocked(storage.get).mockImplementation((key: string) => {
+      if (key === gwsTokenKey('uid-2')) {
+        return makeTokenJson();
+      }
+      return null;
+    });
+
+    const result = await prepareGwsManifest(storage, db as never, tmpDir, log);
+
+    // uid-2 appears in the manifest; uid-1 is only in the summary (as a
+    // signal to the agent that the account exists but was unusable).
+    const manifest = JSON.parse(fs.readFileSync(result!.manifestPath, 'utf-8'));
+    expect(manifest).toHaveLength(1);
+    expect(manifest[0].googleAccountId).toBe('uid-2');
+
+    expect(result!.summary).toHaveLength(2);
+    expect(result!.summary.map((s) => s.email).sort()).toEqual([
+      'alice@gmail.com',
+      'missing@gmail.com',
+    ]);
+  });
+});

--- a/packages/agent-core/tests/unit/utils/task-validation.test.ts
+++ b/packages/agent-core/tests/unit/utils/task-validation.test.ts
@@ -84,4 +84,35 @@ describe('validateTaskConfig', () => {
     const validated = validateTaskConfig(config);
     expect(validated.source).toBeUndefined();
   });
+
+  // Regression: `TaskService.startTask` writes `config.workspaceId` but an
+  // earlier version of `validateTaskConfig` rebuilt the object field-by-field
+  // and silently dropped this one. Downstream, `resolveTaskConfig` never saw
+  // the workspace and skipped knowledge-note injection for every non-resume
+  // task. This test pins the fix so the field always makes it through.
+  it('preserves workspaceId on the validated config', () => {
+    const config: TaskConfig = {
+      prompt: 'Workspace task',
+      workspaceId: 'ws_abc123',
+    };
+
+    const validated = validateTaskConfig(config);
+    expect(validated.workspaceId).toBe('ws_abc123');
+  });
+
+  it('rejects a workspaceId longer than 128 chars (matches other ID fields)', () => {
+    const longId = 'ws_' + 'x'.repeat(200);
+    const config: TaskConfig = {
+      prompt: 'Long workspace',
+      workspaceId: longId,
+    };
+
+    expect(() => validateTaskConfig(config)).toThrow(/exceeds maximum length/i);
+  });
+
+  it('omits workspaceId when not provided', () => {
+    const config: TaskConfig = { prompt: 'No workspace' };
+    const validated = validateTaskConfig(config);
+    expect(validated.workspaceId).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

PR #938 (SDK cutover) rewrote the daemon's `onBeforeStart` to call `generateConfig()` directly with a skimpy argument list, bypassing the "shared one-brain" helper `resolveTaskConfig`. **Six live product features that users configure in Settings silently never reached daemon-run tasks:**

| Feature | Author | Daemon wiring pre-PR |
|---|---|---|
| Google Workspace MCP tools (Gmail, Calendar, Drive, file-picker) — #921 | Avishay Maor | `gwsAccountsManifestPath` never passed |
| User OAuth MCP connectors — #940 | Avishay Maor | `connectors` never passed |
| Workspace knowledge notes injected into the system prompt — #810 | Avishay Maor | `knowledgeNotes` never passed |
| Cloud browser remote CDP configuration — #760 | Avishay Maor | `browser` never passed |
| OpenAI `store: false` for privacy-sensitive prompts | — | not injected |
| UI language preference | — | `language` never passed |

Scheduler and WhatsApp-sourced tasks — both daemon-only — had zero chance of ever picking these up. UI-started tasks lost them when the SDK cutover moved task execution into the daemon.

## What changed

**The headline change** — `apps/daemon/src/task-config-builder.ts` now routes `onBeforeStart` through `resolveTaskConfig`. All 6 features are restored simultaneously.

**Supporting wiring:**

1. **Per-task context through `onBeforeStart`.** New `OnBeforeStartContext { taskId?; workspaceId? }` threaded end-to-end: adapter → server-manager → `onBeforeStart` → `resolveTaskConfig`. Both call-sites (`OpenCodeAdapter.startTask` and `OpenCodeServerManager.ensureTaskRuntime`) forward the context.

2. **`validateTaskConfig` now preserves `workspaceId`.** Found by Codex P1 — the field existed on the zod schema but the sanitiser rebuilt the object field-by-field and silently stripped it. Regression test pins the fix.

3. **`TaskService.resumeSession` accepts + forwards `workspaceId`** with fallback to the stored task's workspaceId when not supplied. Previously every resume turn dropped the workspace context entirely. Three regression tests cover the explicit / fallback / undefined paths.

4. **Per-task config filenames.** `resolveTaskConfig` accepts `configFileName?`; daemon passes `opencode-<taskId>.json` — the taskId portion is sanitised to `[A-Za-z0-9_-]` to prevent path-escape via caller-supplied taskIds (Codex P2). Regression test asserts `taskId='../../../etc/passwd'` stays inside `userDataPath/opencode/`.

5. **GWS manifest as a new `resolveTaskConfig` step.** New pure helper `packages/agent-core/src/google-accounts/prepare-manifest.ts`:
   - Reads connected Google accounts directly via SQL (no class migration)
   - Lazy-refreshes any token within `TOKEN_REFRESH_MARGIN_MS` of expiry inline
   - Writes per-account token files + manifest atomically
   - Returns stale token on refresh failure (best-effort; TokenManager on desktop owns permanent-failure handling)

6. **Daemon now initialises the workspace-meta SQLite DB.** Found only by running the daemon end-to-end and checking the logs — `resolveTaskConfig` calls `getKnowledgeNotesForPrompt`, which uses a separate `workspace-meta-*.db` file that only the desktop main process had ever initialised. Without this fix, every daemon task would throw "Workspace meta database not initialized", the try/catch inside `resolveTaskConfig` would swallow it into a log warning, and knowledge notes would silently drop on every daemon-run task. `StorageService.initialize` now opens both DB files; `close()` mirrors.

## Deliberately NOT in this PR (deferred)

- Moving `AccountManager` / `TokenManager` classes into agent-core.
- Daemon-owned background token-refresh timer (desktop keeps owning).
- Deleting desktop `apps/desktop/src/main/google-accounts/*` copies.
- Fixing SecureStorage's multi-process write-cache race.
- Retiring desktop's dead `apps/desktop/src/main/opencode/config-generator.ts`.
- Folding `workspace-meta.db` into `accomplish.db` + giving it a real migration system (it currently has neither — tracked as a follow-up).

Per review discussion, scoping this PR to the runtime-only fix keeps the review surface tight. Class/timer/ownership migration belongs in a separate refactor.

## Test coverage

**New tests (11 across 3 files):**

`packages/agent-core/tests/unit/google-accounts/prepare-manifest.test.ts` (6): zero accounts → undefined; fresh token → manifest written; near-expiry triggers inline refresh; refresh failure → stale-token fallback; missing token → summary-only; pre-v028 DB → undefined without throw.

`packages/agent-core/tests/unit/utils/task-validation.test.ts` (+3): `workspaceId` preserved; 128-char length cap; omitted when absent.

`apps/daemon/__tests__/unit/task-config-builder.unit.test.ts` (5, **real integration**): runs the REAL `resolveTaskConfig` + `generateConfig` + `prepareGwsManifest` pipeline (only mocking `getKnowledgeNotesForPrompt` and `providerSettings` repo at the sqlite-native boundary), then parses the written `opencode-<taskId>.json` on disk and asserts:
- workspace knowledge notes are embedded in the system prompt
- OpenAI `store: false` is in the provider block
- exactly one `connector-*` MCP server exists with the correct URL + Bearer token (the assertion filters by `connector-` prefix — built-in `slack` has a bare `slack` key, so the test can't false-pass on the default entry)
- `gws-mcp` / `gmail-mcp` / `calendar-mcp` / `request-google-file-picker` all register with `GWS_ACCOUNTS_MANIFEST` env pointing at a manifest file that exists on disk
- malicious taskIds sanitise to safe filenames
- empty ctx falls back to default `opencode.json`

`apps/daemon/__tests__/unit/task-service-parity.test.ts` (+3): `resumeSession` forwards explicit `workspaceId`; falls back to stored task's workspace; leaves undefined when neither is present.

`apps/daemon/__tests__/unit/storage-service.unit.test.ts` (4, new file): `StorageService.initialize` calls `initializeMetaDatabase` with the dev filename; packaged name switches with `ACCOMPLISH_IS_PACKAGED=1`; `close()` tears down the meta DB; `close()` is a no-op when meta DB was never initialised.

**Manual runtime verification (done on `f12fadbe`):**

I ran a `pnpm dev` session and confirmed via the daemon log that:
- The meta-DB init fix lands cleanly: `[StorageService] Workspace meta database initialized at .../workspace-meta-dev.db`
- The previously-always-firing `[resolveTaskConfig] Failed to load workspace knowledge notes` warning is gone after restart (0 occurrences post-fix vs 3 in the pre-fix task run earlier in the same log)

The two headline end-to-end checks (seed a knowledge note and verify it reaches the generated config; connect a Google account and ask *"what are my calendar meetings today?"*) are intentionally out of scope for this PR description — reviewer can run them against the branch if desired.

## Verification

- [x] `pnpm typecheck` — 4 workspaces clean
- [x] `pnpm -F @accomplish_ai/agent-core test` — 628 passed, 1 pre-existing skip
- [x] `pnpm -F @accomplish/daemon test` — 122 passed (was 110 pre-PR → +12 new)
- [x] `pnpm -F @accomplish/web test:unit` — 358 passed, unchanged
- [x] `pnpm -F @accomplish/desktop test:unit` — 352 passed, unchanged
- [x] `pnpm lint:eslint` — 0 errors (3 pre-existing warnings in unrelated `apps/web` file)
- [x] `pnpm build` — all workspaces
- [x] Format check — clean on all PR files (unrelated untracked `docs/dead-code-feature-audit.md` shows up in `format:check` but is not part of this PR's diff)

## Diff stats

**20 files changed, +1570 / −66**

## Follow-up items tracked (from review conversation)

Worth opening separate PRs / issues for:

1. **`workspace-meta.db` has no migration system.** Current schema evolution happens via `CREATE TABLE IF NOT EXISTS` on every startup — works for new-table additions (like `knowledge_notes` in #810), breaks silently for column adds/renames. Recommend folding into `accomplish.db` + proper migration.
2. **Codex's dead-code audit items** (desktop-control rebuild-or-delete, dead `config.ts`, dormant continuation-nudge loop, etc. — already flagged).
3. **Port 9229 collision** with Node's default `--inspect` port — moonshot proxy uses 9229 which collides with live `pnpm dev` Electron debugger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tasks now support workspace context for enhanced configuration management
  * Added Google Workspace account integration with automatic token lifecycle handling
  * Introduced per-task configuration with safe filename generation

* **Tests**
  * Added comprehensive unit tests for metadata handling, task configuration resolution, and Google Workspace account integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->